### PR TITLE
Build data for the Senate as well as the House of Commons

### DIFF
--- a/.rubocop-https---raw-githubusercontent-com-everypolitician-everypolitician-data-master--rubocop-base-yml
+++ b/.rubocop-https---raw-githubusercontent-com-everypolitician-everypolitician-data-master--rubocop-base-yml
@@ -1,0 +1,64 @@
+# A base Rubocop configuration that other repos can inherit from
+# http://rubocop.readthedocs.io/en/latest/configuration/#inheriting-configuration-from-a-remote-url
+
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/Debugger:
+  Enabled: false
+
+Style/RescueStandardError:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: false
+
+Performance/Casecmp:
+  Enabled: false
+
+Style/AndOr:
+  Enabled: false
+
+Style/CollectionMethods:
+  Enabled: true
+
+Style/Documentation:
+  Enabled: false
+
+Style/FormatString:
+  EnforcedStyle: percent
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+
+Style/RescueModifier:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: true
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+# Minitest::Spec uses long blocks to contains the specs, so disable this check
+# for the tests.
+Metrics/BlockLength:
+  Max: 10
+  Exclude:
+    - 'spec/**/*'
+    - 't/**/*'
+    - 'test/**/*'
+    - '*.gemspec'

--- a/build.rb
+++ b/build.rb
@@ -164,7 +164,9 @@ JSON.parse(index_file.read, symbolize_names: true).each do |legislature_h|
     }
   end.uniq
 
-  organizations = membership_rows.map do |membership|
+  organizations = membership_rows.select do |membership|
+    membership[:party]
+  end.map do |membership|
     {
       name: membership.name_object('party_name', LANGUAGE_MAP),
       id: membership[:party].value,
@@ -178,7 +180,9 @@ JSON.parse(index_file.read, symbolize_names: true).each do |legislature_h|
     }
   end.uniq
 
-  areas = membership_rows.map do |membership|
+  areas = membership_rows.select do |membership|
+    membership[:district]
+  end.map do |membership|
     {
       name: membership.name_object('district_name', LANGUAGE_MAP),
       id: membership[:district].value,
@@ -218,8 +222,8 @@ JSON.parse(index_file.read, symbolize_names: true).each do |legislature_h|
     {
       id: membership[:statement].value,
       person_id: membership[:item].value,
-      on_behalf_of_id: membership[:party].value,
-      area_id: membership[:district].value,
+      on_behalf_of_id: membership[:party]&.value,
+      area_id: membership[:district]&.value,
       start_date: membership[:start]&.value,
       end_date: membership[:end]&.value,
       role_code: membership[:role].value,

--- a/build.rb
+++ b/build.rb
@@ -13,6 +13,11 @@ LANGUAGE_MAP = {
 legislative_dir = Pathname.new(__FILE__).dirname.join('legislative')
 index_file = legislative_dir.join('index.json')
 
+def term_condition(term_item_id)
+  return '' unless term_item_id
+  "?statement pq:P2937 wd:#{term_item_id} ."
+end
+
 def query(position_item_id:, term_item_id:)
   <<~SPARQL
     SELECT ?statement
@@ -28,7 +33,8 @@ def query(position_item_id:, term_item_id:)
       ?role rdfs:label ?role_en, ?role_fr .
       FILTER(LANG(?role_en) = "en").
       FILTER(LANG(?role_fr) = "fr").
-      ?statement ps:P39 ?role ; pq:P2937 wd:#{term_item_id} .
+      ?statement ps:P39 ?role .
+      #{term_condition(term_item_id)}
       OPTIONAL { ?statement pq:P580 ?start }
       OPTIONAL { ?statement pq:P582 ?end }
       OPTIONAL {

--- a/build.rb
+++ b/build.rb
@@ -10,6 +10,11 @@ LANGUAGE_MAP = {
   'lang:fr_CA' => 'fr',
 }.freeze
 
+# This is 'member of the House of Commons of Canada'
+position_item_id = 'Q15964890'
+# This is '42nd Canadian Parliament'
+term_item_id = 'Q21157957'
+
 query = <<~SPARQL
   SELECT ?statement
          ?item ?name_en ?name_fr
@@ -18,13 +23,13 @@ query = <<~SPARQL
          ?role ?role_en ?role_fr
          ?start ?end ?facebook
   WHERE {
-    BIND(wd:Q15964890 as ?role) .
+    BIND(wd:#{position_item_id} as ?role) .
     ?item p:P39 ?statement ;
           rdfs:label ?name_en, ?name_fr .
     ?role rdfs:label ?role_en, ?role_fr .
     FILTER(LANG(?role_en) = "en").
     FILTER(LANG(?role_fr) = "fr").
-    ?statement ps:P39 ?role ; pq:P2937 wd:Q21157957 .
+    ?statement ps:P39 ?role ; pq:P2937 wd:#{term_item_id} .
     OPTIONAL { ?statement pq:P580 ?start }
     OPTIONAL { ?statement pq:P582 ?end }
     OPTIONAL {

--- a/legislative/Q841180/popolo-m17n.json
+++ b/legislative/Q841180/popolo-m17n.json
@@ -1,0 +1,20963 @@
+{
+  "persons": [
+    {
+      "name": {
+        "lang:en_CA": "Abner Reid McClelan",
+        "lang:fr_CA": "Abner Reid McClelan"
+      },
+      "id": "Q2821675",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2821675"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Adam Carr Bell",
+        "lang:fr_CA": "Adam Carr Bell"
+      },
+      "id": "Q4678829",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4678829"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Adam Hope",
+        "lang:fr_CA": "Adam Hope"
+      },
+      "id": "Q4679250",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4679250"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Adam Johnston Fergusson Blair",
+        "lang:fr_CA": "Adam Johnston Fergusson Blair"
+      },
+      "id": "Q4679304",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4679304"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Adrian Knatchbull-Hugessen",
+        "lang:fr_CA": "Adrian Knatchbull-Hugessen"
+      },
+      "id": "Q4685164",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4685164"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Aimé Bénard",
+        "lang:fr_CA": "Aimé Bénard"
+      },
+      "id": "Q4697191",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4697191"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alan Macnaughton",
+        "lang:fr_CA": "Alan Macnaughton"
+      },
+      "id": "Q2830544",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2830544"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alasdair Graham",
+        "lang:fr_CA": "Alasdair Graham"
+      },
+      "id": "Q4708427",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4708427"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Albert Edward Kemp",
+        "lang:fr_CA": "Albert Edward Kemp"
+      },
+      "id": "Q4710100",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4710100"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Albert Joseph Brown",
+        "lang:fr_CA": "Albert Joseph Brown"
+      },
+      "id": "Q4710595",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4710595"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Albert Planta",
+        "lang:fr_CA": "Albert Planta"
+      },
+      "id": "Q4711019",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4711019"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander Boyd Baird",
+        "lang:fr_CA": "Alexander Boyd Baird"
+      },
+      "id": "Q4718413",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4718413"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander Duncan McRae",
+        "lang:fr_CA": "Alexander Duncan McRae"
+      },
+      "id": "Q4718776",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4718776"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander Hamilton McDonald",
+        "lang:fr_CA": "Alexander Hamilton McDonald"
+      },
+      "id": "Q4719073",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4719073"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander Macfarlane",
+        "lang:fr_CA": "Alexander Macfarlane"
+      },
+      "id": "Q8194911",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8194911"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander McCall",
+        "lang:fr_CA": "Alexander McCall"
+      },
+      "id": "Q4719576",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4719576"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander Neil McLean",
+        "lang:fr_CA": "Alexander Neil McLean"
+      },
+      "id": "Q4719735",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4719735"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander Vidal",
+        "lang:fr_CA": "Alexander Vidal"
+      },
+      "id": "Q4720294",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4720294"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexander Walker Ogilvie",
+        "lang:fr_CA": "Alexander Walker Ogilvie"
+      },
+      "id": "Q4720331",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4720331"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexandre Lacoste",
+        "lang:fr_CA": "Alexandre Lacoste"
+      },
+      "id": "Q2833795",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2833795"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alexandre-René Chaussegros de Léry",
+        "lang:fr_CA": "Alexandre-René Chaussegros de Léry"
+      },
+      "id": "Q4720799",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4720799"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alfred Ernest Fripp",
+        "lang:fr_CA": "Alfred Ernest Fripp"
+      },
+      "id": "Q2644939",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2644939"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alfred Johnson Brooks",
+        "lang:fr_CA": "Alfred Johnson Brooks"
+      },
+      "id": "Q2835215",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2835215"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alfred Thibaudeau",
+        "lang:fr_CA": "Alfred Thibaudeau"
+      },
+      "id": "Q4723513",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4723513"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Allan Lee Woodrow",
+        "lang:fr_CA": "Allan Lee Woodrow"
+      },
+      "id": "Q4730779",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4730779"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Allen Bristol Aylesworth",
+        "lang:fr_CA": "Allen Bristol Aylesworth"
+      },
+      "id": "Q4731549",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4731549"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Allister Grosart",
+        "lang:fr_CA": "Allister Grosart"
+      },
+      "id": "Q2838349",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2838349"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alphonse Alfred Clément Larivière",
+        "lang:fr_CA": "Alphonse Alfred Clément Larivière"
+      },
+      "id": "Q4735343",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4735343"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alphonse Desjardins",
+        "lang:fr_CA": "Alphonse Desjardins"
+      },
+      "id": "Q2839781",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2839781"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Alphonse-Arthur Miville Déchêne",
+        "lang:fr_CA": "Alphonse Arthur Miville Déchêne"
+      },
+      "id": "Q2839696",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2839696"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ambroise-Hilaire Comeau",
+        "lang:fr_CA": "Ambroise-Hilaire Comeau"
+      },
+      "id": "Q2842362",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2842362"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Amos Edwin Botsford",
+        "lang:fr_CA": "Amos Edwin Botsford"
+      },
+      "id": "Q587924",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q587924"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Amédée E. Forget",
+        "lang:fr_CA": "Amédée Emmanuel Forget"
+      },
+      "id": "Q482172",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q482172"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Andrew Archibald Macdonald",
+        "lang:fr_CA": "Andrew Archibald Macdonald"
+      },
+      "id": "Q503636",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q503636"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Andrew Haydon",
+        "lang:fr_CA": "Andrew Haydon"
+      },
+      "id": "Q4757267",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4757267"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Andrew Trew Wood",
+        "lang:fr_CA": "Andrew Trew Wood"
+      },
+      "id": "Q4758760",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4758760"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Andrée Champagne",
+        "lang:fr_CA": "Andrée Champagne"
+      },
+      "id": "Q2848935",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2848935"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Angus Claude Macdonell",
+        "lang:fr_CA": "Angus Claude Macdonell"
+      },
+      "id": "Q4764088",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4764088"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Anne Cools",
+        "lang:fr_CA": "Anne Cools"
+      },
+      "id": "Q2851043",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2851043"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Anselme-Homère Pâquet",
+        "lang:fr_CA": "Anselme Homère Pâquet"
+      },
+      "id": "Q2852477",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2852477"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Antoine Joseph Léger",
+        "lang:fr_CA": "Antoine Léger"
+      },
+      "id": "Q2854185",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2854185"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Archibald Beaton Gillis",
+        "lang:fr_CA": "Archibald Beaton Gillis"
+      },
+      "id": "Q4786210",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4786210"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Archibald Campbell",
+        "lang:fr_CA": "Archibald Campbell"
+      },
+      "id": "Q4786246",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4786246"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Archibald Hayes Macdonell",
+        "lang:fr_CA": "Archibald Hayes Macdonell"
+      },
+      "id": "Q4786354",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4786354"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Archibald Johnstone",
+        "lang:fr_CA": "Archibald Johnstone"
+      },
+      "id": "Q4786378",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4786378"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Archibald McCoig",
+        "lang:fr_CA": "Archibald McCoig"
+      },
+      "id": "Q4786432",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4786432"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Archibald McLelan",
+        "lang:fr_CA": "Archibald McLelan"
+      },
+      "id": "Q633347",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q633347"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Aristide Blais",
+        "lang:fr_CA": "Aristide Blais"
+      },
+      "id": "Q679748",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q679748"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Armand Daigle",
+        "lang:fr_CA": "Armand Daigle"
+      },
+      "id": "Q4792647",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4792647"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Art Eggleton",
+        "lang:fr_CA": "Art Eggleton"
+      },
+      "id": "Q705518",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q705518"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Bliss Copp",
+        "lang:fr_CA": "Arthur Bliss Copp"
+      },
+      "id": "Q2865007",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2865007"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Boyer",
+        "lang:fr_CA": "Arthur Boyer"
+      },
+      "id": "Q2865014",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2865014"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Charles Hardy",
+        "lang:fr_CA": "Arthur Charles Hardy"
+      },
+      "id": "Q2865043",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2865043"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Hill Gillmor",
+        "lang:fr_CA": "Arthur Hill Gillmor"
+      },
+      "id": "Q2865147",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2865147"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Laing",
+        "lang:fr_CA": "Arthur Laing"
+      },
+      "id": "Q710278",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q710278"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Marcotte",
+        "lang:fr_CA": "Joseph Arthur Marcotte"
+      },
+      "id": "Q4799639",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4799639"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Maurice Pearson",
+        "lang:fr_CA": "Arthur Maurice Pearson"
+      },
+      "id": "Q4799678",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4799678"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Meighen",
+        "lang:fr_CA": "Arthur Meighen"
+      },
+      "id": "Q128645",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q128645"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Roebuck",
+        "lang:fr_CA": "Arthur Roebuck"
+      },
+      "id": "Q4800162",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4800162"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur Tremblay",
+        "lang:fr_CA": "Arthur Tremblay"
+      },
+      "id": "Q2865357",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2865357"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Arthur-Lucien Beaubien",
+        "lang:fr_CA": "Arthur-Lucien Beaubien"
+      },
+      "id": "Q2864958",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2864958"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Asa Allworth Burnham",
+        "lang:fr_CA": "Asa Allworth Burnham"
+      },
+      "id": "Q4803099",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4803099"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Asa Belknap Foster",
+        "lang:fr_CA": "Asa Belknap Foster"
+      },
+      "id": "Q4803101",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4803101"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Asha Seth",
+        "lang:fr_CA": "Asha Seth"
+      },
+      "id": "Q4804519",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4804519"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Athanase David",
+        "lang:fr_CA": "Athanase David"
+      },
+      "id": "Q2868982",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2868982"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Auguste Charles Philippe Robert Landry",
+        "lang:fr_CA": "Auguste Charles Philippe Robert Landry"
+      },
+      "id": "Q2871120",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2871120"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Auguste-Réal Angers",
+        "lang:fr_CA": "Auguste-Réal Angers"
+      },
+      "id": "Q352902",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q352902"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Aurel Léger",
+        "lang:fr_CA": "Aurèle Léger"
+      },
+      "id": "Q2871966",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2871966"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Aurélien Gill",
+        "lang:fr_CA": "Aurélien Gill"
+      },
+      "id": "Q2872046",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2872046"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Austin Claude Taylor",
+        "lang:fr_CA": "Austin Claude Taylor"
+      },
+      "id": "Q2872111",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2872111"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Azellus Denis",
+        "lang:fr_CA": "Azellus Denis"
+      },
+      "id": "Q793652",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q793652"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Benjamin Charles Prowse",
+        "lang:fr_CA": "Benjamin Charles Prowse"
+      },
+      "id": "Q4888388",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4888388"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Benjamin Franklin Smith",
+        "lang:fr_CA": "Benjamin Franklin Smith"
+      },
+      "id": "Q2896080",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2896080"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Benjamin Seymour",
+        "lang:fr_CA": "Benjamin Seymour"
+      },
+      "id": "Q4889218",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4889218"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Benjamin Wier",
+        "lang:fr_CA": "Benjamin Wier"
+      },
+      "id": "Q4889386",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4889386"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Bernie Boudreau",
+        "lang:fr_CA": "Bernie Boudreau"
+      },
+      "id": "Q725023",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q725023"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Bert Brown",
+        "lang:fr_CA": "Bert Brown"
+      },
+      "id": "Q4894988",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4894988"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Betty Kennedy",
+        "lang:fr_CA": "Betty Kennedy"
+      },
+      "id": "Q4898876",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4898876"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Betty Unger",
+        "lang:fr_CA": "Betty Unger"
+      },
+      "id": "Q4898995",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4898995"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Bill Rompkey",
+        "lang:fr_CA": "Bill Rompkey"
+      },
+      "id": "Q862413",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q862413"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Billa Flint",
+        "lang:fr_CA": "Billa Flint"
+      },
+      "id": "Q4911521",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4911521"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Brenda Robertson",
+        "lang:fr_CA": "Brenda Robertson"
+      },
+      "id": "Q2924409",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2924409"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Brewer Waugh Robinson",
+        "lang:fr_CA": "Brewer Waugh Robinson"
+      },
+      "id": "Q4962667",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4962667"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "C. William Doody",
+        "lang:fr_CA": "C. William Doody"
+      },
+      "id": "Q5006975",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5006975"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Cairine Wilson",
+        "lang:fr_CA": "Cairine Wilson"
+      },
+      "id": "Q528201",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q528201"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Caleb Rand Bill",
+        "lang:fr_CA": "Caleb Rand Bill"
+      },
+      "id": "Q5019282",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5019282"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Calixte Savoie",
+        "lang:fr_CA": "Calixte Savoie"
+      },
+      "id": "Q2934056",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2934056"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Calvert Pratt",
+        "lang:fr_CA": "Calvert Pratt"
+      },
+      "id": "Q5024275",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5024275"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Calvin Ruck",
+        "lang:fr_CA": "Calvin Ruck"
+      },
+      "id": "Q5024490",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5024490"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Carl Goldenberg",
+        "lang:fr_CA": "Carl Goldenberg"
+      },
+      "id": "Q5040222",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5040222"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Carolyn Stewart-Olsen",
+        "lang:fr_CA": "Carolyn Stewart Olsen"
+      },
+      "id": "Q5045471",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5045471"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Alphonse Pantaléon Pelletier",
+        "lang:fr_CA": "Charles-Alphonse-Pantaléon Pelletier"
+      },
+      "id": "Q1063332",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1063332"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Arkoll Boulton",
+        "lang:fr_CA": "Charles Arkoll Boulton"
+      },
+      "id": "Q220157",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q220157"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Ballantyne",
+        "lang:fr_CA": "Charles Colquhoun Ballantyne"
+      },
+      "id": "Q2958764",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2958764"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Benjamin Howard",
+        "lang:fr_CA": "Charles Benjamin Howard"
+      },
+      "id": "Q2958524",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2958524"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Bourgeois",
+        "lang:fr_CA": "Charles Bourgeois (homme politique canadien)"
+      },
+      "id": "Q2958607",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2958607"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Burpee",
+        "lang:fr_CA": "Charles Burpee"
+      },
+      "id": "Q2958642",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2958642"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Cormier",
+        "lang:fr_CA": "Charles Cormier"
+      },
+      "id": "Q5076475",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5076475"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Edward Church",
+        "lang:fr_CA": "Charles Edward Church"
+      },
+      "id": "Q5077263",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5077263"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Elliott Tanner",
+        "lang:fr_CA": "Charles Elliott Tanner"
+      },
+      "id": "Q5077367",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5077367"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Eusèbe Casgrain",
+        "lang:fr_CA": "Charles Eusèbe Casgrain"
+      },
+      "id": "Q5077444",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5077444"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles G. Hawkins",
+        "lang:fr_CA": "Charles G. Hawkins"
+      },
+      "id": "Q5077932",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5077932"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Lawrence Bishop",
+        "lang:fr_CA": "Charles Lawrence Bishop"
+      },
+      "id": "Q5080118",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5080118"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles McDonald",
+        "lang:fr_CA": "Charles McDonald"
+      },
+      "id": "Q5080809",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5080809"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles McElman",
+        "lang:fr_CA": "Charles McElman"
+      },
+      "id": "Q5080816",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5080816"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Murphy",
+        "lang:fr_CA": "Charles Murphy"
+      },
+      "id": "Q5081159",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5081159"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles Turner",
+        "lang:fr_CA": "Charles Turner"
+      },
+      "id": "Q5083047",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5083047"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles-Christophe Malhiot",
+        "lang:fr_CA": "Charles-Christophe Malhiot"
+      },
+      "id": "Q2957984",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2957984"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles-Eugène Panet",
+        "lang:fr_CA": "Charles-Eugène Panet"
+      },
+      "id": "Q5074729",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5074729"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles-Philippe Beaubien",
+        "lang:fr_CA": "Charles-Philippe Beaubien"
+      },
+      "id": "Q5074755",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5074755"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles-Séraphin Rodier Jr",
+        "lang:fr_CA": "Charles-Séraphin Rodier Jr"
+      },
+      "id": "Q5074760",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5074760"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charles-Édouard Ferland",
+        "lang:fr_CA": "Charles-Édouard Ferland"
+      },
+      "id": "Q2958332",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2958332"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Charlie Watt",
+        "lang:fr_CA": "Charlie Watt"
+      },
+      "id": "Q2960890",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2960890"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Chesley William Carter",
+        "lang:fr_CA": "Chesley William Carter"
+      },
+      "id": "Q5093264",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5093264"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Christian Pozer",
+        "lang:fr_CA": "Christian Henry Pozer"
+      },
+      "id": "Q2965334",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2965334"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Clarence Emerson",
+        "lang:fr_CA": "Clarence Emerson"
+      },
+      "id": "Q2975554",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2975554"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Clarence Joseph Veniot",
+        "lang:fr_CA": "Clarence Veniot"
+      },
+      "id": "Q2975582",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2975582"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Clarence Primrose",
+        "lang:fr_CA": "Clarence Primrose"
+      },
+      "id": "Q5126708",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5126708"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Claude Carignan",
+        "lang:fr_CA": "Claude Carignan"
+      },
+      "id": "Q2977137",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2977137"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Claude Castonguay",
+        "lang:fr_CA": "Claude Castonguay"
+      },
+      "id": "Q512939",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q512939"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Claudette Tardif",
+        "lang:fr_CA": "Claudette Tardif"
+      },
+      "id": "Q2978387",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2978387"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Clement Francis Cornwall",
+        "lang:fr_CA": "Clement Francis Cornwall"
+      },
+      "id": "Q571983",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q571983"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Clement O'Leary",
+        "lang:fr_CA": "Clement O'Leary"
+      },
+      "id": "Q5131387",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5131387"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Cliff Breitkreuz",
+        "lang:fr_CA": "Cliff Breitkreuz"
+      },
+      "id": "Q5132550",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5132550"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Clive Pringle",
+        "lang:fr_CA": "Clive Pringle"
+      },
+      "id": "Q5134651",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5134651"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Colin Kenny",
+        "lang:fr_CA": "Colin Kenny"
+      },
+      "id": "Q2982619",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2982619"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Consiglio Di Nino",
+        "lang:fr_CA": "Consiglio Di Nino"
+      },
+      "id": "Q5163203",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5163203"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Creelman MacArthur",
+        "lang:fr_CA": "Creelman MacArthur"
+      },
+      "id": "Q3002426",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3002426"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Cyril Sherwood",
+        "lang:fr_CA": "Cyril Sherwood"
+      },
+      "id": "Q5200872",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5200872"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Cyrille Vaillancourt",
+        "lang:fr_CA": "Cyrille Vaillancourt"
+      },
+      "id": "Q5200956",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5200956"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Céline Hervieux-Payette",
+        "lang:fr_CA": "Céline Hervieux-Payette"
+      },
+      "id": "Q3010175",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3010175"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Dalia Wood",
+        "lang:fr_CA": "Dalia Wood"
+      },
+      "id": "Q5210912",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5210912"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Daniel Aloysius Riley",
+        "lang:fr_CA": "Daniel Riley"
+      },
+      "id": "Q386669",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q386669"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Daniel Derbyshire",
+        "lang:fr_CA": "Daniel Derbyshire"
+      },
+      "id": "Q5216957",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5216957"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Daniel Edward Riley",
+        "lang:fr_CA": "Daniel Edward Riley"
+      },
+      "id": "Q5217056",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5217056"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Daniel Gillmor",
+        "lang:fr_CA": "Daniel Gillmor"
+      },
+      "id": "Q3014092",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3014092"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Daniel Lang",
+        "lang:fr_CA": "Daniel Lang"
+      },
+      "id": "Q5217873",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5217873"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Daniel Lang",
+        "lang:fr_CA": "Daniel Lang"
+      },
+      "id": "Q5217874",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5217874"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Adams Richards",
+        "lang:fr_CA": "David Adams Richards"
+      },
+      "id": "Q3017357",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3017357"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Braley",
+        "lang:fr_CA": "David Braley"
+      },
+      "id": "Q5231672",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5231672"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Christie",
+        "lang:fr_CA": "David Christie"
+      },
+      "id": "Q1173997",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1173997"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Croll",
+        "lang:fr_CA": "David Croll"
+      },
+      "id": "Q5232676",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5232676"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Edward Price",
+        "lang:fr_CA": "David Edward Price"
+      },
+      "id": "Q5233280",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5233280"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David James Walker",
+        "lang:fr_CA": "David James Walker"
+      },
+      "id": "Q5235577",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5235577"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Lewis Macpherson",
+        "lang:fr_CA": "David Lewis Macpherson"
+      },
+      "id": "Q1175226",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1175226"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David MacKeen",
+        "lang:fr_CA": "David MacKeen"
+      },
+      "id": "Q5236996",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5236996"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Mills",
+        "lang:fr_CA": "David Mills"
+      },
+      "id": "Q5237580",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5237580"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Ovide L'Espérance",
+        "lang:fr_CA": "David Ovide L'Espérance"
+      },
+      "id": "Q3018567",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3018567"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Reesor",
+        "lang:fr_CA": "David Reesor"
+      },
+      "id": "Q5238963",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5238963"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Smith",
+        "lang:fr_CA": "David Smith"
+      },
+      "id": "Q5239878",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5239878"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Steuart",
+        "lang:fr_CA": "David Steuart"
+      },
+      "id": "Q5240077",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5240077"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Tkachuk",
+        "lang:fr_CA": "David Tkachuk"
+      },
+      "id": "Q3018884",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3018884"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "David Wells",
+        "lang:fr_CA": "David Wells"
+      },
+      "id": "Q5240957",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5240957"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Denise Batters",
+        "lang:fr_CA": "Denise Batters"
+      },
+      "id": "Q5257618",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5257618"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Dennis Dawson",
+        "lang:fr_CA": "Dennis Dawson"
+      },
+      "id": "Q3023150",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3023150"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Dennis Patterson",
+        "lang:fr_CA": "Dennis Patterson"
+      },
+      "id": "Q5258849",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5258849"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Diane Bellemare",
+        "lang:fr_CA": "Diane Bellemare"
+      },
+      "id": "Q5271402",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5271402"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Don Meredith",
+        "lang:fr_CA": "Don Meredith"
+      },
+      "id": "Q5293139",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5293139"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Don Plett",
+        "lang:fr_CA": "Don Plett"
+      },
+      "id": "Q5293328",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5293328"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald A. McLean",
+        "lang:fr_CA": "Donald A. McLean"
+      },
+      "id": "Q5293933",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5293933"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald Cameron",
+        "lang:fr_CA": "Donald Cameron"
+      },
+      "id": "Q5294127",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294127"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald Ferguson",
+        "lang:fr_CA": "Donald Ferguson"
+      },
+      "id": "Q5294345",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294345"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald MacInnes",
+        "lang:fr_CA": "Donald MacInnes"
+      },
+      "id": "Q5294746",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294746"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald MacLennan",
+        "lang:fr_CA": "Donald MacLennan"
+      },
+      "id": "Q5294755",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294755"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald McDonald",
+        "lang:fr_CA": "Donald McDonald"
+      },
+      "id": "Q5294831",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294831"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald McMillan",
+        "lang:fr_CA": "Donald McMillan"
+      },
+      "id": "Q5294860",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294860"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald Montgomery",
+        "lang:fr_CA": "Donald Montgomery"
+      },
+      "id": "Q5294896",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294896"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald Oliver",
+        "lang:fr_CA": "Donald Oliver"
+      },
+      "id": "Q5294957",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5294957"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donald Sutherland",
+        "lang:fr_CA": "Donald Sutherland"
+      },
+      "id": "Q5295206",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5295206"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Donat Raymond",
+        "lang:fr_CA": "Donat Raymond"
+      },
+      "id": "Q3036195",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3036195"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Doris Margaret Anderson",
+        "lang:fr_CA": "Doris Margaret Anderson"
+      },
+      "id": "Q5297961",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5297961"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Doug Black",
+        "lang:fr_CA": "Doug Black"
+      },
+      "id": "Q5300309",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5300309"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Doug Finley",
+        "lang:fr_CA": "Doug Finley"
+      },
+      "id": "Q5300472",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5300472"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Douglas Everett",
+        "lang:fr_CA": "Douglas Everett"
+      },
+      "id": "Q5301445",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5301445"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Douglas Roche",
+        "lang:fr_CA": "Douglas Roche"
+      },
+      "id": "Q5301942",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5301942"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Duncan Jessiman",
+        "lang:fr_CA": "Duncan Jessiman"
+      },
+      "id": "Q5314407",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5314407"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Duncan Kenneth MacTavish",
+        "lang:fr_CA": "Duncan Kenneth MacTavish"
+      },
+      "id": "Q5314419",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5314419"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Duncan Marshall",
+        "lang:fr_CA": "Duncan Marshall"
+      },
+      "id": "Q5314485",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5314485"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "E. D. Smith",
+        "lang:fr_CA": "E. D. Smith"
+      },
+      "id": "Q5321816",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5321816"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Earl Hastings",
+        "lang:fr_CA": "Earl Hastings"
+      },
+      "id": "Q5325908",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5325908"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Earl Wallace Urquhart",
+        "lang:fr_CA": "Earl Wallace Urquhart"
+      },
+      "id": "Q5326148",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5326148"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ebenezer Perry",
+        "lang:fr_CA": "Ebenezer Perry"
+      },
+      "id": "Q5331722",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5331722"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edgar Fournier",
+        "lang:fr_CA": "Edgar Fournier"
+      },
+      "id": "Q3047450",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3047450"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edgar Sydney Little",
+        "lang:fr_CA": "Edgar Sydney Little"
+      },
+      "id": "Q5337480",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5337480"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edmund William Tobin",
+        "lang:fr_CA": "Edmund William Tobin"
+      },
+      "id": "Q3048141",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3048141"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward Goff Penny",
+        "lang:fr_CA": "Edward G. Penny"
+      },
+      "id": "Q3048524",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3048524"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward Joseph Thériault",
+        "lang:fr_CA": "Edward Joseph Thériault"
+      },
+      "id": "Q5343857",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5343857"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward Kenny",
+        "lang:fr_CA": "Edward Kenny"
+      },
+      "id": "Q5343919",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5343919"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward Lavin Girroir",
+        "lang:fr_CA": "Edward Lavin Girroir"
+      },
+      "id": "Q5344065",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5344065"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward M. Lawson",
+        "lang:fr_CA": "Edward M. Lawson"
+      },
+      "id": "Q5344276",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5344276"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward Matthew Farrell",
+        "lang:fr_CA": "Edward Matthew Farrell"
+      },
+      "id": "Q5344367",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5344367"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward Michener",
+        "lang:fr_CA": "Edward Michener"
+      },
+      "id": "Q5344453",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5344453"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Edward Murphy",
+        "lang:fr_CA": "Edward Murphy"
+      },
+      "id": "Q5344552",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5344552"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Eileen Rossiter",
+        "lang:fr_CA": "Eileen Rossiter"
+      },
+      "id": "Q5349445",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5349445"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Elaine McCoy",
+        "lang:fr_CA": "Elaine McCoy"
+      },
+      "id": "Q5353253",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5353253"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Elijah Leonard",
+        "lang:fr_CA": "Elijah Leonard"
+      },
+      "id": "Q5360946",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5360946"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Elizabeth Marshall",
+        "lang:fr_CA": "Elizabeth Marshall"
+      },
+      "id": "Q668271",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q668271"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Elzéar-Henri Juchereau Duchesnay",
+        "lang:fr_CA": "Elzéar-Henri Juchereau Duchesnay"
+      },
+      "id": "Q5368640",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5368640"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Eric Berntson",
+        "lang:fr_CA": "Eric Berntson"
+      },
+      "id": "Q5386124",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5386124"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Eric Cook",
+        "lang:fr_CA": "Eric Cook"
+      },
+      "id": "Q5386303",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5386303"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Erminie Cohen",
+        "lang:fr_CA": "Erminie Cohen"
+      },
+      "id": "Q15063420",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15063420"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ernest G. Cottreau",
+        "lang:fr_CA": "Ernest G. Cottreau"
+      },
+      "id": "Q5393090",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5393090"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ethel Cochrane",
+        "lang:fr_CA": "Ethel Cochrane"
+      },
+      "id": "Q5403090",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5403090"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Eugène Chinic",
+        "lang:fr_CA": "Guillaume-Eugène Chinic"
+      },
+      "id": "Q5408541",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5408541"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Eugène Paquet",
+        "lang:fr_CA": "Eugène Paquet"
+      },
+      "id": "Q3060082",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3060082"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Evans John Price",
+        "lang:fr_CA": "Evan John Price"
+      },
+      "id": "Q5415923",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5415923"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Eymard Corbin",
+        "lang:fr_CA": "Eymard Corbin"
+      },
+      "id": "Q3062784",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3062784"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ezra Churchill",
+        "lang:fr_CA": "Ezra Churchill"
+      },
+      "id": "Q5423340",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5423340"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Fabian Manning",
+        "lang:fr_CA": "Fabian Manning"
+      },
+      "id": "Q3063518",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3063518"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Fernand Fafard",
+        "lang:fr_CA": "Joseph-Fernand Fafard"
+      },
+      "id": "Q3184245",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3184245"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Fernand Leblanc",
+        "lang:fr_CA": "Fernand-E. Leblanc"
+      },
+      "id": "Q3069029",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3069029"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Fernand Roberge",
+        "lang:fr_CA": "Fernand Roberge"
+      },
+      "id": "Q5444532",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5444532"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Fernand Robichaud",
+        "lang:fr_CA": "Fernand Robichaud"
+      },
+      "id": "Q3069319",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3069319"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Finlay MacDonald",
+        "lang:fr_CA": "Finlay MacDonald"
+      },
+      "id": "Q5450538",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5450538"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Finlay McNaughton Young",
+        "lang:fr_CA": "Finlay McNaughton Young"
+      },
+      "id": "Q5450543",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5450543"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Florence Bird",
+        "lang:fr_CA": "Florence Bird"
+      },
+      "id": "Q5460567",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5460567"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Florence Elsie Inman",
+        "lang:fr_CA": "Florence Elsie Inman"
+      },
+      "id": "Q15946286",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15946286"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Francis Clemow",
+        "lang:fr_CA": "Francis Clemow"
+      },
+      "id": "Q5480536",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5480536"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Francis Fox",
+        "lang:fr_CA": "Francis Fox"
+      },
+      "id": "Q1441498",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1441498"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Francis Theodore Frost",
+        "lang:fr_CA": "Francis Theodore Frost"
+      },
+      "id": "Q5482584",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5482584"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frank Bunting Black",
+        "lang:fr_CA": "Frank Bunting Black"
+      },
+      "id": "Q3082526",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3082526"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frank Corbett Welch",
+        "lang:fr_CA": "Frank Corbett Welch"
+      },
+      "id": "Q5485956",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5485956"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frank Patrick O'Connor",
+        "lang:fr_CA": "Frank Patrick O'Connor"
+      },
+      "id": "Q16022924",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16022924"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "François Béchard",
+        "lang:fr_CA": "François Béchard"
+      },
+      "id": "Q3084144",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3084144"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "François-Xavier-Anselme Trudel",
+        "lang:fr_CA": "François-Xavier-Anselme Trudel"
+      },
+      "id": "Q3083679",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3083679"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Fred Dickson",
+        "lang:fr_CA": "Fred Dickson"
+      },
+      "id": "Q5494994",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5494994"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederic McGrand",
+        "lang:fr_CA": "Frederic McGrand"
+      },
+      "id": "Q5497100",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5497100"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederic Thomas Nicholls",
+        "lang:fr_CA": "Frederic Thomas Nicholls"
+      },
+      "id": "Q5497144",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5497144"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick Forsyth Pardee",
+        "lang:fr_CA": "Frederick Forsyth Pardee"
+      },
+      "id": "Q5497785",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5497785"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick Gordon Bradley",
+        "lang:fr_CA": "Frederick Gordon Bradley"
+      },
+      "id": "Q5497873",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5497873"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick Laurence Schaffner",
+        "lang:fr_CA": "Frederick Laurence Schaffner"
+      },
+      "id": "Q5498248",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5498248"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick Murray Blois",
+        "lang:fr_CA": "Frederick Murray Blois"
+      },
+      "id": "Q5498440",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5498440"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick P. Thompson",
+        "lang:fr_CA": "Frederick P. Thompson"
+      },
+      "id": "Q5498504",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5498504"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick William Gershaw",
+        "lang:fr_CA": "Frederick William Gershaw"
+      },
+      "id": "Q5499072",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5499072"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick William Pirie",
+        "lang:fr_CA": "Frederick William Pirie"
+      },
+      "id": "Q5499097",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5499097"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frederick William Rowe",
+        "lang:fr_CA": "Frederick William Rowe"
+      },
+      "id": "Q5499101",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5499101"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Frédéric Liguori Béique",
+        "lang:fr_CA": "Frédéric-Liguori Béique"
+      },
+      "id": "Q3089544",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3089544"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gardner Green Stevens",
+        "lang:fr_CA": "Gardner Green Stevens"
+      },
+      "id": "Q5522599",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5522599"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Albertus Cox",
+        "lang:fr_CA": "George Albertus Cox"
+      },
+      "id": "Q5536134",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5536134"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Alexander",
+        "lang:fr_CA": "George Alexander"
+      },
+      "id": "Q5536143",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5536143"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Barnard Baker",
+        "lang:fr_CA": "George Barnard Baker"
+      },
+      "id": "Q3101411",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3101411"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Burpee Jones",
+        "lang:fr_CA": "George Burpee Jones"
+      },
+      "id": "Q3101447",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3101447"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Crawford",
+        "lang:fr_CA": "George Crawford"
+      },
+      "id": "Q5538200",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5538200"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Crawford McKindsey",
+        "lang:fr_CA": "George Crawford McKindsey"
+      },
+      "id": "Q5538205",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5538205"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Eulas Foster",
+        "lang:fr_CA": "George Eulas Foster"
+      },
+      "id": "Q3101555",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3101555"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Furey",
+        "lang:fr_CA": "George Furey"
+      },
+      "id": "Q5539530",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5539530"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Gerald King",
+        "lang:fr_CA": "George Gerald King"
+      },
+      "id": "Q3101590",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3101590"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Gordon",
+        "lang:fr_CA": "George Gordon"
+      },
+      "id": "Q5539802",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5539802"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Green Foster",
+        "lang:fr_CA": "George Green Foster"
+      },
+      "id": "Q5539886",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5539886"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Henry Barnard",
+        "lang:fr_CA": "George Henry Barnard"
+      },
+      "id": "Q5540422",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5540422"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Henry Bradbury",
+        "lang:fr_CA": "George Henry Bradbury"
+      },
+      "id": "Q5540430",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5540430"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Henry Ross",
+        "lang:fr_CA": "George Henry Ross"
+      },
+      "id": "Q5540476",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5540476"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Hilton Barbour",
+        "lang:fr_CA": "George Hilton Barbour"
+      },
+      "id": "Q5540619",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5540619"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Landerkin",
+        "lang:fr_CA": "George Landerkin"
+      },
+      "id": "Q5541517",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5541517"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Lynch-Staunton",
+        "lang:fr_CA": "George Lynch-Staunton"
+      },
+      "id": "Q5541898",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5541898"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George McHugh",
+        "lang:fr_CA": "George McHugh"
+      },
+      "id": "Q5542322",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5542322"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George McIlraith",
+        "lang:fr_CA": "George McIlraith"
+      },
+      "id": "Q524305",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q524305"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Penny",
+        "lang:fr_CA": "George Penny"
+      },
+      "id": "Q5543312",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5543312"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Percival Burchill",
+        "lang:fr_CA": "George Percival Burchill"
+      },
+      "id": "Q3101829",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3101829"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Riley",
+        "lang:fr_CA": "George Riley"
+      },
+      "id": "Q5543895",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5543895"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Stanley White",
+        "lang:fr_CA": "George Stanley White"
+      },
+      "id": "Q3101923",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3101923"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Taylor",
+        "lang:fr_CA": "George Taylor"
+      },
+      "id": "Q5545096",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5545096"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Taylor Fulford",
+        "lang:fr_CA": "George Taylor Fulford"
+      },
+      "id": "Q5545105",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5545105"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Thomas Baird",
+        "lang:fr_CA": "George Thomas Baird"
+      },
+      "id": "Q3101953",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3101953"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George Van Roggen",
+        "lang:fr_CA": "George Van Roggen"
+      },
+      "id": "Q5545448",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5545448"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George William Allan",
+        "lang:fr_CA": "George William Allan"
+      },
+      "id": "Q710407",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q710407"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George William Fowler",
+        "lang:fr_CA": "George William Fowler"
+      },
+      "id": "Q3102008",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3102008"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George William Howlan",
+        "lang:fr_CA": "George William Howlan"
+      },
+      "id": "Q1508621",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1508621"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "George William Ross",
+        "lang:fr_CA": "George William Ross"
+      },
+      "id": "Q553340",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q553340"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Georges Parent",
+        "lang:fr_CA": "Georges Parent"
+      },
+      "id": "Q2412368",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2412368"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gerald Comeau",
+        "lang:fr_CA": "Gerald J. Comeau"
+      },
+      "id": "Q3103887",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3103887"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gerald Verner White",
+        "lang:fr_CA": "Gerald Verner White"
+      },
+      "id": "Q5549640",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5549640"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gerard Phalen",
+        "lang:fr_CA": "Gerard Phalen"
+      },
+      "id": "Q4555521",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4555521"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gerry McGeer",
+        "lang:fr_CA": "Gerry McGeer"
+      },
+      "id": "Q5552889",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5552889"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gerry Ottenheimer",
+        "lang:fr_CA": "Gerry Ottenheimer"
+      },
+      "id": "Q16014152",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16014152"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gerry St. Germain",
+        "lang:fr_CA": "Gerry St. Germain"
+      },
+      "id": "Q3104351",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3104351"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ghislain Maltais",
+        "lang:fr_CA": "Ghislain Maltais"
+      },
+      "id": "Q5556749",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5556749"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gideon Robertson",
+        "lang:fr_CA": "Gideon Robertson"
+      },
+      "id": "Q5559658",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5559658"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gildas Molgat",
+        "lang:fr_CA": "Gildas Molgat"
+      },
+      "id": "Q3105976",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3105976"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gordon Fogo",
+        "lang:fr_CA": "Gordon Fogo"
+      },
+      "id": "Q15998225",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15998225"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gordon Peter Campbell",
+        "lang:fr_CA": "Gordon Peter Campbell"
+      },
+      "id": "Q5585670",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5585670"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Grant Mitchell",
+        "lang:fr_CA": "Grant Mitchell"
+      },
+      "id": "Q5596353",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5596353"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Grattan O'Leary",
+        "lang:fr_CA": "Grattan O'Leary"
+      },
+      "id": "Q3115710",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3115710"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Guillaume-André Fauteux",
+        "lang:fr_CA": "Guillaume-André Fauteux"
+      },
+      "id": "Q15996926",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15996926"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gunnar Thorvaldson",
+        "lang:fr_CA": "Gunnar Thorvaldson"
+      },
+      "id": "Q5619150",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5619150"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gustave Benjamin Boyer",
+        "lang:fr_CA": "Gustave Benjamin Boyer"
+      },
+      "id": "Q3121115",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3121115"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Gustave Monette",
+        "lang:fr_CA": "Gustave Monette"
+      },
+      "id": "Q5621309",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5621309"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Guy Charbonneau",
+        "lang:fr_CA": "Guy Charbonneau"
+      },
+      "id": "Q3121641",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3121641"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Guy Williams",
+        "lang:fr_CA": "Guy Williams"
+      },
+      "id": "Q16012909",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16012909"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hance James Logan",
+        "lang:fr_CA": "Hance James Logan"
+      },
+      "id": "Q5646985",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5646985"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Harcourt Burland Bull",
+        "lang:fr_CA": "Harcourt Burland Bull"
+      },
+      "id": "Q5655005",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5655005"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Harry Albert Willis",
+        "lang:fr_CA": "Harry Albert Willis"
+      },
+      "id": "Q16077759",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16077759"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Harry Hays",
+        "lang:fr_CA": "Harry Hays"
+      },
+      "id": "Q774447",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q774447"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hartland Molson",
+        "lang:fr_CA": "Hartland Molson"
+      },
+      "id": "Q3127975",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3127975"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Heath MacQuarrie",
+        "lang:fr_CA": "Heath MacQuarrie"
+      },
+      "id": "Q14949448",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q14949448"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hector Fabre",
+        "lang:fr_CA": "Hector Fabre"
+      },
+      "id": "Q137138",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q137138"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henri Charles Bois",
+        "lang:fr_CA": "Henri Charles Bois"
+      },
+      "id": "Q5715370",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5715370"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henri Courtemanche",
+        "lang:fr_CA": "Henri Courtemanche"
+      },
+      "id": "Q3130895",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3130895"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henri Sévérin Béland",
+        "lang:fr_CA": "Henri Sévérin Béland"
+      },
+      "id": "Q3132053",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3132053"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Corby, Jr.",
+        "lang:fr_CA": "Henry Corby"
+      },
+      "id": "Q5719810",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5719810"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Herbert Horsey",
+        "lang:fr_CA": "Henry Herbert Horsey"
+      },
+      "id": "Q15996279",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15996279"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Joseph Cloran",
+        "lang:fr_CA": "Henry Joseph Cloran"
+      },
+      "id": "Q5724085",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5724085"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Kaulback",
+        "lang:fr_CA": "Henry Kaulback"
+      },
+      "id": "Q5724236",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5724236"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Laird",
+        "lang:fr_CA": "Henry Laird"
+      },
+      "id": "Q5724595",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5724595"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Mullins",
+        "lang:fr_CA": "Henry Mullins"
+      },
+      "id": "Q5726132",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5726132"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Read Emmerson",
+        "lang:fr_CA": "Henry Read Emmerson"
+      },
+      "id": "Q3133031",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3133031"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Henry Westman Richardson",
+        "lang:fr_CA": "Henry Westman Richardson"
+      },
+      "id": "Q5730031",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5730031"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Herman William Quinton",
+        "lang:fr_CA": "Herman William Quinton"
+      },
+      "id": "Q5740353",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5740353"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hervé Michaud",
+        "lang:fr_CA": "Hervé Michaud"
+      },
+      "id": "Q3134598",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3134598"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hewitt Bostock",
+        "lang:fr_CA": "Hewitt Bostock"
+      },
+      "id": "Q657712",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q657712"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hippolyte Montplaisir",
+        "lang:fr_CA": "Hippolyte Montplaisir"
+      },
+      "id": "Q3136096",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3136096"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Horatio Clarence Hocken",
+        "lang:fr_CA": "Horatio Clarence Hocken"
+      },
+      "id": "Q1627975",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1627975"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hugh Nelson",
+        "lang:fr_CA": "Hugh Nelson"
+      },
+      "id": "Q222810",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q222810"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Hédard Robichaud",
+        "lang:fr_CA": "Hédard Robichaud"
+      },
+      "id": "Q1642879",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1642879"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ian Alistair Mackenzie",
+        "lang:fr_CA": "Ian Alistair Mackenzie"
+      },
+      "id": "Q1655568",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1655568"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ian David Sinclair",
+        "lang:fr_CA": "Ian David Sinclair"
+      },
+      "id": "Q5981368",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5981368"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ione Christensen",
+        "lang:fr_CA": "Ione Christensen"
+      },
+      "id": "Q16093641",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16093641"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Irvine Barrow",
+        "lang:fr_CA": "Irvine Barrow"
+      },
+      "id": "Q6074304",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6074304"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Irving Gerstein",
+        "lang:fr_CA": "Irving Gerstein"
+      },
+      "id": "Q6074584",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6074584"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Irving Randall Todd",
+        "lang:fr_CA": "Irving Randall Todd"
+      },
+      "id": "Q6074746",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6074746"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Isobel Finnerty",
+        "lang:fr_CA": "Isobel Finnerty"
+      },
+      "id": "Q6085308",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6085308"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Iva Campbell Fallis",
+        "lang:fr_CA": "Iva Campbell Fallis"
+      },
+      "id": "Q6095645",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6095645"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "J. Michel Fournier",
+        "lang:fr_CA": "Joseph Fournier"
+      },
+      "id": "Q639772",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q639772"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "J.-Eugène Lefrançois",
+        "lang:fr_CA": "J.-Eugène Lefrançois"
+      },
+      "id": "Q2385829",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2385829"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jabez Bunting Snowball",
+        "lang:fr_CA": "Jabez Bunting Snowball"
+      },
+      "id": "Q3157019",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3157019"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jack Marshall",
+        "lang:fr_CA": "Jack Marshall"
+      },
+      "id": "Q6113886",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6113886"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jack Wiebe",
+        "lang:fr_CA": "Jack Wiebe"
+      },
+      "id": "Q1677239",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1677239"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jacob Nicol",
+        "lang:fr_CA": "Jacob Nicol"
+      },
+      "id": "Q3157576",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3157576"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jacques Bureau",
+        "lang:fr_CA": "Jacques Bureau"
+      },
+      "id": "Q3158427",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3158427"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jacques Demers",
+        "lang:fr_CA": "Jacques Demers"
+      },
+      "id": "Q927215",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q927215"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jacques Flynn",
+        "lang:fr_CA": "Jacques Flynn"
+      },
+      "id": "Q3158894",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3158894"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jacques Hébert",
+        "lang:fr_CA": "Jacques Hébert"
+      },
+      "id": "Q3159137",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3159137"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Alexander Calder",
+        "lang:fr_CA": "James Alexander Calder"
+      },
+      "id": "Q14915601",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q14915601"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Alexander Lougheed",
+        "lang:fr_CA": "James Alexander Lougheed"
+      },
+      "id": "Q389321",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q389321"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Angus MacKinnon",
+        "lang:fr_CA": "James Angus MacKinnon"
+      },
+      "id": "Q6128753",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6128753"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Arthurs",
+        "lang:fr_CA": "James Arthurs"
+      },
+      "id": "Q6128885",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6128885"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Balfour",
+        "lang:fr_CA": "James Balfour"
+      },
+      "id": "Q6129296",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6129296"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Campbell Haig",
+        "lang:fr_CA": "James Campbell Haig"
+      },
+      "id": "Q6130960",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6130960"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Cox Aikins",
+        "lang:fr_CA": "James Cox Aikins"
+      },
+      "id": "Q1680212",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1680212"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Davies Lewin",
+        "lang:fr_CA": "James Davies Lewin"
+      },
+      "id": "Q6132403",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6132403"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Davis Taylor",
+        "lang:fr_CA": "James Davis Taylor"
+      },
+      "id": "Q6132419",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6132419"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Dever",
+        "lang:fr_CA": "James Dever"
+      },
+      "id": "Q3161026",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3161026"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Domville",
+        "lang:fr_CA": "James Domville"
+      },
+      "id": "Q3161031",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3161031"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Drummond McGregor",
+        "lang:fr_CA": "James Drummond McGregor"
+      },
+      "id": "Q6132856",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6132856"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Duggan",
+        "lang:fr_CA": "James Duggan"
+      },
+      "id": "Q6132905",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6132905"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Edwin Robertson",
+        "lang:fr_CA": "James Edwin Robertson"
+      },
+      "id": "Q6133398",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6133398"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Ferrier",
+        "lang:fr_CA": "James Ferrier"
+      },
+      "id": "Q598786",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q598786"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Gibb Ross",
+        "lang:fr_CA": "James Gibb Ross"
+      },
+      "id": "Q6134587",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6134587"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Gladstone",
+        "lang:fr_CA": "James Gladstone"
+      },
+      "id": "Q1680460",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1680460"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Gray Turgeon",
+        "lang:fr_CA": "James Gray Turgeon"
+      },
+      "id": "Q6134898",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6134898"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Hamilton Ross",
+        "lang:fr_CA": "James Hamilton Ross"
+      },
+      "id": "Q4397895",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4397895"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Harper Prowse",
+        "lang:fr_CA": "James Harper Prowse"
+      },
+      "id": "Q6135601",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6135601"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Horace King",
+        "lang:fr_CA": "James Horace King"
+      },
+      "id": "Q3161161",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3161161"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Houston Spence",
+        "lang:fr_CA": "James Houston Spence"
+      },
+      "id": "Q6136291",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6136291"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James J. Donnelly",
+        "lang:fr_CA": "James J. Donnelly"
+      },
+      "id": "Q15997616",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15997616"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Joseph Hayes Doone",
+        "lang:fr_CA": "James Joseph Hayes Doone"
+      },
+      "id": "Q6136997",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6136997"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Joseph Hughes",
+        "lang:fr_CA": "James Joseph Hughes"
+      },
+      "id": "Q6136999",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6136999"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Kelleher",
+        "lang:fr_CA": "James Kelleher"
+      },
+      "id": "Q15993147",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15993147"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Kirkpatrick Kerr",
+        "lang:fr_CA": "James Kirkpatrick Kerr"
+      },
+      "id": "Q3161209",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3161209"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Leslie",
+        "lang:fr_CA": "James Leslie"
+      },
+      "id": "Q6137999",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6137999"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Mason",
+        "lang:fr_CA": "James Mason"
+      },
+      "id": "Q6139032",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6139032"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James McMullen",
+        "lang:fr_CA": "James McMullen"
+      },
+      "id": "Q6139518",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6139518"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Moffat Douglas",
+        "lang:fr_CA": "James Moffat Douglas"
+      },
+      "id": "Q3161285",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3161285"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Murdock",
+        "lang:fr_CA": "James Murdock"
+      },
+      "id": "Q15997826",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15997826"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James O'Brien",
+        "lang:fr_CA": "James O'Brien"
+      },
+      "id": "Q16030850",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16030850"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James P. McIntyre",
+        "lang:fr_CA": "James P. McIntyre"
+      },
+      "id": "Q15999002",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15999002"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Palmer Rankin",
+        "lang:fr_CA": "James Palmer Rankin"
+      },
+      "id": "Q6140894",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6140894"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Rea Benson",
+        "lang:fr_CA": "James Rea Benson"
+      },
+      "id": "Q6141884",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6141884"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Reid",
+        "lang:fr_CA": "James Reid"
+      },
+      "id": "Q6141944",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6141944"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Robert Gowan",
+        "lang:fr_CA": "James Robert Gowan"
+      },
+      "id": "Q6142204",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6142204"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Skead",
+        "lang:fr_CA": "James Skead"
+      },
+      "id": "Q6143254",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6143254"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Tunney",
+        "lang:fr_CA": "James Tunney"
+      },
+      "id": "Q6144454",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6144454"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James Turner",
+        "lang:fr_CA": "James Turner"
+      },
+      "id": "Q6144484",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6144484"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James W. Ross",
+        "lang:fr_CA": "James W. Ross"
+      },
+      "id": "Q6144898",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6144898"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "James William Carmichael",
+        "lang:fr_CA": "James William Carmichael"
+      },
+      "id": "Q6145559",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6145559"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jane Cordy",
+        "lang:fr_CA": "Jane Cordy"
+      },
+      "id": "Q6151275",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6151275"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Janis Johnson",
+        "lang:fr_CA": "Janis Johnson"
+      },
+      "id": "Q6154629",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6154629"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean Bazin",
+        "lang:fr_CA": "Jean Bazin"
+      },
+      "id": "Q6170242",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6170242"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean Côté",
+        "lang:fr_CA": "Jean Côté"
+      },
+      "id": "Q15487581",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15487581"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean Forest",
+        "lang:fr_CA": "Jean Forest"
+      },
+      "id": "Q6170663",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6170663"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean Lapointe",
+        "lang:fr_CA": "Jean Lapointe"
+      },
+      "id": "Q3172993",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3172993"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean Le Moyne",
+        "lang:fr_CA": "Jean Le Moyne"
+      },
+      "id": "Q3173102",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3173102"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean Noël Desmarais",
+        "lang:fr_CA": "Jean Noël Desmarais"
+      },
+      "id": "Q3173747",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3173747"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Baptiste Guèvremont",
+        "lang:fr_CA": "Jean-Baptiste Guèvremont"
+      },
+      "id": "Q6168923",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6168923"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Baptiste Rolland",
+        "lang:fr_CA": "Jean-Baptiste Rolland"
+      },
+      "id": "Q3164410",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3164410"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Baptiste Romuald Fiset",
+        "lang:fr_CA": "Jean-Baptiste Romuald Fiset"
+      },
+      "id": "Q3164415",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3164415"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Claude Rivest",
+        "lang:fr_CA": "Jean-Claude Rivest"
+      },
+      "id": "Q3165196",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3165196"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-François Pouliot",
+        "lang:fr_CA": "Jean-François Pouliot"
+      },
+      "id": "Q3165833",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3165833"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Guy Dagenais",
+        "lang:fr_CA": "Jean-Guy Dagenais"
+      },
+      "id": "Q6169316",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6169316"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Louis Philippe Robicheau",
+        "lang:fr_CA": "Jean-Louis Philippe Robicheau"
+      },
+      "id": "Q6169459",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6169459"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Marie Dessureault",
+        "lang:fr_CA": "Jean-Marie Dessureault"
+      },
+      "id": "Q6169608",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6169608"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Marie Poitras",
+        "lang:fr_CA": "Jean-Marie Poitras"
+      },
+      "id": "Q3167783",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3167783"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Maurice Simard",
+        "lang:fr_CA": "Jean-Maurice Simard"
+      },
+      "id": "Q3167911",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3167911"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Paul Deschatelets",
+        "lang:fr_CA": "Jean-Paul Deschatelets"
+      },
+      "id": "Q1685131",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1685131"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Pierre Côté",
+        "lang:fr_CA": "Jean-Pierre Côté"
+      },
+      "id": "Q1677284",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1677284"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jean-Robert Gauthier",
+        "lang:fr_CA": "Jean-Robert Gauthier"
+      },
+      "id": "Q3169947",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3169947"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jedediah Slason Carvell",
+        "lang:fr_CA": "Jedediah Slason Carvell"
+      },
+      "id": "Q1294585",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1294585"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jeremiah Northup",
+        "lang:fr_CA": "Jeremiah Northup"
+      },
+      "id": "Q6180929",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6180929"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jerry Grafstein",
+        "lang:fr_CA": "Jerry Grafstein"
+      },
+      "id": "Q3177466",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3177466"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jim Cowan",
+        "lang:fr_CA": "Jim Cowan"
+      },
+      "id": "Q6194381",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6194381"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jim Munson",
+        "lang:fr_CA": "Jim Munson"
+      },
+      "id": "Q6197083",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6197083"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "JoAnne Buth",
+        "lang:fr_CA": "JoAnne Buth"
+      },
+      "id": "Q6204033",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6204033"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joan Cook",
+        "lang:fr_CA": "Joan Cook"
+      },
+      "id": "Q6204955",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6204955"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joan Fraser",
+        "lang:fr_CA": "Joan Fraser"
+      },
+      "id": "Q3179583",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3179583"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joan Neiman",
+        "lang:fr_CA": "Joan Neiman"
+      },
+      "id": "Q6205331",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6205331"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Abbott",
+        "lang:fr_CA": "John Abbott"
+      },
+      "id": "Q128696",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q128696"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Alexander Buchanan",
+        "lang:fr_CA": "John Alexander Buchanan"
+      },
+      "id": "Q16007991",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16007991"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Alexander Macdonald",
+        "lang:fr_CA": "John Alexander Macdonald"
+      },
+      "id": "Q6218591",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6218591"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Alexander Macdonald",
+        "lang:fr_CA": "John Alexander Macdonald"
+      },
+      "id": "Q6218593",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6218593"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Alexander McDonald",
+        "lang:fr_CA": "John Alexander McDonald"
+      },
+      "id": "Q6218604",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6218604"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Alexander Robertson",
+        "lang:fr_CA": "John Alexander Robertson"
+      },
+      "id": "Q6218619",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6218619"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Anthony McDonald",
+        "lang:fr_CA": "John Anthony McDonald"
+      },
+      "id": "Q6219213",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6219213"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Benjamin Stewart",
+        "lang:fr_CA": "John Benjamin Stewart"
+      },
+      "id": "Q6221530",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6221530"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Boyd",
+        "lang:fr_CA": "John Boyd"
+      },
+      "id": "Q3181113",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3181113"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Campbell Elliott",
+        "lang:fr_CA": "John Campbell Elliott"
+      },
+      "id": "Q3181183",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3181183"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Carling",
+        "lang:fr_CA": "John Carling"
+      },
+      "id": "Q6225171",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6225171"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Caswell Davis",
+        "lang:fr_CA": "John Caswell Davis"
+      },
+      "id": "Q6225514",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6225514"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Christian Schultz",
+        "lang:fr_CA": "John Christian Schultz"
+      },
+      "id": "Q1486983",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1486983"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Costigan",
+        "lang:fr_CA": "John Costigan"
+      },
+      "id": "Q3181277",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3181277"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John D. Wallace",
+        "lang:fr_CA": "John D. Wallace"
+      },
+      "id": "Q6228353",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6228353"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Dobson",
+        "lang:fr_CA": "John Dobson"
+      },
+      "id": "Q16031431",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16031431"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Dowsley Reid",
+        "lang:fr_CA": "John Dowsley Reid"
+      },
+      "id": "Q6230029",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6230029"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Everett Lyle Streight",
+        "lang:fr_CA": "John Everett Lyle Streight"
+      },
+      "id": "Q6232066",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6232066"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Ewasew",
+        "lang:fr_CA": "John Ewasew"
+      },
+      "id": "Q6232090",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6232090"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Ewen Sinclair",
+        "lang:fr_CA": "John Ewen Sinclair"
+      },
+      "id": "Q6232098",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6232098"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Frederick Johnston",
+        "lang:fr_CA": "John Frederick Johnston"
+      },
+      "id": "Q6234133",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6234133"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John G. Bryden",
+        "lang:fr_CA": "John G. Bryden"
+      },
+      "id": "Q3181551",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3181551"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John George Bourinot",
+        "lang:fr_CA": "Jean Bourinot"
+      },
+      "id": "Q3170938",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3170938"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Gilbert Higgins",
+        "lang:fr_CA": "John Gilbert Higgins"
+      },
+      "id": "Q6235310",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6235310"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Gillanders Turriff",
+        "lang:fr_CA": "John Gillanders Turriff"
+      },
+      "id": "Q6235360",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6235360"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Glasier",
+        "lang:fr_CA": "John Glasier"
+      },
+      "id": "Q3181595",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3181595"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Hamilton",
+        "lang:fr_CA": "John Hamilton"
+      },
+      "id": "Q6237444",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6237444"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Hawkins Anderson",
+        "lang:fr_CA": "John Hawkins Anderson"
+      },
+      "id": "Q6238296",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6238296"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Henry Wilson",
+        "lang:fr_CA": "John Henry Wilson"
+      },
+      "id": "Q16058538",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16058538"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Hnatyshyn",
+        "lang:fr_CA": "John Hnatyshyn"
+      },
+      "id": "Q6239431",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6239431"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John James Kinley",
+        "lang:fr_CA": "John James Kinley"
+      },
+      "id": "Q6241555",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6241555"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Joseph Bench",
+        "lang:fr_CA": "John Joseph Bench"
+      },
+      "id": "Q6242106",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6242106"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Joseph Connolly",
+        "lang:fr_CA": "John Joseph Connolly"
+      },
+      "id": "Q1500832",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1500832"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Joseph MacDonald",
+        "lang:fr_CA": "John Joseph MacDonald"
+      },
+      "id": "Q6242187",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6242187"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Keith McBroom Laird",
+        "lang:fr_CA": "John Keith McBroom Laird"
+      },
+      "id": "Q16011288",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16011288"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Lang Nichol",
+        "lang:fr_CA": "John Lang Nichol"
+      },
+      "id": "Q16089960",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16089960"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Locke",
+        "lang:fr_CA": "John Locke"
+      },
+      "id": "Q4265771",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4265771"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Lovitt",
+        "lang:fr_CA": "John Lovitt"
+      },
+      "id": "Q6245394",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6245394"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Macdonald",
+        "lang:fr_CA": "John Macdonald"
+      },
+      "id": "Q6246198",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6246198"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John McCormick",
+        "lang:fr_CA": "John McCormick"
+      },
+      "id": "Q6247551",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6247551"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John McLean",
+        "lang:fr_CA": "John McLean"
+      },
+      "id": "Q6248068",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6248068"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Michael Macdonald",
+        "lang:fr_CA": "John Michael Macdonald"
+      },
+      "id": "Q6248647",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6248647"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Milne",
+        "lang:fr_CA": "John Milne"
+      },
+      "id": "Q6248858",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6248858"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Morrow Godfrey",
+        "lang:fr_CA": "John Morrow Godfrey"
+      },
+      "id": "Q6249545",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6249545"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Nesbitt Kirchhoffer",
+        "lang:fr_CA": "John Nesbitt Kirchhoffer"
+      },
+      "id": "Q6250269",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6250269"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John O'Donohoe",
+        "lang:fr_CA": "John O'Donohoe"
+      },
+      "id": "Q6250856",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6250856"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Patrick Molloy",
+        "lang:fr_CA": "John Patrick Molloy"
+      },
+      "id": "Q6252112",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6252112"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Power Howden",
+        "lang:fr_CA": "John Power Howden"
+      },
+      "id": "Q15999323",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15999323"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Sewell Sanborn",
+        "lang:fr_CA": "John Sewell Sanborn"
+      },
+      "id": "Q6257353",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6257353"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Stanfield",
+        "lang:fr_CA": "John Stanfield"
+      },
+      "id": "Q15980338",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15980338"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Stevenson",
+        "lang:fr_CA": "John Stevenson"
+      },
+      "id": "Q6259103",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6259103"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Stewart McLennan",
+        "lang:fr_CA": "John Stewart McLennan"
+      },
+      "id": "Q6259180",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6259180"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Sutherland",
+        "lang:fr_CA": "John Sutherland"
+      },
+      "id": "Q6259698",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6259698"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Sylvain",
+        "lang:fr_CA": "John Sylvain"
+      },
+      "id": "Q6259870",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6259870"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Thomas Hackett",
+        "lang:fr_CA": "John Thomas Hackett"
+      },
+      "id": "Q3182591",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3182591"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Thomas Haig",
+        "lang:fr_CA": "John Thomas Haig"
+      },
+      "id": "Q6260578",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6260578"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Valentine Ellis",
+        "lang:fr_CA": "John Valentine Ellis"
+      },
+      "id": "Q3182637",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3182637"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Wallace de Beque Farris",
+        "lang:fr_CA": "John Wallace de Beque Farris"
+      },
+      "id": "Q6262802",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6262802"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Waterhouse Daniel",
+        "lang:fr_CA": "John Waterhouse Daniel"
+      },
+      "id": "Q3182697",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3182697"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Webster",
+        "lang:fr_CA": "John Webster"
+      },
+      "id": "Q6263329",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6263329"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John William Ritchie",
+        "lang:fr_CA": "John William Ritchie"
+      },
+      "id": "Q518557",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q518557"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "John Yeo",
+        "lang:fr_CA": "John Yeo"
+      },
+      "id": "Q6265142",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6265142"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jonathan McCully",
+        "lang:fr_CA": "Jonathan McCully"
+      },
+      "id": "Q1652320",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1652320"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph A. Day",
+        "lang:fr_CA": "Joseph A. Day"
+      },
+      "id": "Q6280781",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6280781"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Albert Sullivan",
+        "lang:fr_CA": "Joseph Albert Sullivan"
+      },
+      "id": "Q1338112",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1338112"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Arthur Lesage",
+        "lang:fr_CA": "Joseph Arthur Lesage"
+      },
+      "id": "Q6281129",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6281129"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Arthur Paquet",
+        "lang:fr_CA": "Joseph Arthur Paquet"
+      },
+      "id": "Q6281132",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6281132"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Benjamin Prince",
+        "lang:fr_CA": "Joseph Benjamin Prince"
+      },
+      "id": "Q6281443",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6281443"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Bolduc",
+        "lang:fr_CA": "Joseph Bolduc"
+      },
+      "id": "Q3184626",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3184626"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Hormisdas Rainville",
+        "lang:fr_CA": "Joseph Hormisdas Rainville"
+      },
+      "id": "Q3185093",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3185093"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph James Duffus",
+        "lang:fr_CA": "Joseph James Duffus"
+      },
+      "id": "Q15998954",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15998954"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Northwood",
+        "lang:fr_CA": "Joseph Northwood"
+      },
+      "id": "Q6285836",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6285836"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph P. Landry",
+        "lang:fr_CA": "Joseph Landry"
+      },
+      "id": "Q3185206",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3185206"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Philippe Baby Casgrain",
+        "lang:fr_CA": "Joseph Philippe Baby Casgrain"
+      },
+      "id": "Q6286230",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6286230"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Shehyn",
+        "lang:fr_CA": "Joseph Shehyn"
+      },
+      "id": "Q3185635",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3185635"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Tassé",
+        "lang:fr_CA": "Joseph Tassé"
+      },
+      "id": "Q6287360",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6287360"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Willie Comeau",
+        "lang:fr_CA": "Joseph Willie Comeau"
+      },
+      "id": "Q6287997",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6287997"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph Édouard Cauchon",
+        "lang:fr_CA": "Joseph-Édouard Cauchon"
+      },
+      "id": "Q749645",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q749645"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Arthur Bradette",
+        "lang:fr_CA": "Joseph-Arthur Bradette"
+      },
+      "id": "Q6280584",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6280584"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-François Armand",
+        "lang:fr_CA": "Joseph-François Armand"
+      },
+      "id": "Q6280611",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6280611"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Henri-Gustave Lacasse",
+        "lang:fr_CA": "Gustave Lacasse"
+      },
+      "id": "Q3121222",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3121222"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Hormisdas Legris",
+        "lang:fr_CA": "Joseph-Hormisdas Legris"
+      },
+      "id": "Q3184307",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3184307"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Hyacinthe Bellerose",
+        "lang:fr_CA": "Joseph-Hyacinthe Bellerose"
+      },
+      "id": "Q3184311",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3184311"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Marcellin Wilson",
+        "lang:fr_CA": "Joseph-Marcellin Wilson"
+      },
+      "id": "Q3184337",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3184337"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Noël Bossé",
+        "lang:fr_CA": "Joseph-Noël Bossé"
+      },
+      "id": "Q6280674",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6280674"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Octave Arsenault",
+        "lang:fr_CA": "Joseph-Octave Arsenault"
+      },
+      "id": "Q3184385",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3184385"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Octave Villeneuve",
+        "lang:fr_CA": "Joseph-Octave Villeneuve"
+      },
+      "id": "Q3184394",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3184394"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Philippe Guay",
+        "lang:fr_CA": "Joseph-Philippe Guay"
+      },
+      "id": "Q615271",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q615271"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joseph-Rosaire Thibaudeau",
+        "lang:fr_CA": "Joseph-Rosaire Thibaudeau"
+      },
+      "id": "Q16037823",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16037823"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Josiah Burr Plumb",
+        "lang:fr_CA": "Josiah Burr Plumb"
+      },
+      "id": "Q3186040",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3186040"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Josiah Wood",
+        "lang:fr_CA": "Josiah Wood"
+      },
+      "id": "Q3186049",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3186049"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Josie Alice Quart",
+        "lang:fr_CA": "Josie Alice Quart"
+      },
+      "id": "Q6290725",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6290725"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Josée Verner",
+        "lang:fr_CA": "Josée Verner"
+      },
+      "id": "Q3186643",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3186643"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Joyce Fairbairn",
+        "lang:fr_CA": "Joyce Fairbairn"
+      },
+      "id": "Q6297475",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6297475"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Judith Seidman",
+        "lang:fr_CA": "Judith Seidman"
+      },
+      "id": "Q3188008",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3188008"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jules Tessier",
+        "lang:fr_CA": "Jules Tessier"
+      },
+      "id": "Q6306042",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6306042"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Jules-Édouard Prévost",
+        "lang:fr_CA": "Jules-Édouard Prévost"
+      },
+      "id": "Q3188383",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3188383"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Keith Davey",
+        "lang:fr_CA": "Keith Davey"
+      },
+      "id": "Q6384252",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6384252"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Kelvin Ogilvie",
+        "lang:fr_CA": "Kelvin Ogilvie"
+      },
+      "id": "Q6386718",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6386718"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Kennedy Francis Burns",
+        "lang:fr_CA": "Kennedy Francis Burns"
+      },
+      "id": "Q3195156",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3195156"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lachlin McCallum",
+        "lang:fr_CA": "Lachlin McCallum"
+      },
+      "id": "Q6468479",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6468479"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Landon Pearson",
+        "lang:fr_CA": "Landon Pearson"
+      },
+      "id": "Q14949609",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q14949609"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Larry Campbell",
+        "lang:fr_CA": "Larry Campbell"
+      },
+      "id": "Q1680169",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1680169"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Larry Smith",
+        "lang:fr_CA": "Larry Smith"
+      },
+      "id": "Q3218104",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3218104"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Laurent-Olivier David",
+        "lang:fr_CA": "Laurent-Olivier David"
+      },
+      "id": "Q3218980",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3218980"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Laurier LaPierre",
+        "lang:fr_CA": "Laurier LaPierre"
+      },
+      "id": "Q1477331",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1477331"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lawrence Alexander Wilson",
+        "lang:fr_CA": "Lawrence Alexander Wilson"
+      },
+      "id": "Q3219880",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3219880"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lawrence Geoffrey Power",
+        "lang:fr_CA": "Lawrence Geoffrey Power"
+      },
+      "id": "Q3219894",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3219894"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lazarus Phillips",
+        "lang:fr_CA": "Lazarus Phillips"
+      },
+      "id": "Q6505918",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6505918"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lendrum McMeans",
+        "lang:fr_CA": "Lendrum McMeans"
+      },
+      "id": "Q6522351",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6522351"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Leo Kolber",
+        "lang:fr_CA": "Leo Kolber"
+      },
+      "id": "Q3229567",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3229567"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Leonard Gustafson",
+        "lang:fr_CA": "Leonard Gustafson"
+      },
+      "id": "Q6525333",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6525333"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Leonard Marchand",
+        "lang:fr_CA": "Leonard Marchand"
+      },
+      "id": "Q1340024",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1340024"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Leverett George DeVeber",
+        "lang:fr_CA": "Leverett George DeVeber"
+      },
+      "id": "Q6535289",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6535289"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lillian Dyck",
+        "lang:fr_CA": "Lillian Dyck"
+      },
+      "id": "Q2402200",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2402200"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Linda Frum",
+        "lang:fr_CA": "Linda Frum"
+      },
+      "id": "Q6551575",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6551575"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lionel Choquette",
+        "lang:fr_CA": "Lionel Choquette"
+      },
+      "id": "Q6555576",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6555576"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lise Bacon",
+        "lang:fr_CA": "Lise Bacon"
+      },
+      "id": "Q3242479",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3242479"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lorna Marsden",
+        "lang:fr_CA": "Lorna Marsden"
+      },
+      "id": "Q6681372",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6681372"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lorna Milne",
+        "lang:fr_CA": "Lorna Milne"
+      },
+      "id": "Q6681380",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6681380"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lorne Bonnell",
+        "lang:fr_CA": "Lorne Bonnell"
+      },
+      "id": "Q6681430",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6681430"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lorne Campbell Webster",
+        "lang:fr_CA": "Lorne Campbell Webster"
+      },
+      "id": "Q6681433",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6681433"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Auguste Olivier",
+        "lang:fr_CA": "Louis Auguste Olivier"
+      },
+      "id": "Q6686689",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6686689"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Côté",
+        "lang:fr_CA": "Louis Côté"
+      },
+      "id": "Q3261635",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3261635"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Giguère",
+        "lang:fr_CA": "Louis Giguère"
+      },
+      "id": "Q6687248",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6687248"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Lacoste",
+        "lang:fr_CA": "Louis Lacoste"
+      },
+      "id": "Q6687608",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6687608"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Lavergne",
+        "lang:fr_CA": "Louis Lavergne"
+      },
+      "id": "Q3262451",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3262451"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Panet",
+        "lang:fr_CA": "Louis Panet"
+      },
+      "id": "Q6687937",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6687937"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Renaud",
+        "lang:fr_CA": "Louis Renaud"
+      },
+      "id": "Q6688042",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6688042"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis Robitaille",
+        "lang:fr_CA": "Louis Robitaille"
+      },
+      "id": "Q6688078",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6688078"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis-Joseph Forget",
+        "lang:fr_CA": "Louis-Joseph Forget"
+      },
+      "id": "Q3260638",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3260638"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis-Philippe Beaubien",
+        "lang:fr_CA": "Louis-Philippe Beaubien"
+      },
+      "id": "Q6686506",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6686506"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis-Philippe Gélinas",
+        "lang:fr_CA": "Louis-Philippe Gélinas"
+      },
+      "id": "Q6686509",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6686509"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Louis-Rodrigue Masson",
+        "lang:fr_CA": "Louis François Rodrigue Masson"
+      },
+      "id": "Q1552865",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1552865"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lowell Murray",
+        "lang:fr_CA": "Lowell Murray"
+      },
+      "id": "Q6693244",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6693244"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Luc Letellier de St-Just",
+        "lang:fr_CA": "Luc Letellier de Saint-Just"
+      },
+      "id": "Q730078",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q730078"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lucien Moraud",
+        "lang:fr_CA": "Lucien Moraud"
+      },
+      "id": "Q3265644",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3265644"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lyman Melvin Jones",
+        "lang:fr_CA": "Lyman Melvin Jones"
+      },
+      "id": "Q6708063",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6708063"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lynn Beyak",
+        "lang:fr_CA": "Lynn Beyak"
+      },
+      "id": "Q6708935",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6708935"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Lytton Shatford",
+        "lang:fr_CA": "Lytton Shatford"
+      },
+      "id": "Q16043618",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16043618"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Léandre Dumouchel",
+        "lang:fr_CA": "Léandre Dumouchel"
+      },
+      "id": "Q6710943",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6710943"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Léon Mercier Gouin",
+        "lang:fr_CA": "Léon-Mercier Gouin"
+      },
+      "id": "Q3270638",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3270638"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Léon Méthot",
+        "lang:fr_CA": "Léon Méthot"
+      },
+      "id": "Q6711102",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6711102"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Léonard Tremblay",
+        "lang:fr_CA": "Léonard-David Sweezey Tremblay"
+      },
+      "id": "Q3271472",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3271472"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Léonce Mercier",
+        "lang:fr_CA": "Léonce Mercier"
+      },
+      "id": "Q6711142",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6711142"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Léopold Langlois",
+        "lang:fr_CA": "Léopold Langlois"
+      },
+      "id": "Q668183",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q668183"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mabel DeWare",
+        "lang:fr_CA": "Mabel Deware"
+      },
+      "id": "Q6721428",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6721428"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mac Harb",
+        "lang:fr_CA": "Mac Harb"
+      },
+      "id": "Q6722293",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6722293"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mackenzie Bowell",
+        "lang:fr_CA": "Mackenzie Bowell"
+      },
+      "id": "Q128677",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q128677"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Madeleine Plamondon",
+        "lang:fr_CA": "Madeleine Plamondon"
+      },
+      "id": "Q3275714",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3275714"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Malcolm Mercer Hollett",
+        "lang:fr_CA": "Malcolm Mercer Hollett"
+      },
+      "id": "Q6742508",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6742508"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Malcolm Wallace McCutcheon",
+        "lang:fr_CA": "Malcolm Wallace McCutcheon"
+      },
+      "id": "Q6742694",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6742694"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marcel Prud'homme",
+        "lang:fr_CA": "Marcel Prud'homme"
+      },
+      "id": "Q3289316",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3289316"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Margaret Jean Anderson",
+        "lang:fr_CA": "Margaret Jean Anderson"
+      },
+      "id": "Q3290495",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3290495"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Margaret Norrie",
+        "lang:fr_CA": "Margaret Norrie"
+      },
+      "id": "Q6759777",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6759777"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Maria Chaput",
+        "lang:fr_CA": "Maria Chaput"
+      },
+      "id": "Q6761089",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6761089"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marian Maloney",
+        "lang:fr_CA": "Marian Maloney"
+      },
+      "id": "Q6761933",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6761933"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marianna Beauchamp Jodoin",
+        "lang:fr_CA": "Marianna Beauchamp Jodoin"
+      },
+      "id": "Q6762160",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6762160"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marie Charette-Poulin",
+        "lang:fr_CA": "Marie Charette-Poulin"
+      },
+      "id": "Q6762792",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6762792"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marie-Françoise Mégie",
+        "lang:fr_CA": "Marie-Françoise Mégie"
+      },
+      "id": "Q27680092",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q27680092"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marilyn Trenholme Counsell",
+        "lang:fr_CA": "Marilyn Trenholme Counsell"
+      },
+      "id": "Q3293093",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3293093"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mario Beaulieu",
+        "lang:fr_CA": "Mario Beaulieu"
+      },
+      "id": "Q6764557",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6764557"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marisa Ferretti Barth",
+        "lang:fr_CA": "Marisa Ferretti Barth"
+      },
+      "id": "Q3293707",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3293707"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Marjory LeBreton",
+        "lang:fr_CA": "Marjory LeBreton"
+      },
+      "id": "Q3293962",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3293962"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mark Robert Drouin",
+        "lang:fr_CA": "Mark Robert Drouin"
+      },
+      "id": "Q3294220",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3294220"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Martha Bielish",
+        "lang:fr_CA": "Martha Bielish"
+      },
+      "id": "Q6774341",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6774341"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Martial Asselin",
+        "lang:fr_CA": "Martial Asselin"
+      },
+      "id": "Q1903142",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1903142"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mary Elizabeth Kinnear",
+        "lang:fr_CA": "Mary Elizabeth Kinnear"
+      },
+      "id": "Q16012638",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16012638"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Matthew Henry Cochrane",
+        "lang:fr_CA": "Matthew Henry Cochrane"
+      },
+      "id": "Q15458623",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15458623"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Maurice Bourget",
+        "lang:fr_CA": "Maurice Bourget"
+      },
+      "id": "Q956096",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q956096"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Maurice Lamontagne",
+        "lang:fr_CA": "Maurice Lamontagne"
+      },
+      "id": "Q1911361",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1911361"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Maurice Riel",
+        "lang:fr_CA": "Maurice Riel"
+      },
+      "id": "Q3301338",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3301338"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Melvin Perry",
+        "lang:fr_CA": "Melvin Perry"
+      },
+      "id": "Q3305314",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3305314"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael Adams",
+        "lang:fr_CA": "Michael Adams"
+      },
+      "id": "Q3307982",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3307982"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael Basha",
+        "lang:fr_CA": "Michael Basha"
+      },
+      "id": "Q6828479",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6828479"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael Forrestall",
+        "lang:fr_CA": "Michael Forrestall"
+      },
+      "id": "Q6830367",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6830367"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael J. L. Kirby",
+        "lang:fr_CA": "Michael J. L. Kirby"
+      },
+      "id": "Q15516040",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15516040"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael John O'Brien",
+        "lang:fr_CA": "Michael John O'Brien"
+      },
+      "id": "Q13648747",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q13648747"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael L. MacDonald",
+        "lang:fr_CA": "Michael L. MacDonald"
+      },
+      "id": "Q6832030",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6832030"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael Meighen",
+        "lang:fr_CA": "Michael Meighen"
+      },
+      "id": "Q6832793",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6832793"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael Pitfield",
+        "lang:fr_CA": "Michael Pitfield"
+      },
+      "id": "Q6833553",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6833553"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michael Sullivan",
+        "lang:fr_CA": "Michael Sullivan"
+      },
+      "id": "Q6834690",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6834690"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michel Biron",
+        "lang:fr_CA": "Michel Biron"
+      },
+      "id": "Q3309023",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3309023"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michel Cogger",
+        "lang:fr_CA": "Michel Cogger"
+      },
+      "id": "Q6836342",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6836342"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Michel Rivard",
+        "lang:fr_CA": "Michel Rivard"
+      },
+      "id": "Q3310714",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3310714"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mike Duffy",
+        "lang:fr_CA": "Mike Duffy"
+      },
+      "id": "Q3313285",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3313285"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mike Shaikh",
+        "lang:fr_CA": "Mike Shaikh"
+      },
+      "id": "Q6848778",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6848778"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mira Spivak",
+        "lang:fr_CA": "Mira Spivak"
+      },
+      "id": "Q4356984",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4356984"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Mobina Jaffer",
+        "lang:fr_CA": "Mobina Jaffer"
+      },
+      "id": "Q6887337",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6887337"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Muriel McQueen Fergusson",
+        "lang:fr_CA": "Muriel McQueen Fergusson"
+      },
+      "id": "Q3328122",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3328122"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nancy Bell",
+        "lang:fr_CA": "Nancy Bell"
+      },
+      "id": "Q6962556",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6962556"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nancy Greene",
+        "lang:fr_CA": "Nancy Greene"
+      },
+      "id": "Q238041",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q238041"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nancy Hodges",
+        "lang:fr_CA": "Nancy Hodges"
+      },
+      "id": "Q16006583",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16006583"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nancy Ruth",
+        "lang:fr_CA": "Nancy Ruth"
+      },
+      "id": "Q1964518",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1964518"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nancy Teed",
+        "lang:fr_CA": "Nancy Teed"
+      },
+      "id": "Q3335609",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3335609"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Napoléon Belcourt",
+        "lang:fr_CA": "Napoléon Antoine Belcourt"
+      },
+      "id": "Q3335925",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3335925"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Napoléon Kemner Laflamme",
+        "lang:fr_CA": "Napoléon Kemner Laflamme"
+      },
+      "id": "Q3335957",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3335957"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Narcisse-Fortunat Belleau",
+        "lang:fr_CA": "Narcisse-Fortunat Belleau"
+      },
+      "id": "Q505938",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q505938"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nathan Nurgitz",
+        "lang:fr_CA": "Nathan Nurgitz"
+      },
+      "id": "Q6969265",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6969265"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nathaniel Curry",
+        "lang:fr_CA": "Nathaniel Curry"
+      },
+      "id": "Q6969560",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6969560"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nelson Rattenbury",
+        "lang:fr_CA": "Nelson Rattenbury"
+      },
+      "id": "Q6990708",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6990708"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nicholas Taylor",
+        "lang:fr_CA": "Nicholas Taylor"
+      },
+      "id": "Q7026295",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7026295"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nick Sibbeston",
+        "lang:fr_CA": "Nick Sibbeston"
+      },
+      "id": "Q7027927",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7027927"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Nicole Eaton",
+        "lang:fr_CA": "Nicole Eaton"
+      },
+      "id": "Q7030042",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7030042"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Norbert Thériault",
+        "lang:fr_CA": "Norbert Thériault"
+      },
+      "id": "Q3343524",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3343524"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Norman Doyle",
+        "lang:fr_CA": "Norman Doyle"
+      },
+      "id": "Q3343768",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3343768"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Norman MacKenzie",
+        "lang:fr_CA": "Norman MacKenzie"
+      },
+      "id": "Q7052537",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7052537"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Norman McLeod Paterson",
+        "lang:fr_CA": "Norman McLeod Paterson"
+      },
+      "id": "Q7052605",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7052605"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Norman Platt Lambert",
+        "lang:fr_CA": "Norman Platt Lambert"
+      },
+      "id": "Q14949580",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q14949580"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Normand Grimard",
+        "lang:fr_CA": "Normand Grimard"
+      },
+      "id": "Q3736138",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3736138"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Noé Chevrier",
+        "lang:fr_CA": "Noé Chevrier"
+      },
+      "id": "Q7067444",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7067444"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Noël Kinsella",
+        "lang:fr_CA": "Noël Kinsella"
+      },
+      "id": "Q3345838",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3345838"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Olive Lillian Irvine",
+        "lang:fr_CA": "Olive Lillian Irvine"
+      },
+      "id": "Q7087172",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7087172"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Oliver Blake",
+        "lang:fr_CA": "Oliver Blake"
+      },
+      "id": "Q7087410",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7087410"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Oliver Mowat",
+        "lang:fr_CA": "Oliver Mowat"
+      },
+      "id": "Q1387837",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1387837"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Onésiphore Turgeon",
+        "lang:fr_CA": "Onésiphore Turgeon"
+      },
+      "id": "Q3352980",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3352980"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Orville Howard Phillips",
+        "lang:fr_CA": "Orville Howard Phillips"
+      },
+      "id": "Q7105235",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7105235"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pamela Wallin",
+        "lang:fr_CA": "Pamela Wallin"
+      },
+      "id": "Q3361787",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3361787"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pamphile Réal Du Tremblay",
+        "lang:fr_CA": "Pamphile Réal Du Tremblay"
+      },
+      "id": "Q3361816",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3361816"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pascal Poirier",
+        "lang:fr_CA": "Pascal Poirier"
+      },
+      "id": "Q3367566",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3367566"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Patrick Brazeau",
+        "lang:fr_CA": "Patrick Brazeau"
+      },
+      "id": "Q3369280",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3369280"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Patrick Burns",
+        "lang:fr_CA": "Patrick Burns"
+      },
+      "id": "Q7146177",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7146177"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Patrick Charles Murphy",
+        "lang:fr_CA": "Patrick Charles Murphy"
+      },
+      "id": "Q16031100",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16031100"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul David",
+        "lang:fr_CA": "Paul David"
+      },
+      "id": "Q3370985",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3370985"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul Desruisseaux",
+        "lang:fr_CA": "Paul Desruisseaux"
+      },
+      "id": "Q16009957",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16009957"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul Hatfield",
+        "lang:fr_CA": "Paul Hatfield"
+      },
+      "id": "Q7151182",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7151182"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul Henri Bouffard",
+        "lang:fr_CA": "Paul Henri Bouffard"
+      },
+      "id": "Q7151244",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7151244"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul Lafond",
+        "lang:fr_CA": "Paul Lafond"
+      },
+      "id": "Q16012107",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16012107"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul Lucier",
+        "lang:fr_CA": "Paul Lucier"
+      },
+      "id": "Q3371726",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3371726"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul Massicotte",
+        "lang:fr_CA": "Paul J. Massicotte"
+      },
+      "id": "Q386676",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q386676"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul McIntyre",
+        "lang:fr_CA": "Paul McIntyre"
+      },
+      "id": "Q14942774",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q14942774"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Paul Yuzyk",
+        "lang:fr_CA": "Paul Yuzyk"
+      },
+      "id": "Q7154527",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7154527"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Peggy Butts",
+        "lang:fr_CA": "Peggy Butts"
+      },
+      "id": "Q2067379",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2067379"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Percy Downe",
+        "lang:fr_CA": "Percy Downe"
+      },
+      "id": "Q3375189",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3375189"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Percy Mockler",
+        "lang:fr_CA": "Percy Mockler"
+      },
+      "id": "Q3375214",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3375214"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Peter Bosa",
+        "lang:fr_CA": "Peter Bosa"
+      },
+      "id": "Q7172893",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7172893"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Peter McLaren",
+        "lang:fr_CA": "Peter McLaren"
+      },
+      "id": "Q7175805",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7175805"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Peter McSweeney",
+        "lang:fr_CA": "Peter McSweeney"
+      },
+      "id": "Q7175831",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7175831"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Peter Stollery",
+        "lang:fr_CA": "Peter Stollery"
+      },
+      "id": "Q3376900",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3376900"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Peter Talbot",
+        "lang:fr_CA": "Peter Talbot"
+      },
+      "id": "Q7177244",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7177244"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Philip D. Lewis",
+        "lang:fr_CA": "Philip D. Lewis"
+      },
+      "id": "Q16089950",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16089950"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Philippe Gigantès",
+        "lang:fr_CA": "Philippe Gigantès"
+      },
+      "id": "Q6591377",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6591377"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Philippe Roy",
+        "lang:fr_CA": "Philippe Roy"
+      },
+      "id": "Q137208",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q137208"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Philippe-Auguste Choquette",
+        "lang:fr_CA": "Philippe-Auguste Choquette"
+      },
+      "id": "Q3379137",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3379137"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Philippe-Jacques Paradis",
+        "lang:fr_CA": "Philippe-Jacques Paradis"
+      },
+      "id": "Q7184754",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7184754"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierre Antoine Deblois",
+        "lang:fr_CA": "Pierre Antoine Deblois"
+      },
+      "id": "Q7192049",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7192049"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierre Baillargeon",
+        "lang:fr_CA": "Pierre Baillargeon"
+      },
+      "id": "Q7192062",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7192062"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierre Claude Nolin",
+        "lang:fr_CA": "Pierre Claude Nolin"
+      },
+      "id": "Q3384455",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3384455"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierre de Bané",
+        "lang:fr_CA": "Pierre de Bané"
+      },
+      "id": "Q2094001",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2094001"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierre Édouard Blondin",
+        "lang:fr_CA": "Pierre-Édouard Blondin"
+      },
+      "id": "Q951515",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q951515"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierre-Hugues Boisvenu",
+        "lang:fr_CA": "Pierre-Hugues Boisvenu"
+      },
+      "id": "Q3383128",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3383128"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierre-Étienne Fortin",
+        "lang:fr_CA": "Pierre Fortin"
+      },
+      "id": "Q3385044",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3385044"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pierrette Ringuette",
+        "lang:fr_CA": "Pierrette Ringuette"
+      },
+      "id": "Q581686",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q581686"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Pietro Rizzuto",
+        "lang:fr_CA": "Pietro Rizzuto"
+      },
+      "id": "Q3388171",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3388171"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Prosper-Edmond Lessard",
+        "lang:fr_CA": "Prosper-Edmond Lessard"
+      },
+      "id": "Q7250862",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7250862"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ralph Horner",
+        "lang:fr_CA": "Ralph Horner"
+      },
+      "id": "Q7287648",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7287648"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Raoul Dandurand",
+        "lang:fr_CA": "Raoul Dandurand"
+      },
+      "id": "Q3419153",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3419153"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Raoul Hurtubise",
+        "lang:fr_CA": "Raoul Hurtubise"
+      },
+      "id": "Q7293745",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7293745"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ray Perrault",
+        "lang:fr_CA": "Ray Perrault"
+      },
+      "id": "Q2134231",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2134231"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ray Petten",
+        "lang:fr_CA": "Ray Petten"
+      },
+      "id": "Q7297947",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7297947"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Raymond Eudes",
+        "lang:fr_CA": "Raymond Eudes"
+      },
+      "id": "Q3420843",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3420843"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Raymond Lavigne",
+        "lang:fr_CA": "Raymond Lavigne"
+      },
+      "id": "Q3420985",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3420985"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Raymond Setlakwe",
+        "lang:fr_CA": "Raymond Setlakwe"
+      },
+      "id": "Q7299144",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7299144"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Raymond Squires",
+        "lang:fr_CA": "Raymond Squires"
+      },
+      "id": "Q7299155",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7299155"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Raynell Andreychuk",
+        "lang:fr_CA": "Raynell Andreychuk"
+      },
+      "id": "Q7299317",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7299317"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Renaude Lapointe",
+        "lang:fr_CA": "Renaude Lapointe"
+      },
+      "id": "Q3425001",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3425001"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rhéal Bélisle",
+        "lang:fr_CA": "Rhéal Bélisle"
+      },
+      "id": "Q3429915",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3429915"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Blain",
+        "lang:fr_CA": "Richard Blain"
+      },
+      "id": "Q7324198",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7324198"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Donahoe",
+        "lang:fr_CA": "Richard Donahoe"
+      },
+      "id": "Q7325238",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7325238"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Doyle",
+        "lang:fr_CA": "Richard Doyle"
+      },
+      "id": "Q7325271",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7325271"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Hardisty",
+        "lang:fr_CA": "Richard Hardisty"
+      },
+      "id": "Q7326265",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7326265"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard John Cartwright",
+        "lang:fr_CA": "Richard John Cartwright"
+      },
+      "id": "Q7326872",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7326872"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Kroft",
+        "lang:fr_CA": "Richard Kroft"
+      },
+      "id": "Q7327146",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7327146"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Neufeld",
+        "lang:fr_CA": "Richard Neufeld"
+      },
+      "id": "Q7328032",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7328032"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Smeaton White",
+        "lang:fr_CA": "Richard Smeaton White"
+      },
+      "id": "Q7329099",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7329099"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard Stanbury",
+        "lang:fr_CA": "Richard Stanbury"
+      },
+      "id": "Q7329207",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7329207"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Richard William Scott",
+        "lang:fr_CA": "Richard William Scott"
+      },
+      "id": "Q7329994",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7329994"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Alexander Mulholland",
+        "lang:fr_CA": "Robert Alexander Mulholland"
+      },
+      "id": "Q7341433",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7341433"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Beith",
+        "lang:fr_CA": "Robert Beith"
+      },
+      "id": "Q7341994",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7341994"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Duncan Wilmot",
+        "lang:fr_CA": "Robert Duncan Wilmot"
+      },
+      "id": "Q1542244",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1542244"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Forke",
+        "lang:fr_CA": "Robert Forke"
+      },
+      "id": "Q7344433",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7344433"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Francis Green",
+        "lang:fr_CA": "Robert Francis Green"
+      },
+      "id": "Q7344480",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7344480"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Gladstone",
+        "lang:fr_CA": "Robert Gladstone"
+      },
+      "id": "Q7344797",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7344797"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Haythorne",
+        "lang:fr_CA": "Robert Haythorne"
+      },
+      "id": "Q7345345",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7345345"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Jaffray",
+        "lang:fr_CA": "Robert Jaffray"
+      },
+      "id": "Q7346024",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7346024"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Leonard Hazen",
+        "lang:fr_CA": "Robert Leonard Hazen"
+      },
+      "id": "Q3435739",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3435739"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Mackay",
+        "lang:fr_CA": "Robert Mackay"
+      },
+      "id": "Q511064",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q511064"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Muir",
+        "lang:fr_CA": "Robert Muir"
+      },
+      "id": "Q7347862",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7347862"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert Peterson",
+        "lang:fr_CA": "Robert Peterson"
+      },
+      "id": "Q7348857",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7348857"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert William Weir Carrall",
+        "lang:fr_CA": "Robert William Weir Carrall"
+      },
+      "id": "Q7351112",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7351112"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Robert de Cotret",
+        "lang:fr_CA": "Robert de Cotret"
+      },
+      "id": "Q3436630",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3436630"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Roch Bolduc",
+        "lang:fr_CA": "Roch Bolduc"
+      },
+      "id": "Q763511",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q763511"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rod Zimmer",
+        "lang:fr_CA": "Rod Zimmer"
+      },
+      "id": "Q7356418",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7356418"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Roderick Matheson",
+        "lang:fr_CA": "Roderick Matheson"
+      },
+      "id": "Q7356648",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7356648"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rodolphe Lemieux",
+        "lang:fr_CA": "Rodolphe Lemieux"
+      },
+      "id": "Q3438341",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3438341"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Romuald Bourque",
+        "lang:fr_CA": "Romuald Bourque"
+      },
+      "id": "Q3441274",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3441274"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Roméo LeBlanc",
+        "lang:fr_CA": "Roméo LeBlanc"
+      },
+      "id": "Q927934",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q927934"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ron Duhamel",
+        "lang:fr_CA": "Ron Duhamel"
+      },
+      "id": "Q7363717",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7363717"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ron Ghitter",
+        "lang:fr_CA": "Ron Ghitter"
+      },
+      "id": "Q7363823",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7363823"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rose-Marie Losier-Cool",
+        "lang:fr_CA": "Rose-Marie Losier-Cool"
+      },
+      "id": "Q3442339",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3442339"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rose-May Poirier",
+        "lang:fr_CA": "Rose-May Poirier"
+      },
+      "id": "Q3442344",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3442344"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ross Fitzpatrick",
+        "lang:fr_CA": "Ross Fitzpatrick"
+      },
+      "id": "Q7369331",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7369331"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Royce Frith",
+        "lang:fr_CA": "Royce Frith"
+      },
+      "id": "Q7375163",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7375163"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rufus Curry",
+        "lang:fr_CA": "Rufus Curry"
+      },
+      "id": "Q7378021",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7378021"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rufus Henry Pope",
+        "lang:fr_CA": "Rufus Henry Pope"
+      },
+      "id": "Q3452797",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3452797"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Rupert Davies",
+        "lang:fr_CA": "Rupert Davies"
+      },
+      "id": "Q7380274",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7380274"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Salma Ataullahjan",
+        "lang:fr_CA": "Salma Ataullahjan"
+      },
+      "id": "Q7405355",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7405355"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Salter Hayden",
+        "lang:fr_CA": "Salter Hayden"
+      },
+      "id": "Q7406078",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7406078"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Samuel Merner",
+        "lang:fr_CA": "Samuel Merner"
+      },
+      "id": "Q7412171",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7412171"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Samuel Prowse",
+        "lang:fr_CA": "Samuel Prowse"
+      },
+      "id": "Q7412425",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7412425"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Samuel Sylvester Mills",
+        "lang:fr_CA": "Samuel Sylvester Mills"
+      },
+      "id": "Q7412729",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7412729"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Sandra Lovelace Nicholas",
+        "lang:fr_CA": "Sandra Lovelace Nicholas"
+      },
+      "id": "Q3471928",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3471928"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Sanford Johnston Crowe",
+        "lang:fr_CA": "Sanford Johnston Crowe"
+      },
+      "id": "Q7417634",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7417634"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Scott Tannas",
+        "lang:fr_CA": "Scott Tannas"
+      },
+      "id": "Q7437348",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7437348"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Serge Joyal",
+        "lang:fr_CA": "Serge Joyal"
+      },
+      "id": "Q2272463",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2272463"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Sheila Finestone",
+        "lang:fr_CA": "Sheila Finestone"
+      },
+      "id": "Q3481750",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3481750"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Shirley Maheu",
+        "lang:fr_CA": "Shirley Maheu"
+      },
+      "id": "Q3482358",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3482358"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Sidney Buckwold",
+        "lang:fr_CA": "Sidney Buckwold"
+      },
+      "id": "Q7508977",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7508977"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Solange Chaput-Rolland",
+        "lang:fr_CA": "Solange Chaput-Rolland"
+      },
+      "id": "Q3489133",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3489133"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Staff Barootes",
+        "lang:fr_CA": "Staff Barootes"
+      },
+      "id": "Q7596548",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7596548"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Stanley Haidasz",
+        "lang:fr_CA": "Stanley Haidasz"
+      },
+      "id": "Q525528",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q525528"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Stanley McKeen",
+        "lang:fr_CA": "Stanley McKeen"
+      },
+      "id": "Q7599784",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7599784"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Stanley Waters",
+        "lang:fr_CA": "Stanley Waters"
+      },
+      "id": "Q1613118",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1613118"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Stephen Greene",
+        "lang:fr_CA": "Stephen Greene"
+      },
+      "id": "Q7609352",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7609352"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Suzanne Duplessis",
+        "lang:fr_CA": "Suzanne Fortin-Duplessis"
+      },
+      "id": "Q3505956",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3505956"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Sydney John Smith",
+        "lang:fr_CA": "Sydney John Smith"
+      },
+      "id": "Q3506833",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3506833"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ted Morton",
+        "lang:fr_CA": "Ted Morton"
+      },
+      "id": "Q3517040",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3517040"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Terry Mercer",
+        "lang:fr_CA": "Terry Mercer"
+      },
+      "id": "Q7704796",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7704796"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Terry Stratton",
+        "lang:fr_CA": "Terry Stratton"
+      },
+      "id": "Q16104992",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16104992"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thanh Hai Ngo",
+        "lang:fr_CA": "Thanh Hai Ngo"
+      },
+      "id": "Q7710334",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7710334"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thelma Chalifoux",
+        "lang:fr_CA": "Thelma Chalifoux"
+      },
+      "id": "Q3523526",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3523526"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Cantley",
+        "lang:fr_CA": "Thomas Cantley"
+      },
+      "id": "Q7788212",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7788212"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Chapais",
+        "lang:fr_CA": "Thomas Chapais"
+      },
+      "id": "Q3524986",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3524986"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Coffey",
+        "lang:fr_CA": "Thomas Coffey"
+      },
+      "id": "Q7788505",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7788505"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Crerar",
+        "lang:fr_CA": "Thomas Crerar"
+      },
+      "id": "Q1368799",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1368799"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas D'Arcy Leonard",
+        "lang:fr_CA": "Thomas D'Arcy Leonard"
+      },
+      "id": "Q7788772",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7788772"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Dickson Archibald",
+        "lang:fr_CA": "Thomas Dickson Archibald"
+      },
+      "id": "Q7788976",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7788976"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Farquhar",
+        "lang:fr_CA": "Thomas Farquhar"
+      },
+      "id": "Q7789530",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7789530"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Harold Wood",
+        "lang:fr_CA": "Thomas Harold Wood"
+      },
+      "id": "Q2662141",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2662141"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Joseph Kickham",
+        "lang:fr_CA": "Thomas Joseph Kickham"
+      },
+      "id": "Q7791402",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7791402"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Lefebvre",
+        "lang:fr_CA": "Thomas Lefebvre"
+      },
+      "id": "Q3525337",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3525337"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas McKay",
+        "lang:fr_CA": "Thomas McKay"
+      },
+      "id": "Q7792319",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7792319"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Nicholson Gibbs",
+        "lang:fr_CA": "Thomas Nicholson Gibbs"
+      },
+      "id": "Q663451",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q663451"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Osborne Davis",
+        "lang:fr_CA": "Thomas Osborne Davis"
+      },
+      "id": "Q7792898",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7792898"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Reid",
+        "lang:fr_CA": "Thomas Reid"
+      },
+      "id": "Q7793462",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7793462"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Reuben Black",
+        "lang:fr_CA": "Thomas Reuben Black"
+      },
+      "id": "Q2404028",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2404028"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Robert McInnes",
+        "lang:fr_CA": "Thomas Robert McInnes"
+      },
+      "id": "Q1600518",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1600518"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Simpson Sproule",
+        "lang:fr_CA": "Thomas Simpson Sproule"
+      },
+      "id": "Q7793982",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7793982"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Temple",
+        "lang:fr_CA": "Thomas Temple"
+      },
+      "id": "Q3525610",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3525610"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Vien",
+        "lang:fr_CA": "Thomas Vien"
+      },
+      "id": "Q3525631",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3525631"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Vincent Grant",
+        "lang:fr_CA": "Thomas Vincent Grant"
+      },
+      "id": "Q7794708",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7794708"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas Wilson Crothers",
+        "lang:fr_CA": "Thomas Wilson Crothers"
+      },
+      "id": "Q7795229",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7795229"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas-Alfred Bernier",
+        "lang:fr_CA": "Thomas-Alfred Bernier"
+      },
+      "id": "Q7786799",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7786799"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thomas-Jean Bourque",
+        "lang:fr_CA": "Thomas Jean Bourque"
+      },
+      "id": "Q3525246",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3525246"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Théodore Robitaille",
+        "lang:fr_CA": "Théodore Robitaille"
+      },
+      "id": "Q505998",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q505998"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thérèse Casgrain",
+        "lang:fr_CA": "Thérèse Casgrain"
+      },
+      "id": "Q526198",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q526198"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Thérèse Lavoie-Roux",
+        "lang:fr_CA": "Thérèse Lavoie-Roux"
+      },
+      "id": "Q3527356",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3527356"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Tobias Enverga",
+        "lang:fr_CA": "Tobias Enverga"
+      },
+      "id": "Q16186656",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16186656"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Tom McInnis",
+        "lang:fr_CA": "Tom McInnis"
+      },
+      "id": "Q7816827",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7816827"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Tommy Banks",
+        "lang:fr_CA": "Tommy Banks"
+      },
+      "id": "Q3531303",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3531303"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Trevor Eyton",
+        "lang:fr_CA": "Trevor Eyton"
+      },
+      "id": "Q7839140",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7839140"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Ulric-Joseph Tessier",
+        "lang:fr_CA": "Ulric-Joseph Tessier"
+      },
+      "id": "Q7879768",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7879768"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Valentine Ratz",
+        "lang:fr_CA": "Valentine Ratz"
+      },
+      "id": "Q7911002",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7911002"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Vernon White",
+        "lang:fr_CA": "Vernon White"
+      },
+      "id": "Q7922281",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7922281"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Victor Oh",
+        "lang:fr_CA": "Victor Oh"
+      },
+      "id": "Q7926201",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7926201"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Vim Kochhar",
+        "lang:fr_CA": "Vim Kochhar"
+      },
+      "id": "Q3559332",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3559332"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Vincent Burke",
+        "lang:fr_CA": "Vincent Burke"
+      },
+      "id": "Q7931700",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7931700"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Vincent Dupuis",
+        "lang:fr_CA": "Vincent Dupuis"
+      },
+      "id": "Q3559609",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3559609"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Viola Léger",
+        "lang:fr_CA": "Viola Léger"
+      },
+      "id": "Q3560355",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3560355"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "W. David Angus",
+        "lang:fr_CA": "David Angus"
+      },
+      "id": "Q3017386",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3017386"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Walter Aseltine",
+        "lang:fr_CA": "Walter Aseltine"
+      },
+      "id": "Q7964179",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7964179"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Walter Hamilton Dickson",
+        "lang:fr_CA": "Walter Hamilton Dickson"
+      },
+      "id": "Q7965067",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7965067"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Walter McCrea",
+        "lang:fr_CA": "Walter McCrea"
+      },
+      "id": "Q7965594",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7965594"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Walter Patrick Twinn",
+        "lang:fr_CA": "Walter Patrick Twinn"
+      },
+      "id": "Q7965795",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7965795"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Watson Montgomery Crosby",
+        "lang:fr_CA": "Watson Montgomery Crosby"
+      },
+      "id": "Q7974839",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7974839"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Wellington Willoughby",
+        "lang:fr_CA": "Wellington Willoughby"
+      },
+      "id": "Q7981543",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7981543"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Wesley Stambaugh",
+        "lang:fr_CA": "Wesley Stambaugh"
+      },
+      "id": "Q7984006",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7984006"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Wilbert Keon",
+        "lang:fr_CA": "Wilbert Keon"
+      },
+      "id": "Q3568086",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3568086"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Wilfred Moore",
+        "lang:fr_CA": "Wilfred Moore"
+      },
+      "id": "Q8001848",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8001848"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Wilfrid Laurier McDougald",
+        "lang:fr_CA": "Wilfrid Laurier McDougald"
+      },
+      "id": "Q8001956",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8001956"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Albert Boucher",
+        "lang:fr_CA": "William Albert Boucher"
+      },
+      "id": "Q8004222",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8004222"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Alexander Fraser",
+        "lang:fr_CA": "William Alexander Fraser"
+      },
+      "id": "Q16000254",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16000254"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Antrobus Griesbach",
+        "lang:fr_CA": "William Antrobus Griesbach"
+      },
+      "id": "Q8004499",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8004499"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Ashbury Buchanan",
+        "lang:fr_CA": "William Ashbury Buchanan"
+      },
+      "id": "Q15980340",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15980340"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Benjamin Ross",
+        "lang:fr_CA": "William Benjamin Ross"
+      },
+      "id": "Q8005391",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8005391"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Brunt",
+        "lang:fr_CA": "William Brunt"
+      },
+      "id": "Q8006067",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8006067"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Cameron Edwards",
+        "lang:fr_CA": "William Cameron Edwards"
+      },
+      "id": "Q8006484",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8006484"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Craig McNamara",
+        "lang:fr_CA": "William Craig McNamara"
+      },
+      "id": "Q8007230",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8007230"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Daum Euler",
+        "lang:fr_CA": "William Daum Euler"
+      },
+      "id": "Q8007599",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8007599"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Dell Perley",
+        "lang:fr_CA": "William Dell Perley"
+      },
+      "id": "Q8007747",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8007747"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Dennis",
+        "lang:fr_CA": "William Dennis"
+      },
+      "id": "Q8007766",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8007766"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Duff",
+        "lang:fr_CA": "William Duff"
+      },
+      "id": "Q669438",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q669438"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Eli Sanford",
+        "lang:fr_CA": "William Eli Sanford"
+      },
+      "id": "Q8008522",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8008522"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Gibson",
+        "lang:fr_CA": "William Gibson"
+      },
+      "id": "Q8009856",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8009856"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Hales Hingston",
+        "lang:fr_CA": "William Hales Hingston"
+      },
+      "id": "Q3568677",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3568677"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Harmer",
+        "lang:fr_CA": "William Harmer"
+      },
+      "id": "Q8010887",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8010887"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Henry Brouse",
+        "lang:fr_CA": "William Henry Brouse"
+      },
+      "id": "Q8011914",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8011914"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Henry Chaffers",
+        "lang:fr_CA": "William Henry Chaffers"
+      },
+      "id": "Q8011922",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8011922"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Henry Dennis",
+        "lang:fr_CA": "William Henry Dennis"
+      },
+      "id": "Q8011958",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8011958"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Henry Golding",
+        "lang:fr_CA": "William Henry Golding"
+      },
+      "id": "Q8012005",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8012005"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Henry McGuire",
+        "lang:fr_CA": "William Henry McGuire"
+      },
+      "id": "Q14949594",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q14949594"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Henry Sharpe",
+        "lang:fr_CA": "William Henry Sharpe"
+      },
+      "id": "Q8012150",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8012150"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Henry Thorne",
+        "lang:fr_CA": "William Henry Thorne"
+      },
+      "id": "Q8012188",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8012188"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Horace Taylor",
+        "lang:fr_CA": "William Horace Taylor"
+      },
+      "id": "Q8012506",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8012506"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Humphrey Bennett",
+        "lang:fr_CA": "William Humphrey Bennett"
+      },
+      "id": "Q8012672",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8012672"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Hunter Odell",
+        "lang:fr_CA": "William Hunter Odell"
+      },
+      "id": "Q3568718",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3568718"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William James Hushion",
+        "lang:fr_CA": "William James Hushion"
+      },
+      "id": "Q3568735",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3568735"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William John Macdonald",
+        "lang:fr_CA": "William John Macdonald"
+      },
+      "id": "Q8013646",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8013646"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Kerr",
+        "lang:fr_CA": "William Kerr"
+      },
+      "id": "Q8013968",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8013968"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William McDonald",
+        "lang:fr_CA": "William McDonald"
+      },
+      "id": "Q8015377",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8015377"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William McDonough Kelly",
+        "lang:fr_CA": "William McDonough Kelly"
+      },
+      "id": "Q8015383",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8015383"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William McKay",
+        "lang:fr_CA": "William McKay"
+      },
+      "id": "Q8015443",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8015443"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William McMaster",
+        "lang:fr_CA": "William McMaster"
+      },
+      "id": "Q8015495",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8015495"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Michael Wall",
+        "lang:fr_CA": "William Michael Wall"
+      },
+      "id": "Q8015610",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8015610"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Moore Benidickson",
+        "lang:fr_CA": "William Moore Benidickson"
+      },
+      "id": "Q8015780",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8015780"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Muirhead",
+        "lang:fr_CA": "William Muirhead"
+      },
+      "id": "Q8015908",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8015908"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Owens",
+        "lang:fr_CA": "William Owens"
+      },
+      "id": "Q3568861",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3568861"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Petten",
+        "lang:fr_CA": "William Petten"
+      },
+      "id": "Q8016837",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8016837"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Proudfoot",
+        "lang:fr_CA": "William Proudfoot"
+      },
+      "id": "Q8017113",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8017113"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Ross",
+        "lang:fr_CA": "William Ross"
+      },
+      "id": "Q8017774",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8017774"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Steeves",
+        "lang:fr_CA": "William Henry Steeves"
+      },
+      "id": "Q977705",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q977705"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "William Templeman",
+        "lang:fr_CA": "William Templeman"
+      },
+      "id": "Q8019245",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8019245"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Willie Adams",
+        "lang:fr_CA": "Willie Adams"
+      },
+      "id": "Q2581417",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2581417"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Wishart McLea Robertson",
+        "lang:fr_CA": "Wishart McLea Robertson"
+      },
+      "id": "Q3569454",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3569454"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Yoine Goldstein",
+        "lang:fr_CA": "Yoine Goldstein"
+      },
+      "id": "Q14916052",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q14916052"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Yonah Martin",
+        "lang:fr_CA": "Yonah Martin"
+      },
+      "id": "Q8054885",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8054885"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Yves Morin",
+        "lang:fr_CA": "Yves Morin"
+      },
+      "id": "Q3573867",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3573867"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Yvette Boucher Rousseau",
+        "lang:fr_CA": "Yvette Boucher Rousseau"
+      },
+      "id": "Q8062358",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8062358"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Édouard-Charles St-Père",
+        "lang:fr_CA": "Édouard-Charles St-Père"
+      },
+      "id": "Q3579696",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3579696"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Édouard-Louis-Antoine-Charles Juchereau Duchesnay",
+        "lang:fr_CA": "Édouard-Louis-Antoine-Charles Juchereau Duchesnay"
+      },
+      "id": "Q8078091",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8078091"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Élie Beauregard",
+        "lang:fr_CA": "Élie Beauregard"
+      },
+      "id": "Q3587718",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3587718"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en_CA": "Émile Fortin",
+        "lang:fr_CA": "Émile Fortin"
+      },
+      "id": "Q3588507",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3588507"
+        }
+      ],
+      "links": [
+
+      ]
+    }
+  ],
+  "organizations": [
+
+  ],
+  "areas": [
+    {
+      "name": {
+        "lang:en_CA": "Canada",
+        "lang:fr_CA": "Canada"
+      },
+      "id": "Q16",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16"
+        }
+      ],
+      "type": {
+        "lang:en_CA": "Country",
+        "lang:fr_CA": "Pays"
+      }
+    }
+  ],
+  "memberships": [
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2821675-7219C442-E889-4854-BAC1-F1C693C98007",
+      "person_id": "Q2821675",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4678829-202B1E95-6A59-4092-A407-5E790BFB571A",
+      "person_id": "Q4678829",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4679250-7544AACE-6F3A-4316-BA3B-4FCC5A97C42E",
+      "person_id": "Q4679250",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4679304-1844D4FC-9056-49AD-A156-932DA202F0BB",
+      "person_id": "Q4679304",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4685164-594D47B4-7FDC-4B9D-A01A-790CD4629F5F",
+      "person_id": "Q4685164",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4697191-BB58FC3D-C108-4498-9CA0-B562E6146C9A",
+      "person_id": "Q4697191",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2830544-E7273FA0-8100-429B-A428-95240BFD4C1D",
+      "person_id": "Q2830544",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4708427-512CA076-6BCE-4330-B6E5-382D173DA956",
+      "person_id": "Q4708427",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4710100-82E2AD4D-1BC0-469A-A85A-D7FEEE771AB4",
+      "person_id": "Q4710100",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4710595-ABFFFC24-4892-4BF4-839C-DC68D84C0F2B",
+      "person_id": "Q4710595",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4711019-424F3604-DF2A-44D8-BC4F-941FE9CB1AEB",
+      "person_id": "Q4711019",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4718413-BF964F23-505B-415C-B43F-76E559379888",
+      "person_id": "Q4718413",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4718776-1FD35480-6A5E-4C82-8E2F-9F7BCA5390BC",
+      "person_id": "Q4718776",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4719073-B88D7784-18C5-456F-8BB5-553B412FC1B3",
+      "person_id": "Q4719073",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8194911-96DF63BA-D1AC-4C63-9DB5-B18E042AACC1",
+      "person_id": "Q8194911",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4719576-7B6863BB-E525-447C-8234-A1FDD2565611",
+      "person_id": "Q4719576",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4719735-EF951D3E-3BBF-48AF-AD8E-3EA00E581434",
+      "person_id": "Q4719735",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4720294-813E82EA-984D-4F64-B108-0B28C50DA489",
+      "person_id": "Q4720294",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4720331-69F08F5C-0971-4DDF-B2ED-46223F1A52ED",
+      "person_id": "Q4720331",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2833795-269B36F1-28E3-4400-AFD3-CEC9FEB4EDDC",
+      "person_id": "Q2833795",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4720799-D4ECF63C-EAC0-4BBF-AA6C-7559139723E4",
+      "person_id": "Q4720799",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2644939-35D2A5E9-5C2E-4072-94B7-9AAE4F98F4D5",
+      "person_id": "Q2644939",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2835215-66E2360A-06AA-48FA-B01A-80FDABB240D1",
+      "person_id": "Q2835215",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4723513-8F2EA448-41E4-4550-BE6F-F4F7AC1A72B3",
+      "person_id": "Q4723513",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4730779-5093B47F-5548-474E-AC47-42979F4CFC25",
+      "person_id": "Q4730779",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4731549-682DF4CA-FF7A-405A-807F-23BEB7ADFD07",
+      "person_id": "Q4731549",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2838349-81E2D15C-ADC9-452B-96DE-AB73C87E16FC",
+      "person_id": "Q2838349",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4735343-D549A972-66D4-4ED8-B27D-6C4A5775F22F",
+      "person_id": "Q4735343",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2839781-016832DD-1533-4FA2-8D96-4220100A6ED9",
+      "person_id": "Q2839781",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2839696-C38F897E-366B-4A7F-87EF-00980CD299A3",
+      "person_id": "Q2839696",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2842362-513DAF71-9962-4D31-BD4D-574A1F52143B",
+      "person_id": "Q2842362",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q587924-ED87DF9F-947C-4F05-BA26-DC307923EBDF",
+      "person_id": "Q587924",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q482172-109E5E4A-0598-4C14-A3C2-94713BB9C389",
+      "person_id": "Q482172",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q503636-C0BF6D05-5485-49D5-B970-B328D0C198EE",
+      "person_id": "Q503636",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4757267-0BD4C144-4A26-4B81-9AE5-A030708971AA",
+      "person_id": "Q4757267",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4758760-D0C0754F-1278-48B8-8AFD-49E4D964E690",
+      "person_id": "Q4758760",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2848935-4A866BFF-3CAE-4848-98C8-183E21AB1F5B",
+      "person_id": "Q2848935",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4764088-D1D804D4-311C-4429-ACCF-BA68DAEDAE4A",
+      "person_id": "Q4764088",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2851043-51EF10ED-79E1-4A90-B53F-76364F53F6F2",
+      "person_id": "Q2851043",
+      "start_date": "1984-01-13",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2852477-98CEE6BA-EBB2-47C9-9B46-1800C76DF13A",
+      "person_id": "Q2852477",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2854185-7CC07253-F3FA-4EFC-AE12-0F67EEE25BBC",
+      "person_id": "Q2854185",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4786210-D2531BB3-6806-41E3-8D0C-CBFFDD08B975",
+      "person_id": "Q4786210",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4786246-11FDDFAC-1E34-4E09-BB19-B546CA1F8E6E",
+      "person_id": "Q4786246",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4786354-DF300C9D-DDB4-47E7-9F7D-B9B49ABBAA18",
+      "person_id": "Q4786354",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4786378-714D757A-9822-445B-A3C4-A952199C6CFF",
+      "person_id": "Q4786378",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4786432-DA90E27A-FD34-4C2F-8631-F36C78E714B2",
+      "person_id": "Q4786432",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q633347-71573A72-5E98-49D5-8657-22403EB17371",
+      "person_id": "Q633347",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q679748-0CA77506-E623-4946-83DB-1A959BB23C5B",
+      "person_id": "Q679748",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4792647-903B88D2-F15B-42A3-AFE0-5BB090AB77A6",
+      "person_id": "Q4792647",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q705518-356E078E-C7A6-4DBC-AC55-A4C523AAA06E",
+      "person_id": "Q705518",
+      "start_date": "2005-03-24",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2865007-ECB9DB32-2619-4C8F-98F9-B1678A1EDC1B",
+      "person_id": "Q2865007",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2865014-62F1EE55-AFBB-473F-A067-D7BE4D57F862",
+      "person_id": "Q2865014",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2865043-F699EC22-1016-4EC8-8323-70EED15343AA",
+      "person_id": "Q2865043",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2865147-FE3B9009-EF03-49C2-8705-595CD2ED9FD6",
+      "person_id": "Q2865147",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q710278-E6EB9FCE-9DFC-40F3-92E3-6AFA83FC26F8",
+      "person_id": "Q710278",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4799639-C3B273F9-6BD4-4CCE-BEF3-EFADB25463AE",
+      "person_id": "Q4799639",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4799678-ABE44606-522B-4D4F-9C72-9EE1036AA78B",
+      "person_id": "Q4799678",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q128645-F87ECE92-B6AA-405C-8AC0-1767FF6636BA",
+      "person_id": "Q128645",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4800162-8151FC6A-6EAA-443E-ADFB-0F6094ECFE37",
+      "person_id": "Q4800162",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2865357-659CE47B-BF8B-4AD2-A8FC-EEB25096D4DD",
+      "person_id": "Q2865357",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2864958-4EB879A4-6400-43F8-AAA4-239B2E802133",
+      "person_id": "Q2864958",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4803099-DBA1BE24-C610-4773-8FDE-5301E147F52A",
+      "person_id": "Q4803099",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4803101-5078B9F5-329A-46CC-A842-5E5C15E09ECC",
+      "person_id": "Q4803101",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4804519-CF7CBEE2-3538-482E-8FF8-B4D2D86DF42B",
+      "person_id": "Q4804519",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2868982-EE013086-D410-4CA8-BC51-A24D7A854B0D",
+      "person_id": "Q2868982",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2871120-0B6D2B55-24BE-4F52-968D-EB9193D29307",
+      "person_id": "Q2871120",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q352902-A2A27F18-3BBC-425C-AB88-03CCD3C7FE22",
+      "person_id": "Q352902",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2871966-1FB7F2A4-4383-45F1-9FA6-B8A2D56C1260",
+      "person_id": "Q2871966",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2872046-19658493-1E9C-442D-AD08-4FE4D20E7E11",
+      "person_id": "Q2872046",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2872111-6AB84050-5B44-4B04-BBCD-5DB5D486F2C0",
+      "person_id": "Q2872111",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q793652-68D3AB4D-5323-4574-94AA-40AAA8FD17AC",
+      "person_id": "Q793652",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4888388-E048EF7C-4E82-4E8D-AB0E-057E114E6E2C",
+      "person_id": "Q4888388",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2896080-8AD42990-2B54-4E02-A565-E7CBFCEFC912",
+      "person_id": "Q2896080",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4889218-990C65E3-A717-4CCE-B4B9-47E6F2EEF83F",
+      "person_id": "Q4889218",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4889386-E8293FA4-9DB9-4074-AD37-3AC4E81F77A4",
+      "person_id": "Q4889386",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q725023-9ECC38B9-1378-4BE9-889D-D6F3A6757C0A",
+      "person_id": "Q725023",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4894988-C1F95BFC-0B33-48E4-B678-A2A4477C34D7",
+      "person_id": "Q4894988",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4898876-8231FA3C-93D0-4E0B-A1DE-EC379E9CE1B6",
+      "person_id": "Q4898876",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4898995-736B0610-5FDD-4588-A810-1628E01D6E97",
+      "person_id": "Q4898995",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q862413-0E68E874-95DF-4164-B926-B79B48CF095A",
+      "person_id": "Q862413",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4911521-FA4A248F-C18E-441F-BECE-138109289BF2",
+      "person_id": "Q4911521",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2924409-38FA32B5-FD8F-4702-8303-DE23E408B031",
+      "person_id": "Q2924409",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4962667-F5749A2B-FB3C-46EF-8524-8D544B99CC05",
+      "person_id": "Q4962667",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5006975-34FF267E-A1A6-4B67-8B57-412EC4BDDED0",
+      "person_id": "Q5006975",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q528201-57F4306B-AC87-45C6-AC71-1550E9960282",
+      "person_id": "Q528201",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5019282-F83CE1B0-1BA4-4A5B-9020-2FEEF1BD826F",
+      "person_id": "Q5019282",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2934056-6762DB14-031C-4B52-8CF1-38E95497BCF6",
+      "person_id": "Q2934056",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5024275-E6779538-44A0-4BA5-97FE-57AF19621FD7",
+      "person_id": "Q5024275",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5024490-A95C8F69-657C-48F2-B8A0-BC5002411BC8",
+      "person_id": "Q5024490",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5040222-DEAFA584-E09B-40E6-9AA6-EBEB3732E62F",
+      "person_id": "Q5040222",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5045471-A48924AD-099B-4192-AB66-5FA5534C8BAA",
+      "person_id": "Q5045471",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1063332-297C4EAD-908A-4062-BE51-121903628B00",
+      "person_id": "Q1063332",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q220157-8219BC83-191B-46FF-BB20-A9310D0C613C",
+      "person_id": "Q220157",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2958764-31C33D2E-44DD-4F47-92E6-BE7BEFE36281",
+      "person_id": "Q2958764",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2958524-9B3D5F2B-52A7-4B4D-929D-D7FCB777CC67",
+      "person_id": "Q2958524",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2958607-32E30437-C4A1-4E03-BAAA-D111A7FF751A",
+      "person_id": "Q2958607",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2958642-9A21496D-220A-45D8-A484-B5243FEC587F",
+      "person_id": "Q2958642",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5076475-03542D72-0CA3-4492-BE2F-C06CFA0407A3",
+      "person_id": "Q5076475",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5077263-7D7A2C7C-4764-4802-B6E4-66407C3B9B77",
+      "person_id": "Q5077263",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5077367-08C518A2-0EB1-45A1-BC63-98ADC52E9BDF",
+      "person_id": "Q5077367",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5077444-51C2510A-DDF1-48EB-AF35-E7D639C4E165",
+      "person_id": "Q5077444",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5077932-7B7B9420-F90F-4FE1-8570-69F57FB07142",
+      "person_id": "Q5077932",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5080118-2A9C4747-75BD-40CA-B17D-77FB81424F7B",
+      "person_id": "Q5080118",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5080809-7452378A-12AC-48D1-A3EC-7B4A0829CC4F",
+      "person_id": "Q5080809",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5080816-F1823A48-7082-4C88-B9A0-257C465AD0EB",
+      "person_id": "Q5080816",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5081159-44A53306-20EC-4E11-83C7-C7108622A7F9",
+      "person_id": "Q5081159",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5083047-53580883-050B-48D8-A632-36A30492C252",
+      "person_id": "Q5083047",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2957984-4E9A74EB-4DAD-4DCB-AE08-167C3FAA5178",
+      "person_id": "Q2957984",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5074729-545D673F-0AD5-4733-87E5-BDA909DBF0D0",
+      "person_id": "Q5074729",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5074755-126C83CD-E30B-44E9-B26A-AA1F7BBD9D3C",
+      "person_id": "Q5074755",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5074760-D259923D-CE2F-4B5F-8DDA-41B09D3FBEA6",
+      "person_id": "Q5074760",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2958332-B2359CBE-C402-41F2-9EED-E678E032E560",
+      "person_id": "Q2958332",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2960890-95445923-8F8C-4A16-B58F-941538887AE5",
+      "person_id": "Q2960890",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5093264-BD92C25E-A330-42E6-BA71-C345900C1189",
+      "person_id": "Q5093264",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2965334-EC78374B-809A-4A49-9ED8-08CE21D0F791",
+      "person_id": "Q2965334",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2975554-9ACE0DE7-0CF1-4E41-95EA-24A1D94367D7",
+      "person_id": "Q2975554",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2975582-92D63FDA-ECA0-4B8D-A9B4-C835F4EFB293",
+      "person_id": "Q2975582",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5126708-DB75CDF4-0306-4A8D-A3CB-E00A3A711BE1",
+      "person_id": "Q5126708",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2977137-08F161E6-9790-4A10-81ED-977FB0906E60",
+      "person_id": "Q2977137",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q512939-0CBACCB2-E39A-4896-A3D1-C40EE592E1D2",
+      "person_id": "Q512939",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2978387-E8F032FC-D1CA-4556-949C-F67274E9FD69",
+      "person_id": "Q2978387",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q571983-11510AF1-A65E-4D4E-B2DD-A9C81DF60C78",
+      "person_id": "Q571983",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5131387-86D1B008-81BF-4F52-8DA2-CB220CF4B2FB",
+      "person_id": "Q5131387",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5132550-275214DA-0800-4CDE-AC8B-323D758D939D",
+      "person_id": "Q5132550",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5134651-0C307C32-1BFB-4C2F-A390-2CC4A8B82589",
+      "person_id": "Q5134651",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2982619-739AA5D3-893E-4988-883B-B358B0E683A5",
+      "person_id": "Q2982619",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5163203-8BDD256F-0A35-41A7-996C-9681C9292D1E",
+      "person_id": "Q5163203",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3002426-91BB249B-2CAC-4B8F-82A0-DD6D1CADD218",
+      "person_id": "Q3002426",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5200872-B212F5B8-D7EB-48C0-BA72-AAB30BB19E41",
+      "person_id": "Q5200872",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5200956-3DA33754-BCD2-4307-996A-29BED3B846D8",
+      "person_id": "Q5200956",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3010175-7584E6F5-C40F-45C9-9071-A4264D24FFCA",
+      "person_id": "Q3010175",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5210912-2B03C87D-7861-4506-9EC8-B9B09CA85AC2",
+      "person_id": "Q5210912",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q386669-0A1D866D-DE2B-4ABA-90AA-78E9EB3C09FD",
+      "person_id": "Q386669",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5216957-AA72F1A7-63D5-4C46-8674-EB2BECF88E85",
+      "person_id": "Q5216957",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5217056-39B21BCE-D5A9-4A0B-9352-AC0C187FF02E",
+      "person_id": "Q5217056",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3014092-599E1D55-80E5-4F9F-8601-8334C5AD2A41",
+      "person_id": "Q3014092",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5217873-901BA676-FA48-407B-87FE-9E609C34EC58",
+      "person_id": "Q5217873",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5217874-129C096C-1D39-4C3A-9899-326DB0683628",
+      "person_id": "Q5217874",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3017357-c6d09549-42c6-e278-2ea3-3ae1d5be5dae",
+      "person_id": "Q3017357",
+      "start_date": "2017-09-01",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5231672-DEC5CC34-2566-43AF-89D7-A40DF06C9122",
+      "person_id": "Q5231672",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1173997-E726B1DE-53AA-4008-8509-AAD8B152B485",
+      "person_id": "Q1173997",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5232676-AF14B24E-15F7-458B-A3AE-6FAB5994C898",
+      "person_id": "Q5232676",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5233280-2751DB19-8649-4795-B8CE-C2600C232291",
+      "person_id": "Q5233280",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5235577-F68681F6-12C6-4F7A-95A1-C81CFF7D20C2",
+      "person_id": "Q5235577",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1175226-DACE30AA-35D0-486E-867B-369B0D12D486",
+      "person_id": "Q1175226",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5236996-39C12AD8-C3F9-419B-9B66-DA046EE9E0A5",
+      "person_id": "Q5236996",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5237580-94FCB609-390D-418C-9054-BECED02C2A08",
+      "person_id": "Q5237580",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3018567-DBA9C77F-C715-4DD9-9939-1D6050762C58",
+      "person_id": "Q3018567",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5238963-F408E96A-DE4D-41D6-9C46-8B42B6C736AA",
+      "person_id": "Q5238963",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5239878-85A35E51-F2F0-40E8-9B18-CA4EA929D50B",
+      "person_id": "Q5239878",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5240077-A7124475-A017-4DFA-BFA4-5B607719974B",
+      "person_id": "Q5240077",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3018884-2F593A30-C078-4A09-B4A0-235683FBF0A3",
+      "person_id": "Q3018884",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5240957-9C8F605C-7EBE-453B-BFEB-0BFC37CCFAAD",
+      "person_id": "Q5240957",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5257618-F22B6E6C-70BD-440C-BD2D-0DED56748E16",
+      "person_id": "Q5257618",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3023150-8F018A50-D11C-4339-A5C2-9AB7F59992D0",
+      "person_id": "Q3023150",
+      "start_date": "2005-08-02",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5258849-5E8D40E8-EB75-4B38-8765-97DF555DCB81",
+      "person_id": "Q5258849",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5271402-AEE24542-CD89-4404-B7B2-761ADA210122",
+      "person_id": "Q5271402",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5293139-30A228A8-5521-4689-AC18-A7C2A599BFB9",
+      "person_id": "Q5293139",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5293328-54A6723A-2A6A-4E59-BF05-9B438C68C9E4",
+      "person_id": "Q5293328",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5293933-04E2F445-6199-48CB-A988-47F4952D2731",
+      "person_id": "Q5293933",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294127-CC6057FD-CA76-4C65-8DF1-43816D32A461",
+      "person_id": "Q5294127",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294345-6531A1A1-F145-4E6D-9A50-C7AB9A0FDC4E",
+      "person_id": "Q5294345",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294746-1788B16C-AE54-4B6A-A533-A956F87CFBD7",
+      "person_id": "Q5294746",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294755-85BD2169-95E5-4114-A569-A0D500F3EBFF",
+      "person_id": "Q5294755",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294831-EAC46279-8FC0-4994-B965-A5174EB05EA0",
+      "person_id": "Q5294831",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294860-54B221C4-C3DA-4B77-A7E3-325FD5645747",
+      "person_id": "Q5294860",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294896-8CB00816-D0EF-454E-881C-2C6557BB76BB",
+      "person_id": "Q5294896",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5294957-60788ADF-3862-4DB0-8C28-6BB84D970755",
+      "person_id": "Q5294957",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5295206-5B4D53C7-0E12-4A1C-B52D-CE9E2660D6B8",
+      "person_id": "Q5295206",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3036195-5EB72734-E8C5-4125-94D8-354CB75EBEDD",
+      "person_id": "Q3036195",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5297961-BA4E1632-DD4A-4B2C-B2CD-E7C2A3629619",
+      "person_id": "Q5297961",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5300309-12EC1E2B-D639-4553-8CB9-C4F5082C25DF",
+      "person_id": "Q5300309",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5300472-8D901248-EF1F-4829-8E41-E31E21A2EEA2",
+      "person_id": "Q5300472",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5301445-18C6DC26-B6AF-43AB-A93B-E1F9A2CE0F58",
+      "person_id": "Q5301445",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5301942-D598A53F-08D7-4A14-9021-1F05D7C6FA8D",
+      "person_id": "Q5301942",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5314407-897AE8FF-EE5D-446C-8BEE-CD420396B2FA",
+      "person_id": "Q5314407",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5314419-AD940944-1633-436D-B14B-55870A8C0C62",
+      "person_id": "Q5314419",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5314485-B7C300D4-D3E4-4FAD-BB68-67D89584667B",
+      "person_id": "Q5314485",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5321816-1D87ACB4-4083-49BF-B25D-67C9A1ADDE43",
+      "person_id": "Q5321816",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5325908-5FB94C65-AD37-4B49-9D4D-C64869E3DF4B",
+      "person_id": "Q5325908",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5326148-C4CB024D-907B-44D1-8BB7-8B76373B94E7",
+      "person_id": "Q5326148",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5331722-5C9DF437-0F1A-41EE-A4DF-A5AEDAF5090D",
+      "person_id": "Q5331722",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3047450-08DEFF74-6DD8-4A4C-94C6-67407F3E252D",
+      "person_id": "Q3047450",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5337480-90C2B2C7-41D4-4B72-B578-E8B7069482BC",
+      "person_id": "Q5337480",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3048141-12B76FC5-FCB4-4B48-A4DE-4C274F9E3F1F",
+      "person_id": "Q3048141",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3048524-FDB80FDF-C580-420F-AD51-B95EB6B64624",
+      "person_id": "Q3048524",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5343857-C1EC6E1F-85F6-413A-AAFB-93393A50DDC5",
+      "person_id": "Q5343857",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5343919-E7367BFB-4397-4A18-A31B-6884E32571BF",
+      "person_id": "Q5343919",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5344065-A09F1CE6-9FEE-46D7-9975-8F9016CFCFBC",
+      "person_id": "Q5344065",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5344276-9178EF7F-26F1-414A-AC36-EE88B731DA80",
+      "person_id": "Q5344276",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5344367-964F7B7E-1F14-446C-BD11-1B51D4D21AA3",
+      "person_id": "Q5344367",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5344453-7E3E9F0A-E192-495D-86F4-E5A410BC979B",
+      "person_id": "Q5344453",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5344552-05CA7408-45D2-4298-86D9-48DF1D82E535",
+      "person_id": "Q5344552",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5349445-AC7AD743-F9BA-4065-8BB1-9A01975A25FE",
+      "person_id": "Q5349445",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5353253-82BCDBB8-EE32-4C92-A72B-A7E5DED9F75A",
+      "person_id": "Q5353253",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5360946-E6DB32BD-40EF-4F27-BAD7-08B5461E90F8",
+      "person_id": "Q5360946",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q668271-69A9B2A0-7CF4-4123-B948-8F124F40118F",
+      "person_id": "Q668271",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5368640-363F69DD-CAD6-4457-BA2C-5CB01E27F20B",
+      "person_id": "Q5368640",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5386124-E67882C3-528E-4DC1-825A-7FC0D8590733",
+      "person_id": "Q5386124",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5386303-425D5B11-6722-44E7-96C1-9142824B2CB2",
+      "person_id": "Q5386303",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15063420-60339342-9661-4D36-976F-020523FE2F7C",
+      "person_id": "Q15063420",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5393090-362AE484-F5E5-4533-80F3-4E06137C0A3B",
+      "person_id": "Q5393090",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5403090-F2B26FB7-9FA4-4BAD-8AD5-46C62B140060",
+      "person_id": "Q5403090",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5408541-17BA0E36-AFE5-4AA3-BA6E-01FBF6535A1B",
+      "person_id": "Q5408541",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3060082-3A5AF3E8-1205-48C5-8773-63CBD5703A63",
+      "person_id": "Q3060082",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5415923-4B0F129F-BC65-484E-908E-57798D2B2721",
+      "person_id": "Q5415923",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3062784-C33CDF4E-E286-4BEF-AD78-CE4E726F2202",
+      "person_id": "Q3062784",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5423340-34E2CFA7-3CEB-4597-B910-30C9C5F40720",
+      "person_id": "Q5423340",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3063518-dcb39070-4d8c-efec-0410-8cd50a425bf1",
+      "person_id": "Q3063518",
+      "start_date": "2011-05-25",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3184245-15CE71CC-E44F-40C6-B65F-E7F77C05E88A",
+      "person_id": "Q3184245",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3069029-6A605EAB-B27A-4C8B-8488-47EBE5018FAA",
+      "person_id": "Q3069029",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5444532-0CF89A0A-9813-4CC6-AE50-E1C3DD9B2458",
+      "person_id": "Q5444532",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3069319-AC9B96C2-26C4-4D2D-A33E-980F665953A4",
+      "person_id": "Q3069319",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5450538-DEB3A7CB-3237-488F-8040-5B59783AD031",
+      "person_id": "Q5450538",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5450543-2EFC722F-7CB2-4F1A-9FB5-C7B168B3DD12",
+      "person_id": "Q5450543",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5460567-EA8411A5-2C1F-4A05-939F-E3B49FD3CAB5",
+      "person_id": "Q5460567",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15946286-75820962-BDFA-4D8D-B351-78A264F413FB",
+      "person_id": "Q15946286",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5480536-B518CE1E-E11E-4B74-B862-0C4B4DD52AC6",
+      "person_id": "Q5480536",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1441498-090D0990-A8E3-4AC2-AAAC-0B6F1B04012D",
+      "person_id": "Q1441498",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5482584-07727F30-EC27-474A-9691-47E2F7986E76",
+      "person_id": "Q5482584",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3082526-30662B19-234B-4169-B1BA-6240E82DF783",
+      "person_id": "Q3082526",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5485956-106EF4F7-47F4-4A8C-9EFE-2F585DC57930",
+      "person_id": "Q5485956",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16022924-2544011F-30C5-4A25-99F1-5CB9B9CD1D12",
+      "person_id": "Q16022924",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3084144-35C6B4DE-A627-489B-A73A-1D6EED0A8478",
+      "person_id": "Q3084144",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3083679-541B3C03-1CB2-47B8-8A1F-0FF6A9EC3085",
+      "person_id": "Q3083679",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5494994-E8C7AB70-142B-4CD8-8AFD-78E032F65031",
+      "person_id": "Q5494994",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5497100-B5736342-C113-473B-9DCB-584427D4BFD7",
+      "person_id": "Q5497100",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5497144-8443CBCA-6E65-467C-AD28-0968846CD66F",
+      "person_id": "Q5497144",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5497785-4C7FBEF6-0089-4919-B820-B0FC37B0AB80",
+      "person_id": "Q5497785",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5497873-31B198A2-0951-41E0-A9D1-7A823D038756",
+      "person_id": "Q5497873",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5498248-BA0559F1-82E0-4BE5-842B-70E6F68C4DD5",
+      "person_id": "Q5498248",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5498440-97778140-E4E9-4466-A214-3888B5B24A7E",
+      "person_id": "Q5498440",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5498504-F3ED093D-FFFC-4634-8DC6-F057BE304CD7",
+      "person_id": "Q5498504",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5499072-0FCDF25D-6DC6-4AE4-B5D4-52187CEA8A13",
+      "person_id": "Q5499072",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5499097-A5E20A1B-13B5-4A56-968B-6FE4B1CDA273",
+      "person_id": "Q5499097",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5499101-C2A3E07A-A4FE-4B0C-A0E9-D2FDC1F96854",
+      "person_id": "Q5499101",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3089544-84DF40B2-580E-4397-904D-A32170E0D7A2",
+      "person_id": "Q3089544",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5522599-45DED283-35E4-4AF2-BAA7-AD393B3DDBF0",
+      "person_id": "Q5522599",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5536134-B53D4A54-5F42-4605-A336-36FE66C6F88E",
+      "person_id": "Q5536134",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5536143-D3626EBC-FD7B-4F18-81A8-DAD073C227B7",
+      "person_id": "Q5536143",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3101411-29205609-4076-4661-958F-571281DBFF37",
+      "person_id": "Q3101411",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3101447-4732D8A4-0785-4038-BF7D-F8D0EA63493F",
+      "person_id": "Q3101447",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5538200-711C0D32-8663-4448-83B4-6B053D0C7CAC",
+      "person_id": "Q5538200",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5538205-BCEBDF36-6683-4757-9069-8BD78C0753E8",
+      "person_id": "Q5538205",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3101555-7B5AD2A2-E444-4D08-9A52-57A78B712667",
+      "person_id": "Q3101555",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5539530-C090EC79-E12B-4ADA-9413-9214A9B1BB10",
+      "person_id": "Q5539530",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3101590-05A195A0-71A6-4DC3-A102-16CBA182634C",
+      "person_id": "Q3101590",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5539802-2E3F9060-62B4-4BEC-A768-155BF748A3E0",
+      "person_id": "Q5539802",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5539886-0EFEC508-2654-4632-B800-E6B1ACBD4D15",
+      "person_id": "Q5539886",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5540422-1E9FC37B-7482-45E3-BF41-575D67BE86C7",
+      "person_id": "Q5540422",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5540430-66622720-AD9E-44C7-B574-B9E81E55FFB3",
+      "person_id": "Q5540430",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5540476-A6A3CE87-0049-4765-B713-E536A0F89D61",
+      "person_id": "Q5540476",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5540619-415C500E-42E5-4D96-B93E-E28544270D7A",
+      "person_id": "Q5540619",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5541517-D8607251-238E-45C7-A086-773ED9B28D4C",
+      "person_id": "Q5541517",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5541898-AE507D1E-F8A4-4782-9FBC-1AF52C580B9C",
+      "person_id": "Q5541898",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5542322-CE79778D-02EE-4C7B-AAD1-7C651923C4F7",
+      "person_id": "Q5542322",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q524305-16028435-3CCB-4A96-B033-6F402D623CA6",
+      "person_id": "Q524305",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5543312-4727F3BE-8149-42F7-B26F-1B89AC541D3A",
+      "person_id": "Q5543312",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3101829-C516B828-EE42-4970-9271-DF4EBE82EBF4",
+      "person_id": "Q3101829",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5543895-FEA9CB4F-436C-42BA-B33D-946FD48E0090",
+      "person_id": "Q5543895",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3101923-C2C1E234-571E-41D3-BD88-B39E49FC84A4",
+      "person_id": "Q3101923",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5545096-EB3BBD0F-DEED-4382-96E8-FAC15F12F2C5",
+      "person_id": "Q5545096",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5545105-ED144579-8DE5-4A21-88FD-8C0B29B788BA",
+      "person_id": "Q5545105",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3101953-43C5A680-03B2-4BF4-A4BC-F24A72A0FDBF",
+      "person_id": "Q3101953",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5545448-0C094BD7-57E6-4AAF-ABE6-9963F518C9AC",
+      "person_id": "Q5545448",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q710407-620C66F1-D586-43C5-820C-6D3C52B6076A",
+      "person_id": "Q710407",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3102008-4CD9BB6E-FBB3-43AE-B35E-F5B93C5C59FC",
+      "person_id": "Q3102008",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1508621-1D5D150D-2525-4747-82F5-6DD4FF7110AA",
+      "person_id": "Q1508621",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q553340-22030CA1-3C6D-45C7-84A6-312526B80F37",
+      "person_id": "Q553340",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2412368-38D4612E-ADDA-4D5D-B5A2-900C9587C56F",
+      "person_id": "Q2412368",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3103887-BF736D95-68C5-4A06-8C0C-A08FF89FB46F",
+      "person_id": "Q3103887",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5549640-608C6CA3-7628-451B-8C88-1AA43EB9270D",
+      "person_id": "Q5549640",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4555521-8D932DF5-F732-4C36-98C7-FCC1827FDFA0",
+      "person_id": "Q4555521",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5552889-46E8086A-EA9E-456B-82DA-2C1D97503621",
+      "person_id": "Q5552889",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16014152-FE7342A9-32F8-48CE-8D9F-84B2666E40BB",
+      "person_id": "Q16014152",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3104351-6F387A62-8ADE-431F-933C-8B0ABF3CA7A3",
+      "person_id": "Q3104351",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5556749-494B1DAC-1017-4100-914E-0D3CEED0557E",
+      "person_id": "Q5556749",
+      "start_date": "2012-01-06",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5559658-850A0C49-4341-4747-BDF1-B11E52EB75B4",
+      "person_id": "Q5559658",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3105976-C0F918D0-483B-4FBD-A478-9706C9EEC016",
+      "person_id": "Q3105976",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15998225-46ED4073-967B-4F8E-8087-4E0407B3F689",
+      "person_id": "Q15998225",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5585670-453C0D13-C94B-4CCC-9BCE-DB6876A8C149",
+      "person_id": "Q5585670",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5596353-80D68CF1-889F-4592-9E8F-B200E28C4DA0",
+      "person_id": "Q5596353",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3115710-7721F921-0139-4100-BC25-5900989A94D9",
+      "person_id": "Q3115710",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15996926-32184DFC-90A3-4A17-9438-B39721894AE2",
+      "person_id": "Q15996926",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5619150-52C0ABAC-01BE-4E00-8A02-EE4ABE0C1E82",
+      "person_id": "Q5619150",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3121115-844CBA09-FF44-4EE2-8F07-834B94456006",
+      "person_id": "Q3121115",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5621309-69063F13-768B-4C3A-A447-9C4333296368",
+      "person_id": "Q5621309",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3121641-2EA1BDBA-494C-4CEE-A1A3-4111EA880FF2",
+      "person_id": "Q3121641",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16012909-750671BE-9D8A-4781-BA24-FC09C847D035",
+      "person_id": "Q16012909",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5646985-6511B0B3-7048-43F7-B2D2-9623567E6373",
+      "person_id": "Q5646985",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5655005-2DA01816-4670-4A4C-BB3D-A65AE122329C",
+      "person_id": "Q5655005",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16077759-1282801B-AEA4-4F25-B8AE-80E3C52EF86A",
+      "person_id": "Q16077759",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q774447-7E9D9A63-3042-44F7-8735-DBB45ABDBD78",
+      "person_id": "Q774447",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3127975-D31B8129-C844-46FE-B9F3-6B2C4A9BA8DF",
+      "person_id": "Q3127975",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q14949448-F0D81F23-ACFB-4CF6-8102-6D43ABE44C12",
+      "person_id": "Q14949448",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q137138-0BD99104-3083-4782-9F66-C990108BA35A",
+      "person_id": "Q137138",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5715370-E8E5CDB1-FBF1-4DBE-9A71-71546B7D7AB4",
+      "person_id": "Q5715370",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3130895-09F24C91-5F8B-491F-A7C1-5E82874CF3D2",
+      "person_id": "Q3130895",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3132053-83290953-8EBB-4375-A812-62122393D237",
+      "person_id": "Q3132053",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5719810-184D8B5D-96BA-4E49-8CAD-05F741AC86AC",
+      "person_id": "Q5719810",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15996279-193A046E-E23B-4B27-AE68-A78B138BBA32",
+      "person_id": "Q15996279",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5724085-3F42410D-FB2A-43F3-BB72-2A34DDBA6692",
+      "person_id": "Q5724085",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5724236-96003AC8-03BC-4C70-9AFA-94BB335BAD28",
+      "person_id": "Q5724236",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5724595-F45B7681-256B-431F-A5FC-6119C208EF53",
+      "person_id": "Q5724595",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5726132-2339975A-B22C-48F1-A458-222EFD3FF24F",
+      "person_id": "Q5726132",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3133031-D40095C4-C76B-45AC-86E9-3D92CC51D423",
+      "person_id": "Q3133031",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5730031-1FFACC1E-B3EF-4627-93C9-903CBBDFF9C2",
+      "person_id": "Q5730031",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5740353-84C4F34C-979B-47A6-B305-BE9AED03EB1B",
+      "person_id": "Q5740353",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3134598-D8CFC2C1-AA8C-445C-9911-F3053D196D76",
+      "person_id": "Q3134598",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q657712-BF5AE100-2F97-42AC-BCC2-29F53C94E821",
+      "person_id": "Q657712",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3136096-94D7A03A-2B7A-4587-8A53-4C72FC30DC20",
+      "person_id": "Q3136096",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1627975-26043BFA-2A21-4CF8-9F75-DE5AB4DD3AAD",
+      "person_id": "Q1627975",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q222810-7559C5B1-A6C2-4982-8568-5B5AF4F624C5",
+      "person_id": "Q222810",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1642879-573224C7-824A-448F-B78F-ADCDC3FA7EAC",
+      "person_id": "Q1642879",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1655568-F121FC14-9896-4AF6-B001-E717B55FF4A1",
+      "person_id": "Q1655568",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5981368-9BE8D2B0-2F7C-4795-9896-EBC77F197E6B",
+      "person_id": "Q5981368",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16093641-25E7A99F-68AB-417A-A3AB-D9C87BFD1E22",
+      "person_id": "Q16093641",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6074304-BFD1F9F2-2D67-47EC-938C-4052E6A19482",
+      "person_id": "Q6074304",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6074584-72C7334B-CCE1-4698-9600-05109DBDA755",
+      "person_id": "Q6074584",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6074746-EE3A2072-CB41-49E6-AD73-1663B32B9EC1",
+      "person_id": "Q6074746",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6085308-C831EA7C-C987-45E7-991B-C60BC66AB16F",
+      "person_id": "Q6085308",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6095645-45A2C0C1-199F-408F-95D6-BBE9425F423D",
+      "person_id": "Q6095645",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q639772-1BFFAF35-AE47-45A0-81BA-242FB6C68F91",
+      "person_id": "Q639772",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2385829-55568D73-780B-42A8-895E-2321417237E9",
+      "person_id": "Q2385829",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3157019-8C4511AA-5064-4929-B08E-8A7C3DF05AC5",
+      "person_id": "Q3157019",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6113886-CBEF55F9-5FDF-4D87-9544-D3CF0C8E63F3",
+      "person_id": "Q6113886",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1677239-12275AC6-F751-4556-B8FA-4AB46080F648",
+      "person_id": "Q1677239",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3157576-F6D41385-9F13-40F4-842D-E571144B8A8D",
+      "person_id": "Q3157576",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3158427-0E74C3E3-7015-4EA8-A4DF-0724023EC8C3",
+      "person_id": "Q3158427",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q927215-B5E2EB5E-108F-4D34-9AF0-08028FFFA63A",
+      "person_id": "Q927215",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3158894-B620CBD4-70B9-4175-B9EB-3888DA93F896",
+      "person_id": "Q3158894",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3159137-FDD84B9B-BB59-414C-800D-7C809A6D252F",
+      "person_id": "Q3159137",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q14915601-867CC3C4-305C-4E0C-AE68-05E2869E78FE",
+      "person_id": "Q14915601",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q389321-B7851328-F2C2-4DAE-A11D-1D83B71E3E74",
+      "person_id": "Q389321",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6128753-9F3AA22A-91EC-439E-A9D5-2F65ED200E78",
+      "person_id": "Q6128753",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6128885-E6A81217-FC59-4DFD-83D3-BCC5323F9D9F",
+      "person_id": "Q6128885",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6129296-DD949330-206F-4160-A77C-C9FE0C68C48A",
+      "person_id": "Q6129296",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6130960-467C604D-D001-4DDC-BCE9-A76907615A8E",
+      "person_id": "Q6130960",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1680212-72E2CB13-CD18-4C4A-9A07-4F80363E0F2F",
+      "person_id": "Q1680212",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6132403-CD59A075-BFE4-4B81-A305-D000ACB1A9B7",
+      "person_id": "Q6132403",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6132419-100378E3-7212-4F42-BBCE-C7DB3729A094",
+      "person_id": "Q6132419",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3161026-CECFF2D9-AEC6-4498-A520-8340C3615F5D",
+      "person_id": "Q3161026",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3161031-AEADAEE7-C1A8-4AFA-B71D-FD90B5627C85",
+      "person_id": "Q3161031",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6132856-041E3B7C-3A52-40A9-9002-13188CB61EE9",
+      "person_id": "Q6132856",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6132905-B3127098-052F-4998-B143-A8DB41282E30",
+      "person_id": "Q6132905",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6133398-E4B447F4-A118-4A5E-9613-BA78FE900DEE",
+      "person_id": "Q6133398",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q598786-F70BF777-219D-4CE3-9E73-1975E7C78160",
+      "person_id": "Q598786",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6134587-E4759E3D-F277-4A92-BB15-D20FC57A41CF",
+      "person_id": "Q6134587",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1680460-97BAA85C-DBDB-44E2-9627-CBAE2F240B84",
+      "person_id": "Q1680460",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6134898-DE70BA65-4AE2-4918-8489-46F23F3C9F4E",
+      "person_id": "Q6134898",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4397895-8A79153C-4BE1-476C-A459-6772B99D562C",
+      "person_id": "Q4397895",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6135601-F9307421-E1B2-464A-A77E-055AD39A602B",
+      "person_id": "Q6135601",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3161161-F52FEDAF-620B-4C25-B2DA-08F8171796A2",
+      "person_id": "Q3161161",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6136291-C2403695-781B-4FEF-9924-A6291AAC44FB",
+      "person_id": "Q6136291",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15997616-C897CE3B-7195-4A18-A88F-384FF2E299EB",
+      "person_id": "Q15997616",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6136997-11574EAA-B96A-4E03-9713-8471AE3B8BED",
+      "person_id": "Q6136997",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6136999-A26AC1D5-1C1D-4368-9B7C-E62EA5179428",
+      "person_id": "Q6136999",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15993147-2DA6A443-CB48-4B09-9C47-04B2B7AD47FE",
+      "person_id": "Q15993147",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3161209-2287DD08-D493-4A49-8E7B-89C598417CEB",
+      "person_id": "Q3161209",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6137999-24BA9913-893B-4ECC-A5D8-9588D13D4C49",
+      "person_id": "Q6137999",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6139032-644F2792-9310-434D-A309-4B0042503774",
+      "person_id": "Q6139032",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6139518-0367AB18-9F57-4455-B14B-2FB08A656E55",
+      "person_id": "Q6139518",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3161285-59E85D6E-1367-4875-95BE-5BE9E7E60A6B",
+      "person_id": "Q3161285",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15997826-7AC5D82D-E75B-457B-A98B-69CA547A1B74",
+      "person_id": "Q15997826",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16030850-8A5C2D2C-34A4-4C57-B917-1AC3B743B0C1",
+      "person_id": "Q16030850",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15999002-C4076DC1-6711-460D-9DBF-6F79D23A5EBD",
+      "person_id": "Q15999002",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6140894-937740BA-5767-4DD5-8F1C-45A87ECDBDDD",
+      "person_id": "Q6140894",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6141884-D7F61CB6-98BA-4F6D-9EA7-CBD291726FCD",
+      "person_id": "Q6141884",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6141944-712121D7-BC37-4E1F-A40D-803173D2CCC5",
+      "person_id": "Q6141944",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6142204-E3EFB1A5-A4C7-4041-9B61-F140345B2EA0",
+      "person_id": "Q6142204",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6143254-59CA2F33-59DA-4E14-BC91-222F816DAC2B",
+      "person_id": "Q6143254",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6144454-999EFFE6-8166-4B16-8FD8-93CFA876C1E7",
+      "person_id": "Q6144454",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6144484-17824D96-D1F0-4942-A252-5D7BD163327F",
+      "person_id": "Q6144484",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6144898-FFF58033-CFA9-4756-A7E4-777361C6B5C7",
+      "person_id": "Q6144898",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6145559-E004C37B-95B5-4C6A-AB83-D9CF9A9B06FB",
+      "person_id": "Q6145559",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6151275-DAA3F24E-16A0-430A-854B-D4DF03CDC012",
+      "person_id": "Q6151275",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6154629-8EE79618-1525-4DE4-829F-B9743BC9EAFC",
+      "person_id": "Q6154629",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6170242-3D69A077-F6BB-4B4E-A9F2-6BA41B6EC7D4",
+      "person_id": "Q6170242",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15487581-96EB8259-CA8B-4051-B389-816C39DFFA7C",
+      "person_id": "Q15487581",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6170663-45BCF87C-218A-4476-8FEC-E8DC14930CEE",
+      "person_id": "Q6170663",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3172993-93A6A134-6C3E-4E00-87FA-4F443CCA1950",
+      "person_id": "Q3172993",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3173102-BA985902-B8D3-478E-A2B1-BE1386FC460C",
+      "person_id": "Q3173102",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3173747-366365FE-6963-44A5-8E09-CCBF5F93A582",
+      "person_id": "Q3173747",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6168923-3B95E25C-7D17-44E2-B3CE-2B36B8CFE71B",
+      "person_id": "Q6168923",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3164410-AF193958-1F0E-42CA-9914-8943F8CC1BA7",
+      "person_id": "Q3164410",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3164415-4578F84D-ECB8-43E1-B9C1-3C5019E8DA06",
+      "person_id": "Q3164415",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3165196-367FF498-28DB-4D7F-9BF0-CDF059DF1DBE",
+      "person_id": "Q3165196",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3165833-6870C780-F28D-4B7C-839C-504D2D5BBA07",
+      "person_id": "Q3165833",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6169316-2318ECF9-916C-4D23-ABBD-DFEB62256566",
+      "person_id": "Q6169316",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6169459-1CB8BB46-9E9B-4E2B-883A-A1594F38D6B2",
+      "person_id": "Q6169459",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6169608-A0344BAA-E719-4656-A1CC-B94E9B6AC404",
+      "person_id": "Q6169608",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3167783-F9F129C5-1FCA-405E-AD76-7E7E2427B2FF",
+      "person_id": "Q3167783",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3167911-7135EABC-4E86-470A-B426-20E3EDAFC3FA",
+      "person_id": "Q3167911",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1685131-D412F0EE-7D83-4690-873B-827B13C23FE7",
+      "person_id": "Q1685131",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1677284-98CD6AE9-4F75-4620-9DCB-F868EE884C9C",
+      "person_id": "Q1677284",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3169947-A8036617-CBA6-4380-A2B6-B169C45015CD",
+      "person_id": "Q3169947",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1294585-F454422D-9C04-4DF6-A282-7F88DD500F0A",
+      "person_id": "Q1294585",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6180929-158E9ACD-1D0E-439C-BED0-ADCF24B7DA73",
+      "person_id": "Q6180929",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3177466-595D2357-3FFD-41E3-B017-85999618AEC8",
+      "person_id": "Q3177466",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6194381-D590F98F-4DFD-4EA9-A75C-3D2BCECD825C",
+      "person_id": "Q6194381",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6197083-F791A133-0697-417F-88F2-E0E2F98E3326",
+      "person_id": "Q6197083",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6204033-C96FB38B-DDC0-464C-B671-9991EFEA1B91",
+      "person_id": "Q6204033",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6204955-430767F5-F4D4-46DF-8861-5FF72D054F61",
+      "person_id": "Q6204955",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3179583-A284FED7-673F-443C-AD08-5159C3C83362",
+      "person_id": "Q3179583",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6205331-A36DA93C-B53B-449A-A2BC-DE221AA205EC",
+      "person_id": "Q6205331",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q128696-806C3D28-AA72-4748-A4BD-CA797D9BA222",
+      "person_id": "Q128696",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16007991-DA1464B8-9EBB-4484-9C32-EE371015D2A0",
+      "person_id": "Q16007991",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6218591-20DDF56E-63F4-41CC-822A-F09E1589C2F2",
+      "person_id": "Q6218591",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6218593-86C5D56F-F118-4D57-B3D6-4CCA4594FCEB",
+      "person_id": "Q6218593",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6218604-B582278B-A90F-4941-B8AB-7B19ABD8D884",
+      "person_id": "Q6218604",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6218619-7F9DC4B6-7593-42CA-92E3-ADD1E307BE67",
+      "person_id": "Q6218619",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6219213-A8F9E26C-A8D7-4941-814D-2DE1A8CA5C37",
+      "person_id": "Q6219213",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6221530-39C6BFA4-0B2A-449A-B80C-73A189781CCD",
+      "person_id": "Q6221530",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3181113-532280E4-2464-4EFC-9556-C935A643B297",
+      "person_id": "Q3181113",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3181183-553EE937-7E7D-45FD-AA1C-13E569AFD750",
+      "person_id": "Q3181183",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6225171-4657CDFA-31B4-4248-B5DA-8EE6857F2EE1",
+      "person_id": "Q6225171",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6225514-F4F07718-D062-4443-A751-FC4BA6DEF14D",
+      "person_id": "Q6225514",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1486983-1ED22E4A-D2BD-49D6-BA76-3716182337CA",
+      "person_id": "Q1486983",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3181277-FB5790FC-0D23-4460-94E7-80E815147F42",
+      "person_id": "Q3181277",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6228353-29FF568A-9044-490E-A0AD-5BDFA968B1D3",
+      "person_id": "Q6228353",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16031431-273DCF44-9BD4-44C9-8E56-A8D908495ADD",
+      "person_id": "Q16031431",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6230029-AB12229B-0F04-4233-AFCB-C02F9CB11A7A",
+      "person_id": "Q6230029",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6232066-6AA5B129-71C4-4CD3-96DF-FA0C8A7535EB",
+      "person_id": "Q6232066",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6232090-061D0035-3281-4999-8FBC-07E11AD6CF5F",
+      "person_id": "Q6232090",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6232098-77FFE652-36F8-4C95-B6B7-F27A4A0FC06E",
+      "person_id": "Q6232098",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6234133-A354ABC1-5F19-4033-BE88-8DFACA4CB90C",
+      "person_id": "Q6234133",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3181551-E4AF2FE3-E059-4607-82B0-3ED61E1B0BE3",
+      "person_id": "Q3181551",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3170938-F34C22BA-EED1-4C66-B963-6C5555D7CAF2",
+      "person_id": "Q3170938",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6235310-836A6370-542F-4E6B-8995-2413CFAA0C1F",
+      "person_id": "Q6235310",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6235360-4932B841-2DD5-4094-8E28-AC8D72732870",
+      "person_id": "Q6235360",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3181595-2604EED0-881B-4A15-A383-A7F29CC866C5",
+      "person_id": "Q3181595",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6237444-38392491-9549-415A-953D-FF9B06FA7592",
+      "person_id": "Q6237444",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6238296-70630B66-ED80-4913-BCCB-A385E556A786",
+      "person_id": "Q6238296",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16058538-13CE31D6-F2FA-44D8-91AB-945DF34FBB38",
+      "person_id": "Q16058538",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6239431-80E62543-7BDD-44BF-A124-CEAF383E3666",
+      "person_id": "Q6239431",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6241555-D6C6D812-F6BC-4C89-8FCB-A4779462C433",
+      "person_id": "Q6241555",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6242106-09CC7D56-16FF-4BF0-AE5A-7A80C5F66CAF",
+      "person_id": "Q6242106",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1500832-F6C94DC7-83FD-4A75-85B7-1E5020B9EE60",
+      "person_id": "Q1500832",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6242187-EDAF2D06-00EE-4CB6-8CF4-264D1AD44800",
+      "person_id": "Q6242187",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16011288-FA689076-4D59-4074-AA44-A872513422C2",
+      "person_id": "Q16011288",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16089960-00007A9F-5D50-4ECB-90F2-4E2019EED88C",
+      "person_id": "Q16089960",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4265771-5CD36951-FA13-4A76-AEA3-710797BED2DC",
+      "person_id": "Q4265771",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6245394-677F2749-2081-43BF-8844-4746E171C23C",
+      "person_id": "Q6245394",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6246198-FE05F6E2-DFB6-49DD-9F37-7EBFE3F12F24",
+      "person_id": "Q6246198",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6247551-4D151F94-1AED-475A-8A43-9F1F6574F34F",
+      "person_id": "Q6247551",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6248068-9AA60C78-72C6-4B74-B4C8-202E6C5F5C02",
+      "person_id": "Q6248068",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6248647-A17FDF8A-2DA5-441A-A680-FA6C2C901165",
+      "person_id": "Q6248647",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6248858-872D5DC2-BEB3-489A-BBE1-DE886EEF4F31",
+      "person_id": "Q6248858",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6249545-9A6E542F-E88C-4EC3-B2D7-32B3003A7EDF",
+      "person_id": "Q6249545",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6250269-EFA835E9-1F81-4DA3-B7E2-F061A68906B1",
+      "person_id": "Q6250269",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6250856-2EA8418B-2DA6-4B3F-820B-9D046647C8D8",
+      "person_id": "Q6250856",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6252112-85359EE7-C480-4854-9C66-C5761D2F5AE2",
+      "person_id": "Q6252112",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15999323-4E4021DD-B618-44EC-9E29-F53CF9607C7E",
+      "person_id": "Q15999323",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6257353-0ECCF151-055B-45E5-89B9-D3636A44D0B2",
+      "person_id": "Q6257353",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15980338-1BC35392-089D-4C72-8FBF-84B592BECBE2",
+      "person_id": "Q15980338",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6259103-B599CCA5-F640-4083-A81B-46A6AAC5943F",
+      "person_id": "Q6259103",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6259180-4BD6E99E-7866-4096-9387-DF59DDDDD9DD",
+      "person_id": "Q6259180",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6259698-A199B60A-B812-4AC5-A58C-A54DA8F9EE72",
+      "person_id": "Q6259698",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6259870-BD759FA2-8A19-4FC6-B7A8-553381AB4D88",
+      "person_id": "Q6259870",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3182591-6423C248-135C-4FA3-911B-93FE96722218",
+      "person_id": "Q3182591",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6260578-54F2B5DF-8446-474F-A9B8-F358C912F9C2",
+      "person_id": "Q6260578",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3182637-91A99688-D661-44D5-BC17-6941BCC3B783",
+      "person_id": "Q3182637",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6262802-D2A5A83E-4D99-494A-88BE-8BCA7CDFB444",
+      "person_id": "Q6262802",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3182697-C1BEC2D9-07BC-4FFC-890B-E6C5071C8218",
+      "person_id": "Q3182697",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6263329-B38A4E4F-2171-4155-9B66-3D5DE847A038",
+      "person_id": "Q6263329",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q518557-E10D122A-0226-416B-969A-37DF01578315",
+      "person_id": "Q518557",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6265142-2EB1A8F8-7627-4DB6-8772-8B2BCA022E1C",
+      "person_id": "Q6265142",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1652320-66A322C6-D1EB-4108-B9B7-76CFC42CE4DE",
+      "person_id": "Q1652320",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6280781-EB324E2D-15E9-47EE-A626-15BDAEA9D0A0",
+      "person_id": "Q6280781",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1338112-484C0ED8-712A-457D-937F-80D0BF7B5A65",
+      "person_id": "Q1338112",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6281129-CEF8BFC9-75F5-4B2C-AA19-AFC5DF8F441D",
+      "person_id": "Q6281129",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6281132-B84AD3C2-17E8-4FFF-ACCE-B1F4E05E8584",
+      "person_id": "Q6281132",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6281443-76AF62B5-F832-483B-9AAE-1BB14F4AFB10",
+      "person_id": "Q6281443",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3184626-F8173A60-33AA-49D2-AF83-78FC5C4BE003",
+      "person_id": "Q3184626",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3185093-FC16F042-E25A-4783-9005-D45DC02E1D86",
+      "person_id": "Q3185093",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15998954-D8D2F276-9CD2-4408-8A9B-968933A21829",
+      "person_id": "Q15998954",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6285836-7937572E-0B79-48AE-A6A7-CAF055F04241",
+      "person_id": "Q6285836",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3185206-1165E5ED-D531-4868-BD70-0B5AC686A5BC",
+      "person_id": "Q3185206",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6286230-8A72C0BA-753A-4CEC-937F-0A54A3E68427",
+      "person_id": "Q6286230",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3185635-F4BC7A74-7169-4F37-B4D0-E6BBDDFA255C",
+      "person_id": "Q3185635",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6287360-34C80635-BC1E-48D2-86AB-96EF1D5A4C8D",
+      "person_id": "Q6287360",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6287997-E7BED4AE-0727-4B57-A59B-4553EACFB0F2",
+      "person_id": "Q6287997",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q749645-2AC46B0F-D043-451F-86B2-8AEE34B91E55",
+      "person_id": "Q749645",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6280584-29AAC412-CF6C-4685-BDB7-3634CFEF9172",
+      "person_id": "Q6280584",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6280611-B2A8AB4C-0E99-4077-B599-46D51672B99F",
+      "person_id": "Q6280611",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3121222-AFD52240-4A7F-44C8-976A-4D6EA90D673E",
+      "person_id": "Q3121222",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3184307-25C0B419-C351-413E-A3EE-B9F18BE88FB1",
+      "person_id": "Q3184307",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3184311-B7069D63-37E3-4387-BFA3-BD693B16DEAB",
+      "person_id": "Q3184311",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3184337-F8169FA7-8BFE-4E62-9AF2-E94E0A48DC6E",
+      "person_id": "Q3184337",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6280674-F92F55D6-CD77-4C89-9217-BD8D5BAD236A",
+      "person_id": "Q6280674",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3184385-A823CB3A-EA80-4A1D-9394-DC89A5EEC1C7",
+      "person_id": "Q3184385",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3184394-10BACF05-92D0-42D9-894F-2A24754B9723",
+      "person_id": "Q3184394",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q615271-93B33BE2-9792-4A30-BD44-8D2D762ACBD3",
+      "person_id": "Q615271",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16037823-FE8F0DD6-AECD-4932-9013-A870F82E3FE7",
+      "person_id": "Q16037823",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3186040-9D23C7B1-2C36-45B8-B45D-69F0396103E5",
+      "person_id": "Q3186040",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3186049-FB4D07D7-8D34-4226-BF0D-839D11524B22",
+      "person_id": "Q3186049",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6290725-0BC91F1A-82DE-46E6-9BA7-BD066AF6D2DB",
+      "person_id": "Q6290725",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3186643-83DE75E1-BCAC-46CC-9BE0-A3C71F04AA07",
+      "person_id": "Q3186643",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6297475-9112A32F-3D3A-4F2C-A500-CDF7A2C6FA7C",
+      "person_id": "Q6297475",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3188008-4560C1D9-0864-4669-B485-4DB2AFEC6E4C",
+      "person_id": "Q3188008",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6306042-EC84FB93-62C5-41CD-8F5F-C3D0F017A85F",
+      "person_id": "Q6306042",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3188383-141E9A3B-1FD4-4F3A-A7CA-81571A0B086C",
+      "person_id": "Q3188383",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6384252-E431041B-83D6-4A1A-82B4-D3A3D3D3E5FB",
+      "person_id": "Q6384252",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6386718-285FD346-6001-41BE-BE93-BED88C7DB6CC",
+      "person_id": "Q6386718",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3195156-31AFFE69-0533-4BAD-A23C-BA39867D993C",
+      "person_id": "Q3195156",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6468479-CF40F5D2-D978-44BD-BED1-E24E6F07830D",
+      "person_id": "Q6468479",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q14949609-CF99A362-375C-4B32-9C63-82F2561B518D",
+      "person_id": "Q14949609",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1680169-AFCC5F12-0E8B-406D-B5F7-38943D051D63",
+      "person_id": "Q1680169",
+      "start_date": "2005-08-02",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3218104-7B76BDB0-24A0-4EA1-9C34-9E569B689FA9",
+      "person_id": "Q3218104",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3218980-02682A52-B216-484E-B2C3-4F6D605E087C",
+      "person_id": "Q3218980",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1477331-3E55B272-7111-493F-AB01-89D3A5AAEF01",
+      "person_id": "Q1477331",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3219880-C2C88850-4897-4EEB-B0FD-FD1B8227F5E0",
+      "person_id": "Q3219880",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3219894-D2EE9155-EC64-47CE-B1F3-876E61101203",
+      "person_id": "Q3219894",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6505918-F08FC237-E4A9-44F4-A235-C1EDC3A8BC9E",
+      "person_id": "Q6505918",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6522351-0D4C29E6-498E-46AE-AB0B-9B1FA850CE5A",
+      "person_id": "Q6522351",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3229567-4B6A8741-48E0-497F-BF8E-607370C58A62",
+      "person_id": "Q3229567",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6525333-00FEA521-C119-4337-9F7D-54BA22EC1EF1",
+      "person_id": "Q6525333",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1340024-3E0D3447-4CEF-4B09-BDE9-E33E71D82BB4",
+      "person_id": "Q1340024",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6535289-7EF5F818-0667-4F91-9115-A537912E4D47",
+      "person_id": "Q6535289",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2402200-323E00B6-D3F5-43C2-AB3B-A7313664FCB5",
+      "person_id": "Q2402200",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6551575-D99A88B8-80F7-46BF-BEFB-0451FD5BFA16",
+      "person_id": "Q6551575",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6555576-D76D5E40-D652-4EDA-9F71-F6017A078135",
+      "person_id": "Q6555576",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3242479-48F6ED34-9125-492E-9694-2335A1CD2976",
+      "person_id": "Q3242479",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6681372-08E7767C-1FF0-4FE1-B17C-5B3E47B6A88E",
+      "person_id": "Q6681372",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6681380-836CF954-F6D0-444F-A21E-52E16FD2A3EE",
+      "person_id": "Q6681380",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6681430-177598CE-637C-4700-8E78-A6D66A3E7063",
+      "person_id": "Q6681430",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6681433-A5339D1F-4D1D-4FDC-A0C2-78D278750E82",
+      "person_id": "Q6681433",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6686689-AB0CDD3E-3596-4C05-A639-3F2AD57D4081",
+      "person_id": "Q6686689",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3261635-F7F95E83-6722-443F-BBDC-B57A18CC7002",
+      "person_id": "Q3261635",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6687248-8AFF4D22-05AA-4969-98AF-6A41E7BDF6B0",
+      "person_id": "Q6687248",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6687608-4B48FCD8-025A-4AEF-9DD2-0E0C7DF27CCF",
+      "person_id": "Q6687608",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3262451-E45C5CB7-D6A0-4D2D-9C09-BDD799F297E8",
+      "person_id": "Q3262451",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6687937-6739BDAE-552D-4C74-AC5E-BE5074C935A3",
+      "person_id": "Q6687937",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6688042-354B2F52-694B-4AE1-9239-897BE80F3020",
+      "person_id": "Q6688042",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6688078-A8D4003D-BE7F-4F82-8B67-A9DEDAA59715",
+      "person_id": "Q6688078",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3260638-352BE50A-5972-4A59-8A52-E8D3985BF629",
+      "person_id": "Q3260638",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6686506-1CDC48FF-0AC8-4180-9094-D2851DA0230A",
+      "person_id": "Q6686506",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6686509-2F58E8A8-3940-4B92-8536-B2B8BB5871CD",
+      "person_id": "Q6686509",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1552865-A1C7D8C1-048D-4DBF-A76A-64F66196ECFF",
+      "person_id": "Q1552865",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6693244-10E15164-DB8D-484A-91BA-C0EA1ECD4755",
+      "person_id": "Q6693244",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q730078-211D3647-258C-4767-8405-40DC329B2F14",
+      "person_id": "Q730078",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3265644-F982156E-E167-40D4-8530-9540393C9425",
+      "person_id": "Q3265644",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6708063-EBB54BE3-DA38-460B-BA79-3386BB8DC7B4",
+      "person_id": "Q6708063",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6708935-7F65FD69-726C-4194-B56D-14C044FC5F12",
+      "person_id": "Q6708935",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16043618-A4294A8F-FFF5-406E-8EB0-DC9B808579E2",
+      "person_id": "Q16043618",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6710943-80047D0E-82D8-4C96-A172-7AAC09063F83",
+      "person_id": "Q6710943",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3270638-0259A4D3-C44E-47DF-B24A-757873F1AA61",
+      "person_id": "Q3270638",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6711102-AAC2E5EB-6BED-4108-95CF-9F8594FB3EE4",
+      "person_id": "Q6711102",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3271472-12853983-31F8-431B-BB42-7C56C07BBF97",
+      "person_id": "Q3271472",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6711142-F916F01F-17AC-4133-BB27-EF679CE898A6",
+      "person_id": "Q6711142",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q668183-02BF0B21-F59F-4234-9012-2F79A52D77F4",
+      "person_id": "Q668183",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6721428-F2BC38F4-C695-466C-85EB-4F2433C589ED",
+      "person_id": "Q6721428",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6722293-0C830CD0-C64B-4EED-A486-69C465B8D61A",
+      "person_id": "Q6722293",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q128677-FB5876B6-2DA0-4B7E-96A4-036CE4FE8093",
+      "person_id": "Q128677",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3275714-A87AEEF3-FC5B-480C-8203-709D37957451",
+      "person_id": "Q3275714",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6742508-28232870-BB90-4944-B4A7-CF4034D462B8",
+      "person_id": "Q6742508",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6742694-518C7D26-EFA5-4A44-8E43-7293CF3854DF",
+      "person_id": "Q6742694",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3289316-02AAB0CD-E8C9-4FDF-AAE0-8EEBF2A30D3D",
+      "person_id": "Q3289316",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3290495-33A9C1F6-52F1-41BA-B64B-4CE8169903CC",
+      "person_id": "Q3290495",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6759777-C63C99D6-F493-4905-A576-80B132E55CCD",
+      "person_id": "Q6759777",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6761089-FB8C69F3-8B79-4BF4-A886-47A9D54D25CF",
+      "person_id": "Q6761089",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6761933-572A2183-A5DD-4C7E-B8BE-D7E8B7A6F031",
+      "person_id": "Q6761933",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6762160-1EE02134-2A8C-4835-92CA-EC74BB291C5D",
+      "person_id": "Q6762160",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6762792-5924717A-CA9A-4844-ABCF-E34BB51444AE",
+      "person_id": "Q6762792",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q27680092-d37a7831-4f98-7e21-1c5b-59f408cbb5b8",
+      "person_id": "Q27680092",
+      "start_date": "2016-11-25",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3293093-F0A9EC1A-AB01-4948-88AA-C52F7FE5A9A5",
+      "person_id": "Q3293093",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6764557-7FBADE06-0D49-4E15-A179-2DA52613A4F9",
+      "person_id": "Q6764557",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3293707-E24A9E5C-0FA6-408A-9911-C77BE571F61B",
+      "person_id": "Q3293707",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3293962-B94E6F2D-E6C6-4D3E-AFBD-0990FF5A7940",
+      "person_id": "Q3293962",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3294220-175D840D-39FB-4422-BD09-CFF2CC7863C1",
+      "person_id": "Q3294220",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6774341-4DDACF1B-0F68-4BF2-9169-7D89E48848E9",
+      "person_id": "Q6774341",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1903142-C738FD47-3B72-4C98-B113-93F0680D6C2C",
+      "person_id": "Q1903142",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16012638-32177244-85E4-4681-92E5-20F6CDAF991E",
+      "person_id": "Q16012638",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15458623-7EA1C40F-F274-4771-8C22-767DC7BAD59D",
+      "person_id": "Q15458623",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q956096-4967BF55-63C7-4444-984B-8BC6F5169D0F",
+      "person_id": "Q956096",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1911361-AFCD0CE6-3D4B-4A08-9CD1-0F7F3D9DC56E",
+      "person_id": "Q1911361",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3301338-E8C05FCC-C84C-41D2-813B-70D93BCA0514",
+      "person_id": "Q3301338",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3305314-B5ADDF37-BE22-4E64-B3AD-AFA32074D480",
+      "person_id": "Q3305314",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3307982-01DBF02C-E53C-45BA-B874-145446EFC39B",
+      "person_id": "Q3307982",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6828479-4582114A-347C-4A6C-AA34-114AE2CCB26F",
+      "person_id": "Q6828479",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6830367-4DCB58E9-18D7-4D96-9BC5-FC0B11A44001",
+      "person_id": "Q6830367",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15516040-F03DE1F5-6B70-4CE9-9D85-2B6650165211",
+      "person_id": "Q15516040",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q13648747-9E3E7FF3-0112-4AAB-B317-9FB3C395BCDE",
+      "person_id": "Q13648747",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6832030-31F6C2D6-C9E9-4FEE-BD4D-CA6DFCF036E8",
+      "person_id": "Q6832030",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6832793-8C59D413-8D1C-4FC5-961B-605765C29D45",
+      "person_id": "Q6832793",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6833553-EDA59D80-4303-48F3-A01F-1C07564E2005",
+      "person_id": "Q6833553",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6834690-9885001B-E2E0-475D-BDE3-BFD8FE9F325C",
+      "person_id": "Q6834690",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3309023-4C38316D-6D88-4BC9-9E8C-9102A46235D6",
+      "person_id": "Q3309023",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6836342-588D4D7A-ED2C-496A-B47C-BF1CC4F685FB",
+      "person_id": "Q6836342",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3310714-8F6E6DFF-18C2-4D6E-A5BB-64F1F639022B",
+      "person_id": "Q3310714",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3313285-902BA4DC-0922-4459-9E34-346E43E842E4",
+      "person_id": "Q3313285",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6848778-7CF354CC-DB42-45C5-9FE7-602591C37F22",
+      "person_id": "Q6848778",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4356984-DB9ECD24-99CB-4741-BE5F-8631E2A1E5F4",
+      "person_id": "Q4356984",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6887337-928BDA78-B576-4672-99C2-E84C0F341E37",
+      "person_id": "Q6887337",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3328122-848ADE0C-346C-4EE7-9610-258DF2316A88",
+      "person_id": "Q3328122",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6962556-33DB7097-C2C9-475B-9C39-842864C43C26",
+      "person_id": "Q6962556",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q238041-2F2B355D-A8C5-4E9C-B227-FD50837A5B7B",
+      "person_id": "Q238041",
+      "start_date": "2009-01-02",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16006583-039FF3FF-9DAD-465C-9D44-DC29FF9CDC0A",
+      "person_id": "Q16006583",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1964518-13C11F64-65CA-4FA5-9A84-34BE7F7C16AC",
+      "person_id": "Q1964518",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3335609-3017882F-A7C5-4E4F-ACFC-FF50F7B1BC4D",
+      "person_id": "Q3335609",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3335925-FCD1643E-4CDF-4F06-829F-4F307179D104",
+      "person_id": "Q3335925",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3335957-0108371A-6836-435B-B2EA-FBB027F33208",
+      "person_id": "Q3335957",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q505938-FF950898-584C-4B9C-92B2-1CA83416F15B",
+      "person_id": "Q505938",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6969265-F9CFF780-B89A-483A-9C08-086169C154A4",
+      "person_id": "Q6969265",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6969560-2C08CB6F-667D-4005-8B4A-38D7A08DE915",
+      "person_id": "Q6969560",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6990708-F82B0FB5-B0C6-4FA9-AA33-0746CD232C4C",
+      "person_id": "Q6990708",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7026295-BA15FA49-FA82-4F72-A90A-0CCCD7F4E46E",
+      "person_id": "Q7026295",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7027927-B49A8947-611F-411B-8B3A-E3ACAE18CDA4",
+      "person_id": "Q7027927",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7030042-1BE7CEFF-2327-4096-8D49-35C4925D9879",
+      "person_id": "Q7030042",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3343524-45990EF5-9D2E-4BFB-B8C1-57DA821CF2F2",
+      "person_id": "Q3343524",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3343768-4D0127E4-5938-4957-9E67-EA9E4598BDDD",
+      "person_id": "Q3343768",
+      "start_date": "2012-01-06",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7052537-7439DD26-64BE-4B0F-B706-0826A7A42E59",
+      "person_id": "Q7052537",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7052605-7284316E-7865-4B5F-BECA-DAF8CABFAC00",
+      "person_id": "Q7052605",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q14949580-D963E974-1B41-433F-9D4B-B800E6BE7D32",
+      "person_id": "Q14949580",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3736138-B0E3ED8C-AE41-4683-8B5B-76D839829317",
+      "person_id": "Q3736138",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7067444-35F8B3FB-2C6D-4637-82C3-AA1F35CBBBF1",
+      "person_id": "Q7067444",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3345838-DD01937C-2398-4890-9B21-E9E913BF2DCD",
+      "person_id": "Q3345838",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7087172-3BF8DEFD-941D-4EE2-9ABF-BA2B1B5C1D83",
+      "person_id": "Q7087172",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7087410-114D8941-8C33-4A87-BA4F-9BBA8C7DE337",
+      "person_id": "Q7087410",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1387837-CB02D81F-D54F-4D33-BA2C-9195943956D2",
+      "person_id": "Q1387837",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3352980-9F5291BE-6F81-4679-8269-D9A32571F9DB",
+      "person_id": "Q3352980",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7105235-9379367D-41E6-4B1B-B495-7522F3885346",
+      "person_id": "Q7105235",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3361787-8C047E4B-4AE5-44E7-B83E-C9BC591DB830",
+      "person_id": "Q3361787",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3361816-027BBDA2-C4CF-45EF-B903-326C2C26BF96",
+      "person_id": "Q3361816",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3367566-D4F4695D-C6BD-449B-A018-BE37054FBAB3",
+      "person_id": "Q3367566",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3369280-E9797917-FE0E-41A3-9D40-85FA0F5686A9",
+      "person_id": "Q3369280",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7146177-E25851D0-FDFC-40A6-BC03-EC7EC5160F46",
+      "person_id": "Q7146177",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16031100-B6E1957D-7EED-4D11-81A1-74B3697A30D5",
+      "person_id": "Q16031100",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3370985-40B05C48-AA3A-40B8-BFC5-04853127AC5A",
+      "person_id": "Q3370985",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16009957-AA87E6BB-F9C7-49BA-A6FE-CBABE7F71D8F",
+      "person_id": "Q16009957",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7151182-F97C22A5-A5B4-444C-B681-801194C62848",
+      "person_id": "Q7151182",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7151244-718E80F2-679A-49EC-B8C5-A56013BA0632",
+      "person_id": "Q7151244",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16012107-D6B2E1D7-55AA-4DBE-BDFE-425A5DA570D1",
+      "person_id": "Q16012107",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3371726-424339C9-B5AC-4FEB-A8F3-402CA220574F",
+      "person_id": "Q3371726",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q386676-966AAA02-39AA-43EB-9095-336B3F451B12",
+      "person_id": "Q386676",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q14942774-98CDF2B8-D08E-42D3-B59C-0CE31AACA890",
+      "person_id": "Q14942774",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7154527-1DB2594E-E827-41F7-B719-D344FBB398F3",
+      "person_id": "Q7154527",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2067379-5E383541-B61B-4DEE-AC6A-B45DF08A9E24",
+      "person_id": "Q2067379",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3375189-3DBEA0C6-D0CF-468B-9CC8-C38CA4BFF5B3",
+      "person_id": "Q3375189",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3375214-BE9116E7-458C-44CE-87D8-6E1CD7219960",
+      "person_id": "Q3375214",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7172893-4084AC86-25C4-41C1-9467-CC020BCA15D0",
+      "person_id": "Q7172893",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7175805-8633FC41-E15D-44DF-B07A-6006989B6344",
+      "person_id": "Q7175805",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7175831-1409C464-18CD-4AAC-93DF-0883EF5FD69E",
+      "person_id": "Q7175831",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3376900-DDE578CA-1A73-4710-91FB-596F26AEB21F",
+      "person_id": "Q3376900",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7177244-CC7042B7-362D-472C-B09F-8A7782FDFE9F",
+      "person_id": "Q7177244",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16089950-2717B0B3-4CA2-403F-B25B-82D8CD693BA0",
+      "person_id": "Q16089950",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6591377-1E405F3B-50CE-4ED5-8C9F-FE13A57BF846",
+      "person_id": "Q6591377",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q137208-272548B6-714B-4F23-9E36-E6A4006297D0",
+      "person_id": "Q137208",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3379137-A2624097-4C7E-4AA7-8899-B2F1000FEAD3",
+      "person_id": "Q3379137",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7184754-49976E0B-1843-4047-98E6-5AA5C25D69F9",
+      "person_id": "Q7184754",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7192049-56B91204-0014-449B-A187-665898502B36",
+      "person_id": "Q7192049",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7192062-824D9FF6-2CFD-43C3-BC7A-E48AEA1B92B8",
+      "person_id": "Q7192062",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3384455-822B3577-852D-4C8E-BFFE-1E87BFD8643D",
+      "person_id": "Q3384455",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2094001-F7FD4789-91AF-4A8F-B8B9-9964B8049BB6",
+      "person_id": "Q2094001",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q951515-ABBF9E35-3D63-47E7-8CA2-FF67DD68A0D6",
+      "person_id": "Q951515",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3383128-F6FD617D-E542-4149-A013-8507FEC1E019",
+      "person_id": "Q3383128",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3385044-12DEE974-CCB5-4B16-8EFD-921694BDE1B5",
+      "person_id": "Q3385044",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q581686-5828304F-F1E6-47F1-90C8-60468DF18E04",
+      "person_id": "Q581686",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3388171-AC7811C5-C561-4D69-815B-01D3B2B3F22D",
+      "person_id": "Q3388171",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7250862-300C2A99-2267-4B57-92A1-A2D99C49A221",
+      "person_id": "Q7250862",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7287648-AC1DAE4D-85FB-4F66-A459-4DF9B4E1C43F",
+      "person_id": "Q7287648",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3419153-4A5F034C-BDD2-4A80-9CCF-4152F41D3620",
+      "person_id": "Q3419153",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7293745-3E4040D6-DC43-4557-B278-BC1070148A1D",
+      "person_id": "Q7293745",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2134231-AC9562E3-DB84-481F-BD1F-BC64283FD1FF",
+      "person_id": "Q2134231",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7297947-3BAFCEB3-3101-4348-8406-C164F8D4C4EE",
+      "person_id": "Q7297947",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3420843-16E59F41-76C6-4485-814B-1EA89F9AB4EB",
+      "person_id": "Q3420843",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3420985-38678806-7BE3-48ED-BEA4-B6E9C52BBEEC",
+      "person_id": "Q3420985",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7299144-009E7E32-0107-4B59-844D-B2F1448893AE",
+      "person_id": "Q7299144",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7299155-050AFC4D-0FE0-4DF7-87DB-04FD380F6885",
+      "person_id": "Q7299155",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7299317-0630AC7B-1144-462B-BE46-874786CAC088",
+      "person_id": "Q7299317",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3425001-3C858BB9-796E-44BC-B944-3CF3AFB1D9A5",
+      "person_id": "Q3425001",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3429915-AA8CF444-BD95-4C3C-8C0C-88069CD60492",
+      "person_id": "Q3429915",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7324198-CA610E03-9D65-4E35-A4A4-7FD18A27B423",
+      "person_id": "Q7324198",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7325238-FACF5D8F-8A53-4951-B388-2545466663EC",
+      "person_id": "Q7325238",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7325271-B79B856F-C896-4FEA-B26D-7D60D5FD4F59",
+      "person_id": "Q7325271",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7326265-FFDB1906-96D3-4CF4-B5B0-AEE631AB1988",
+      "person_id": "Q7326265",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7326872-BE12CF23-E9D5-4C0D-87BA-6E95092D3CE3",
+      "person_id": "Q7326872",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7327146-35ED34C0-A2A5-42CA-96A2-2130102E39F2",
+      "person_id": "Q7327146",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7328032-F1C1D554-9EA7-4F7A-98F9-3B8C17F637D1",
+      "person_id": "Q7328032",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7329099-0E313A17-60AA-42FA-91A4-BBE5212BC448",
+      "person_id": "Q7329099",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7329207-F292BEF2-D462-4BF5-BCC5-C11A0E7B7D55",
+      "person_id": "Q7329207",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7329994-67C8457F-F193-441C-89AA-675C03704583",
+      "person_id": "Q7329994",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7341433-975A7BA7-95E1-4808-8028-DD943EF1B157",
+      "person_id": "Q7341433",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7341994-E96946EE-3046-4F60-98A4-3B5BF0142F33",
+      "person_id": "Q7341994",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1542244-FAB8D807-E244-4F02-B132-BA74F238CB63",
+      "person_id": "Q1542244",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7344433-13CE65F4-E2D8-42EC-89A0-F1E9EE6649F3",
+      "person_id": "Q7344433",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7344480-2B707267-EEBF-4A3F-9C32-EB95402527B9",
+      "person_id": "Q7344480",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7344797-6152F2FF-99DE-4613-BE6E-6ADDD1CFF93E",
+      "person_id": "Q7344797",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7345345-6BD40E38-99EF-4986-9E51-A7F094D0BCCA",
+      "person_id": "Q7345345",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7346024-EDE42325-6322-44EB-8703-B604E9873ABC",
+      "person_id": "Q7346024",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3435739-2AC10F68-8A1F-45C0-8A98-E56895EEF7CA",
+      "person_id": "Q3435739",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q511064-BB5B3ADA-6747-4A72-9B21-9DD016CF4E23",
+      "person_id": "Q511064",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7347862-C2245D42-C193-4BF2-AFA5-36B3FE79C5A5",
+      "person_id": "Q7347862",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7348857-EAC67931-FC44-4962-BD92-DB924592FEFC",
+      "person_id": "Q7348857",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7351112-309B8C30-37A9-4596-8446-74CB4E051AFD",
+      "person_id": "Q7351112",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3436630-51B5F43F-FCFA-4DCB-A221-2100DCA2DBE0",
+      "person_id": "Q3436630",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q763511-C95680FD-2F72-4510-A470-E7A25A8923FE",
+      "person_id": "Q763511",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7356418-CC2D803C-C30B-4B5A-8577-C2AC2E8DC20F",
+      "person_id": "Q7356418",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7356648-1637B2BC-EDFB-4275-B0BE-9011D04439A8",
+      "person_id": "Q7356648",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3438341-A9F12ABA-ADA4-46B0-8358-0AB2FD261FF2",
+      "person_id": "Q3438341",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3441274-377BDB28-1286-4242-A455-9CF12DC6C2D4",
+      "person_id": "Q3441274",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q927934-C8665A35-45DB-4DF2-8422-8202614CFACD",
+      "person_id": "Q927934",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7363717-EDF11F03-D252-41B2-AB66-03B0FC6E197F",
+      "person_id": "Q7363717",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7363823-8405B823-81A9-46B8-B8C4-FDA4A9F36DEF",
+      "person_id": "Q7363823",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3442339-565B0EB0-CF48-444F-BF17-765E32E38A5A",
+      "person_id": "Q3442339",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3442344-5FDD5096-45EB-4917-BF4B-A927350E1551",
+      "person_id": "Q3442344",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7369331-77C6466A-FFC4-49C9-8779-3F2CD9CD329E",
+      "person_id": "Q7369331",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7375163-C43EB9B7-E41F-4637-875F-EFB2FE82AA69",
+      "person_id": "Q7375163",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7378021-B85E0DB2-B6AD-444E-99DD-B4CCB6039FCF",
+      "person_id": "Q7378021",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3452797-93E35422-2ADF-47C7-893F-8D39597280AD",
+      "person_id": "Q3452797",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7380274-CBA02F48-EFE9-4913-8009-5C337F222ACB",
+      "person_id": "Q7380274",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7405355-E0B7B958-F601-4141-9BA7-E0902BB6A4C5",
+      "person_id": "Q7405355",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7406078-2837CD97-127A-442E-A898-2E7A6862D982",
+      "person_id": "Q7406078",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7412171-9F4638A0-0861-4D80-A31A-520B576CBCF1",
+      "person_id": "Q7412171",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7412425-5B5B2C1C-9A61-47B2-88CF-CC1E23CBF40A",
+      "person_id": "Q7412425",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7412729-39C7FD3F-DFC1-49B1-B61A-078EEA6CA53A",
+      "person_id": "Q7412729",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3471928-6E6C06F5-BFBA-429C-B977-19C7B2780CC7",
+      "person_id": "Q3471928",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7417634-E446516D-A00C-4EDE-B916-E60B610A2E70",
+      "person_id": "Q7417634",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7437348-608751A5-130F-4203-ADF8-EE3A7E0D1499",
+      "person_id": "Q7437348",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2272463-843231CA-BEB9-4A80-BF53-62F2B187384A",
+      "person_id": "Q2272463",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3481750-8A718B5C-8394-45DD-B660-6323F9E88C1F",
+      "person_id": "Q3481750",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3482358-C4511CF5-D647-4136-852E-371315E9CFEF",
+      "person_id": "Q3482358",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7508977-0F7732EB-38BD-4CC8-98F0-470D98EF4189",
+      "person_id": "Q7508977",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3489133-173DE9A5-D57F-460D-820D-3DC8EA32C0A3",
+      "person_id": "Q3489133",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7596548-92B98739-12C0-4896-BBCD-B5855A7FADB0",
+      "person_id": "Q7596548",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q525528-6DC5584E-AC64-48DA-A12F-482959ECD0EE",
+      "person_id": "Q525528",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7599784-CB90764B-3F21-4C8C-90FA-334F3E503A5A",
+      "person_id": "Q7599784",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1613118-522CD29A-A6B1-48D3-B580-3FAB8830BA2A",
+      "person_id": "Q1613118",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7609352-195ECA0F-EDBF-421A-A2C4-56570A2827A0",
+      "person_id": "Q7609352",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3505956-FFD53878-EAA6-4537-A724-96C83E6F282D",
+      "person_id": "Q3505956",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3506833-2C7B1350-3B03-4AE4-94EE-D745941DB4A0",
+      "person_id": "Q3506833",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3517040-CDD8ECC4-3482-4DF8-B778-0B98ACFC13E8",
+      "person_id": "Q3517040",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7704796-301915AC-51EE-4E4E-B796-DCE58B78D107",
+      "person_id": "Q7704796",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16104992-E5140587-F2FD-4D83-9AD9-331FFACD01B3",
+      "person_id": "Q16104992",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7710334-F62BDC30-FB24-4DEE-996F-92BFACD9A2A3",
+      "person_id": "Q7710334",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3523526-18635B61-CF22-46B5-9308-19E7E0A58A32",
+      "person_id": "Q3523526",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7788212-0879326F-FA3C-432E-B9EB-E1DA3F5AEE8E",
+      "person_id": "Q7788212",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3524986-67C22CFB-2EC0-4F9F-8FD3-4AFF98F97E11",
+      "person_id": "Q3524986",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7788505-1690160C-395F-40C3-95ED-7C16BC9D07C3",
+      "person_id": "Q7788505",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1368799-22FDFC7F-1641-46BF-B01E-21A1900BEDE8",
+      "person_id": "Q1368799",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7788772-C2E3AB61-3F83-4D77-9B92-A4490EA8A700",
+      "person_id": "Q7788772",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7788976-1DD28101-0E9D-4D0E-AF21-8DE727B05459",
+      "person_id": "Q7788976",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7789530-2A26801F-DDE4-45E0-BCDD-C7D84B0E9B7B",
+      "person_id": "Q7789530",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2662141-B6263B00-3253-44A9-BE9D-430D74F30A74",
+      "person_id": "Q2662141",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7791402-74658C0F-4D7B-4DD3-80B6-825C70F2FDDA",
+      "person_id": "Q7791402",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3525337-ACA0219D-6B08-4F8C-84E7-EA120E7BED0C",
+      "person_id": "Q3525337",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7792319-C85CC3C5-6D86-46AD-9AA4-84FB5930218A",
+      "person_id": "Q7792319",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q663451-EAFBB29F-B18D-4BE2-BB37-CAC5E128365C",
+      "person_id": "Q663451",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7792898-159E4F88-BE53-446D-AB47-099F2A40F1AC",
+      "person_id": "Q7792898",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7793462-B69546E3-F780-4830-AFF3-FA80E6A5E53E",
+      "person_id": "Q7793462",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2404028-39FB6B93-95AC-4AD1-A2CB-428C954B85D3",
+      "person_id": "Q2404028",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1600518-E6AB9E75-58B1-41C3-86FD-35D0F64B0E50",
+      "person_id": "Q1600518",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7793982-B9B3B04A-4F93-43E2-9F5C-288C3B5763B6",
+      "person_id": "Q7793982",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3525610-64673373-9711-4BCF-AD14-BA31AD2D0FCF",
+      "person_id": "Q3525610",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3525631-A706E31F-15C5-4ADF-BD2B-1D446A1C2BAC",
+      "person_id": "Q3525631",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7794708-31E1F3DE-0C54-43AF-9F6D-5E74C3816BAC",
+      "person_id": "Q7794708",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7795229-6662B024-46E3-481F-98E1-FF516BB4465A",
+      "person_id": "Q7795229",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7786799-A97F6E7D-A935-4880-A2E6-9022250696BC",
+      "person_id": "Q7786799",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3525246-3A94A90D-09F9-496B-8DB5-4DD926E82EAF",
+      "person_id": "Q3525246",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q505998-75A68D2D-37BB-4964-A711-DE238F1B8CBE",
+      "person_id": "Q505998",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q526198-993409FB-4D89-455F-8702-A5A9271C6BAE",
+      "person_id": "Q526198",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3527356-D1E204D8-0596-40AF-9D09-3EB45113F388",
+      "person_id": "Q3527356",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16186656-8F9B12E1-E9C7-40BA-B33A-501CD512B7DD",
+      "person_id": "Q16186656",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7816827-18838AA7-B41F-46F5-8E76-B24AC2830ABA",
+      "person_id": "Q7816827",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3531303-7469BAF4-5948-44EE-ADCF-DB31F1A43B14",
+      "person_id": "Q3531303",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7839140-ACDAE694-C4FD-4C6F-8460-E76FAA1B5AC2",
+      "person_id": "Q7839140",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7879768-92A5810A-564A-46A1-90C2-2A1C5BFB0F72",
+      "person_id": "Q7879768",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7911002-FCC9FEEA-3C36-4020-B2EE-0951E9A69796",
+      "person_id": "Q7911002",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7922281-362B4DED-61D5-426A-B7D9-EBB9BDF72248",
+      "person_id": "Q7922281",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7926201-C4C50107-FB82-48A5-8194-8C9419699045",
+      "person_id": "Q7926201",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3559332-FD4AD13F-406E-4CE1-837F-6DBBEBF85B0D",
+      "person_id": "Q3559332",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7931700-C383EABF-745B-469F-B3A6-0D97409B1119",
+      "person_id": "Q7931700",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3559609-D3C88DC0-B1BC-4A6F-A34A-BEA406A625EA",
+      "person_id": "Q3559609",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3560355-E350B917-4F1A-4C72-A4D4-1DE930276F82",
+      "person_id": "Q3560355",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3017386-25157EC6-B10F-48CC-BA37-1FB1FE33A61D",
+      "person_id": "Q3017386",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7964179-041E8037-1E29-4C63-B9DF-52F17013AE25",
+      "person_id": "Q7964179",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7965067-5C322C98-EF66-4BEF-8BFF-054B0970A9D4",
+      "person_id": "Q7965067",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7965594-5FDAFCB9-D4A5-479A-B09C-87A4943DF4AF",
+      "person_id": "Q7965594",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7965795-4D4703CA-5D40-4521-B3C7-82CC18CB0FB8",
+      "person_id": "Q7965795",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7974839-29D2D5A6-0C17-41A2-AB1B-AC10DB39D2D1",
+      "person_id": "Q7974839",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7981543-6B080A8E-7759-4D8C-9731-85B1EC5E685A",
+      "person_id": "Q7981543",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7984006-31DE6EED-D2C5-40ED-9DC5-2417740D1B7C",
+      "person_id": "Q7984006",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3568086-A523909D-CA7C-4A74-AE3A-5D688C9B4BB5",
+      "person_id": "Q3568086",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8001848-8A0D0DBC-CDBF-40E0-9DBB-B79BADD568EB",
+      "person_id": "Q8001848",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8001956-FC9FEBA6-D6B2-4884-829E-9050D2DE719D",
+      "person_id": "Q8001956",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8004222-BC7E9172-C923-4B4A-8083-8421BB0B7EE9",
+      "person_id": "Q8004222",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16000254-26233001-0C27-4B4C-8B62-01C04D2016B6",
+      "person_id": "Q16000254",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8004499-44BF43B6-B5BF-481B-908C-3D3F0E554E32",
+      "person_id": "Q8004499",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15980340-1E06AAC2-DB74-42F5-96CD-8522B5CB77E5",
+      "person_id": "Q15980340",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8005391-3F1DC0F6-5301-48A7-87E2-C8000DC9D677",
+      "person_id": "Q8005391",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8006067-758ECBC4-9AD6-4003-899E-062859AF7076",
+      "person_id": "Q8006067",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8006484-B6033B68-5F2D-48B8-A999-F268B384DF5A",
+      "person_id": "Q8006484",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8007230-25AEDF90-2930-4063-B695-F6A8392D76D9",
+      "person_id": "Q8007230",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8007599-E21A4B9D-83DC-4993-861C-035134838F00",
+      "person_id": "Q8007599",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8007747-4756EED9-5A2C-4617-8742-94E0F958C6EF",
+      "person_id": "Q8007747",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8007766-4ECA5D6D-48B4-41FA-9135-DE69500EDE2C",
+      "person_id": "Q8007766",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q669438-C48EC6E5-79F5-4B53-B297-903D9CF72739",
+      "person_id": "Q669438",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8008522-CE48AF5C-84AB-47C4-80FC-3FBBF8E5BB79",
+      "person_id": "Q8008522",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8009856-4D4A910E-8703-41F5-9758-B1FB99D8FB86",
+      "person_id": "Q8009856",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3568677-8BB01934-C224-4DFB-8298-1F178853C4FA",
+      "person_id": "Q3568677",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8010887-BFBA8EB1-326B-4EA0-851B-8FEE1E6ABE8D",
+      "person_id": "Q8010887",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8011914-7D994070-B3D4-406B-94D3-ADA648D32E56",
+      "person_id": "Q8011914",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8011922-FFC150E0-E299-4619-96BD-24043887158E",
+      "person_id": "Q8011922",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8011958-560F3CFF-4E95-48B1-B285-C3DABB3DD06D",
+      "person_id": "Q8011958",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8012005-00286E31-0430-4ACF-A0E2-3868CCDDD51A",
+      "person_id": "Q8012005",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q14949594-2F8D5356-66A8-431E-BB45-6D718850EB10",
+      "person_id": "Q14949594",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8012150-58E0284D-7B72-4CC5-A820-0223920CD461",
+      "person_id": "Q8012150",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8012188-0B4ACA72-66F2-4D92-B8F2-05D0D589A2C9",
+      "person_id": "Q8012188",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8012506-94BF2330-ADBA-4481-B720-6C4DE9A4D045",
+      "person_id": "Q8012506",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8012672-5B0766EB-9378-46CB-B1B5-69967F69DBC8",
+      "person_id": "Q8012672",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3568718-40B4B3C1-6285-4A36-B03C-F2AABDCC0578",
+      "person_id": "Q3568718",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3568735-37B192B3-B430-4654-A8FC-F2C64AC91F98",
+      "person_id": "Q3568735",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8013646-FA6F9238-C140-4FB1-BAF2-61FFDA336645",
+      "person_id": "Q8013646",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8013968-4940023A-C1F3-4F58-8DE1-BD561F1FE7D2",
+      "person_id": "Q8013968",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8015377-867CDB27-18C2-4F73-AE58-CCB0C41B1EEC",
+      "person_id": "Q8015377",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8015383-3A8FABB6-5BBC-4FE4-8740-60D37DDE158C",
+      "person_id": "Q8015383",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8015443-59926A5F-23A1-4165-82A5-5ADD7264E3E1",
+      "person_id": "Q8015443",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8015495-9C4AEF36-80E3-4B66-AAAE-A6F939BF27AB",
+      "person_id": "Q8015495",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8015610-A3FD4BE6-A614-4071-A2D4-55AE0985D327",
+      "person_id": "Q8015610",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8015780-460BC84F-2140-4109-B115-3626A835B0CB",
+      "person_id": "Q8015780",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8015908-49B05C90-EF96-475B-9876-61D71BA48AC7",
+      "person_id": "Q8015908",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3568861-FE770DEB-BE3B-4BD7-B717-0F72378D1C83",
+      "person_id": "Q3568861",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8016837-3622004E-DA22-4130-A83B-2432B5E0E073",
+      "person_id": "Q8016837",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8017113-9B1300FC-7D98-4BAB-BDFD-0509E23A576E",
+      "person_id": "Q8017113",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8017774-03D64CA8-9A16-4DE7-91C5-13CB14121266",
+      "person_id": "Q8017774",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q977705-F4F8FEF0-9C41-4F66-9C1C-E80157918108",
+      "person_id": "Q977705",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8019245-32F35255-59DD-4F40-851F-E328C822F3A1",
+      "person_id": "Q8019245",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2581417-CDA9D091-6D12-405E-8C03-18643E2921BC",
+      "person_id": "Q2581417",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3569454-73E535EB-88C3-4832-812A-2B946B7DFBDA",
+      "person_id": "Q3569454",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q14916052-E16EC079-0B4B-47DD-86E7-A7E6DCF9D215",
+      "person_id": "Q14916052",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8054885-A3601D82-123C-431A-B6E0-C31CCC0700D3",
+      "person_id": "Q8054885",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3573867-2DD13A8E-9E4F-4A12-9297-8094B009B740",
+      "person_id": "Q3573867",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8062358-5B50CBFE-2796-4993-BA8B-AEF2F79A08EA",
+      "person_id": "Q8062358",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3579696-152AAB8C-C0FC-4990-87CD-4D341089E161",
+      "person_id": "Q3579696",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8078091-248A1F54-129F-485B-BED4-FC33EF2FFF38",
+      "person_id": "Q8078091",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3587718-676DCAF3-B989-444C-A20D-4EEFE5AE68C0",
+      "person_id": "Q3587718",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3588507-11E6684B-4A93-420D-8F48-A8DAF55D307E",
+      "person_id": "Q3588507",
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en_CA": "Member of the Senate of Canada",
+        "lang:fr_CA": "membre du Sénat du Canada"
+      }
+    }
+  ]
+}

--- a/legislative/index.json
+++ b/legislative/index.json
@@ -4,5 +4,12 @@
         "house_item_id": "Q383590",
         "position_item_id": "Q15964890",
         "term_item_id": "Q21157957"
+    },
+    {
+        "comment": "The Senate of Canada",
+        "house_item_id": "Q841180",
+        "position_item_id": "Q18524027",
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
     }
 ]

--- a/legislative/index.json
+++ b/legislative/index.json
@@ -1,0 +1,8 @@
+[
+    {
+        "comment": "The House of Commons of Canada",
+        "house_item_id": "Q383590",
+        "position_item_id": "Q15964890",
+        "term_item_id": "Q21157957"
+    }
+]


### PR DESCRIPTION
Previously the `build.rb` script only built data for the House of Commons, and output the JSON to standard output. This pull request:

* adds a file with Wikidata item IDs relevant to each legislature to build
* changes the build script iterate over those legislatures and output to the right directory under `legislative`
* adds data for the Senate