### PR TITLE
Standardise on 2-space indentation in JSON

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -1,361 +1,361 @@
 [
-    {
-        "directory": "country",
-        "area_type_wikidata_item_id": "Q6256",
-        "associations": [
-            {
-                "comment": "prime minister",
-                "position_item_id": "Q14212"
-            }
-        ],
-        "name_columns": {
-            "lang:en_CA": "name_en",
-            "lang:fr_CA": "name_fr"
-        }
-    },
-    {
-        "directory": "federal-constituencies",
-        "associations": [
-            {
-                "comment": "member of the House of Commons of Canada",
-                "position_item_id": "Q15964890"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q17202187",
-        "name_columns": {
-            "lang:en_CA": "ENNAME",
-            "lang:fr_CA": "FRNAME"
-        }
-    },
-    {
-        "directory": "provinces",
-        "associations": [
-            {
-                "comment": "Member of the Senate of Canada",
-                "position_item_id": "Q18524027"
-            },
-            {
-                "comment": "head of government of a Canadian province or territory",
-                "position_item_id": "Q2505921"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q2879",
-        "name_columns": {
-            "lang:en_CA": "name_en",
-            "lang:fr_CA": "name_fr"
-        }
-    },
-    {
-        "directory": "province-alberta",
-        "associations": [
-            {
-                "comment": "member of Alberta Legislative Assembly",
-                "position_item_id": "Q15964815"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q4711861",
-        "name_columns": {
-            "lang:en_CA": "EDName2010"
-        }
-    },
-    {
-        "directory": "province-manitoba",
-        "associations": [
-            {
-                "comment": "member of the Legislative Assembly of Manitoba ",
-                "position_item_id": "Q19007867"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47455017",
-        "name_columns": {
-            "lang:en_CA": "ED"
-        }
-    },
-    {
-        "directory": "province-quebec",
-        "associations": [
-            {
-                "comment": "Member of the National Assembly of Quebec",
-                "position_item_id": "Q3305338"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q2973931",
-        "name_columns": {
-            "lang:fr_CA": "NM_CEP"
-        }
-    },
-    {
-        "directory": "province-newfoundland-and-labrador",
-        "associations": [
-            {
-                "comment": "Member of the Newfoundland and Labrador House of Assembly",
-                "position_item_id": "Q19403853"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47454980",
-        "name_columns": {
-            "lang:en_CA": "Name"
-        }
-    },
-    {
-        "directory": "province-saskatchewan",
-        "associations": [
-            {
-                "comment": "Member of the Legislative Assembly of Saskatchewan",
-                "position_item_id": "Q18675661"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q6596424",
-        "name_columns": {
-            "lang:en_CA": "Con_Name"
-        }
-    },
-    {
-        "directory": "province-prince-edward-island",
-        "associations": [
-            {
-                "comment": "Member of the Legislative Assembly of Prince Edward Island",
-                "position_item_id": "Q21010685"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q19823486",
-        "name_columns": {
-            "lang:en_CA": "Descriptio"
-        }
-    },
-    {
-        "directory": "province-nova-scotia",
-        "associations": [
-            {
-                "comment": "member of the Nova Scotia House of Assembly",
-                "position_item_id": "Q18239264"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q6592593",
-        "name_columns": {
-            "lang:en_CA": "name"
-        }
-    },
-    {
-        "directory": "territory-northwest-territories",
-        "associations": [
-            {
-                "comment": "Member of the Legislative Assembly of the Northwest Territories",
-                "position_item_id": "Q45308871"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q15896168",
-        "name_columns": {
-            "lang:en_CA": "name"
-        }
-    },
-    {
-        "directory": "territory-nunavut",
-        "associations": [
-            {
-                "comment": "Member of the Legislative Assembly of Nunavut",
-                "position_item_id": "Q45308607"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47454933",
-        "name_columns": {
-            "lang:en_CA": "Name"
-        }
-    },
-    {
-        "directory": "territory-yukon",
-        "associations": [
-            {
-                "comment": "Member of the Yukon Legislative Assembly",
-                "position_item_id": "Q18608478"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47454928",
-        "name_columns": {
-            "lang:en_CA": "Name"
-        }
-    },
-    {
-        "directory": "province-ontario",
-        "associations": [
-            {
-                "comment": "Member of Ontario Provincial Parliament",
-                "position_item_id": "Q3305347"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q6593033",
-        "name_columns": {
-            "lang:en_CA": "name"
-        }
-    },
-    {
-        "directory": "toronto-wards",
-        "associations": [
-            {
-                "comment": "Member of Toronto City Council",
-                "position_item_id": "Q45413990"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47455500",
-        "name_columns": {
-            "lang:en_CA": "NAME"
-        }
-    },
-    {
-        "directory": "calgary-wards",
-        "associations": [
-            {
-                "comment": "Member of Calgary City Council",
-                "position_item_id": "Q45414913"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47455759",
-        "name_columns": {
-            "lang:en_CA": "label"
-        }
-    },
-    {
-        "directory": "ottawa-wards",
-        "associations": [
-            {
-                "comment": "Member of Ottawa City Council",
-                "position_item_id": "Q47487122"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47486824",
-        "name_columns": {
-            "lang:en_CA": "WARD_NAME_",
-            "lang:fr_CA": "WARD_NAME1"
-        }
-    },
-    {
-        "directory": "edmonton-wards",
-        "associations": [
-            {
-                "comment": "Member of Edmonton City Council",
-                "position_item_id": "Q47490130"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47489972",
-        "name_columns": {
-            "lang:en_CA": "name"
-        }
-    },
-    {
-        "directory": "winnipeg-wards",
-        "associations": [
-            {
-                "comment": "Member of Winnipeg City Council",
-                "position_item_id": "Q47490128"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47489974",
-        "name_columns": {
-            "lang:en_CA": "name"
-        }
-    },
-    {
-        "directory": "halifax-wards",
-        "associations": [
-            {
-                "comment": "Member of Halifax Regional Council",
-                "position_item_id": "Q47490131"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47489973",
-        "name_columns": {
-            "lang:en_CA": "DISTNAME"
-        }
-    },
-    {
-        "directory": "vancouver-wards",
-        "associations": [
-            {
-                "comment": "Member of Vancouver City Council",
-                "position_item_id": "Q47490129"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47489971",
-        "name_columns": {
-            "lang:en_CA": "Name"
-        }
-    },
-    {
-        "directory": "quebec-city-wards",
-        "associations": [
-            {
-                "comment": "Member of Quebec City Council",
-                "position_item_id": "Q47490318"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q6936314",
-        "name_columns": {
-            "lang:fr_CA": "NOM"
-        }
-    },
-    {
-        "directory": "montreal-boroughs",
-        "associations": [
-            {
-                "comment": "Borough Mayor (Montreal)",
-                "position_item_id": "Q47450833"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q578521",
-        "name_columns": {
-            "lang:en_CA": "Name"
-        }
-    },
-    {
-        "directory": "montreal-districts",
-        "associations": [
-            {
-                "comment": "Montreal City Councillor",
-                "position_item_id": "Q45414411"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q47456033",
-        "name_columns": {
-            "lang:en_CA": "Name"
-        }
-    },
-    {
-        "directory": "cities",
-        "associations": [
-            {
-                "comment": "Mayor",
-                "position_item_id": "Q30185"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q515",
-        "name_columns": {
-            "lang:en_CA": "NAME"
-        }
-    },
-    {
-        "directory": "province-british-columbia",
-        "associations": [
-            {
-                "comment": "Member of the Legislative Assembly of British Columbia",
-                "position_item_id": "Q19004821"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q6564784",
-        "name_columns": {
-            "lang:en_CA": "ED_NAME"
-        }
-    },
-    {
-        "directory": "province-new-brunswick",
-        "associations": [
-            {
-                "comment": "Member of the Legislative Assembly of New Brunswick",
-                "position_item_id": "Q18984329"
-            }
-        ],
-        "area_type_wikidata_item_id": "Q6591764",
-        "name_columns": {
-            "lang:en_CA": "PED_Name_E"
-        }
+  {
+    "directory": "country",
+    "area_type_wikidata_item_id": "Q6256",
+    "associations": [
+      {
+        "comment": "prime minister",
+        "position_item_id": "Q14212"
+      }
+    ],
+    "name_columns": {
+      "lang:en_CA": "name_en",
+      "lang:fr_CA": "name_fr"
     }
+  },
+  {
+    "directory": "federal-constituencies",
+    "associations": [
+      {
+        "comment": "member of the House of Commons of Canada",
+        "position_item_id": "Q15964890"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q17202187",
+    "name_columns": {
+      "lang:en_CA": "ENNAME",
+      "lang:fr_CA": "FRNAME"
+    }
+  },
+  {
+    "directory": "provinces",
+    "associations": [
+      {
+        "comment": "Member of the Senate of Canada",
+        "position_item_id": "Q18524027"
+      },
+      {
+        "comment": "head of government of a Canadian province or territory",
+        "position_item_id": "Q2505921"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q2879",
+    "name_columns": {
+      "lang:en_CA": "name_en",
+      "lang:fr_CA": "name_fr"
+    }
+  },
+  {
+    "directory": "province-alberta",
+    "associations": [
+      {
+        "comment": "member of Alberta Legislative Assembly",
+        "position_item_id": "Q15964815"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q4711861",
+    "name_columns": {
+      "lang:en_CA": "EDName2010"
+    }
+  },
+  {
+    "directory": "province-manitoba",
+    "associations": [
+      {
+        "comment": "member of the Legislative Assembly of Manitoba ",
+        "position_item_id": "Q19007867"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47455017",
+    "name_columns": {
+      "lang:en_CA": "ED"
+    }
+  },
+  {
+    "directory": "province-quebec",
+    "associations": [
+      {
+        "comment": "Member of the National Assembly of Quebec",
+        "position_item_id": "Q3305338"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q2973931",
+    "name_columns": {
+      "lang:fr_CA": "NM_CEP"
+    }
+  },
+  {
+    "directory": "province-newfoundland-and-labrador",
+    "associations": [
+      {
+        "comment": "Member of the Newfoundland and Labrador House of Assembly",
+        "position_item_id": "Q19403853"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47454980",
+    "name_columns": {
+      "lang:en_CA": "Name"
+    }
+  },
+  {
+    "directory": "province-saskatchewan",
+    "associations": [
+      {
+        "comment": "Member of the Legislative Assembly of Saskatchewan",
+        "position_item_id": "Q18675661"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q6596424",
+    "name_columns": {
+      "lang:en_CA": "Con_Name"
+    }
+  },
+  {
+    "directory": "province-prince-edward-island",
+    "associations": [
+      {
+        "comment": "Member of the Legislative Assembly of Prince Edward Island",
+        "position_item_id": "Q21010685"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q19823486",
+    "name_columns": {
+      "lang:en_CA": "Descriptio"
+    }
+  },
+  {
+    "directory": "province-nova-scotia",
+    "associations": [
+      {
+        "comment": "member of the Nova Scotia House of Assembly",
+        "position_item_id": "Q18239264"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q6592593",
+    "name_columns": {
+      "lang:en_CA": "name"
+    }
+  },
+  {
+    "directory": "territory-northwest-territories",
+    "associations": [
+      {
+        "comment": "Member of the Legislative Assembly of the Northwest Territories",
+        "position_item_id": "Q45308871"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q15896168",
+    "name_columns": {
+      "lang:en_CA": "name"
+    }
+  },
+  {
+    "directory": "territory-nunavut",
+    "associations": [
+      {
+        "comment": "Member of the Legislative Assembly of Nunavut",
+        "position_item_id": "Q45308607"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47454933",
+    "name_columns": {
+      "lang:en_CA": "Name"
+    }
+  },
+  {
+    "directory": "territory-yukon",
+    "associations": [
+      {
+        "comment": "Member of the Yukon Legislative Assembly",
+        "position_item_id": "Q18608478"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47454928",
+    "name_columns": {
+      "lang:en_CA": "Name"
+    }
+  },
+  {
+    "directory": "province-ontario",
+    "associations": [
+      {
+        "comment": "Member of Ontario Provincial Parliament",
+        "position_item_id": "Q3305347"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q6593033",
+    "name_columns": {
+      "lang:en_CA": "name"
+    }
+  },
+  {
+    "directory": "toronto-wards",
+    "associations": [
+      {
+        "comment": "Member of Toronto City Council",
+        "position_item_id": "Q45413990"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47455500",
+    "name_columns": {
+      "lang:en_CA": "NAME"
+    }
+  },
+  {
+    "directory": "calgary-wards",
+    "associations": [
+      {
+        "comment": "Member of Calgary City Council",
+        "position_item_id": "Q45414913"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47455759",
+    "name_columns": {
+      "lang:en_CA": "label"
+    }
+  },
+  {
+    "directory": "ottawa-wards",
+    "associations": [
+      {
+        "comment": "Member of Ottawa City Council",
+        "position_item_id": "Q47487122"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47486824",
+    "name_columns": {
+      "lang:en_CA": "WARD_NAME_",
+      "lang:fr_CA": "WARD_NAME1"
+    }
+  },
+  {
+    "directory": "edmonton-wards",
+    "associations": [
+      {
+        "comment": "Member of Edmonton City Council",
+        "position_item_id": "Q47490130"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47489972",
+    "name_columns": {
+      "lang:en_CA": "name"
+    }
+  },
+  {
+    "directory": "winnipeg-wards",
+    "associations": [
+      {
+        "comment": "Member of Winnipeg City Council",
+        "position_item_id": "Q47490128"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47489974",
+    "name_columns": {
+      "lang:en_CA": "name"
+    }
+  },
+  {
+    "directory": "halifax-wards",
+    "associations": [
+      {
+        "comment": "Member of Halifax Regional Council",
+        "position_item_id": "Q47490131"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47489973",
+    "name_columns": {
+      "lang:en_CA": "DISTNAME"
+    }
+  },
+  {
+    "directory": "vancouver-wards",
+    "associations": [
+      {
+        "comment": "Member of Vancouver City Council",
+        "position_item_id": "Q47490129"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47489971",
+    "name_columns": {
+      "lang:en_CA": "Name"
+    }
+  },
+  {
+    "directory": "quebec-city-wards",
+    "associations": [
+      {
+        "comment": "Member of Quebec City Council",
+        "position_item_id": "Q47490318"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q6936314",
+    "name_columns": {
+      "lang:fr_CA": "NOM"
+    }
+  },
+  {
+    "directory": "montreal-boroughs",
+    "associations": [
+      {
+        "comment": "Borough Mayor (Montreal)",
+        "position_item_id": "Q47450833"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q578521",
+    "name_columns": {
+      "lang:en_CA": "Name"
+    }
+  },
+  {
+    "directory": "montreal-districts",
+    "associations": [
+      {
+        "comment": "Montreal City Councillor",
+        "position_item_id": "Q45414411"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q47456033",
+    "name_columns": {
+      "lang:en_CA": "Name"
+    }
+  },
+  {
+    "directory": "cities",
+    "associations": [
+      {
+        "comment": "Mayor",
+        "position_item_id": "Q30185"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q515",
+    "name_columns": {
+      "lang:en_CA": "NAME"
+    }
+  },
+  {
+    "directory": "province-british-columbia",
+    "associations": [
+      {
+        "comment": "Member of the Legislative Assembly of British Columbia",
+        "position_item_id": "Q19004821"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q6564784",
+    "name_columns": {
+      "lang:en_CA": "ED_NAME"
+    }
+  },
+  {
+    "directory": "province-new-brunswick",
+    "associations": [
+      {
+        "comment": "Member of the Legislative Assembly of New Brunswick",
+        "position_item_id": "Q18984329"
+      }
+    ],
+    "area_type_wikidata_item_id": "Q6591764",
+    "name_columns": {
+      "lang:en_CA": "PED_Name_E"
+    }
+  }
 ]

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
-    "language_map": {
-        "lang:en_CA": "en",
-        "lang:fr_CA": "fr"
-    },
-    "country_wikidata_id": "Q16"
+  "language_map": {
+    "lang:en_CA": "en",
+    "lang:fr_CA": "fr"
+  },
+  "country_wikidata_id": "Q16"
 }

--- a/executive/index.json
+++ b/executive/index.json
@@ -1,212 +1,212 @@
 [
-    {
-        "comment": "Cabinet of Canada",
-        "executive_item_id": "Q2458227",
-        "positions": [
-            {
-                "comment": "Prime Minister",
-                "position_item_id": "Q14212"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Ontario",
-        "executive_item_id": "Q5589283",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Quebec",
-        "executive_item_id": "Q3112634",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Nova Scotia",
-        "executive_item_id": "Q5589276",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of New Brunswick",
-        "executive_item_id": "Q3112626",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Manitoba",
-        "executive_item_id": "Q20552083",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of British Columbia",
-        "executive_item_id": "Q30295427",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Prince Edward Island",
-        "executive_item_id": "Q5589299",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Saskatchewan",
-        "executive_item_id": "Q30295437",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Alberta",
-        "executive_item_id": "Q33121932",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Newfoundland and Labrador",
-        "executive_item_id": "Q5589273",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Yukon",
-        "executive_item_id": "Q17108558",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "The Government of Nunavut",
-        "executive_item_id": "Q33121937",
-        "positions": [
-            {
-                "comment": "Premier",
-                "position_item_id": "Q2505921"
-            }
-        ]
-    },
-    {
-        "comment": "Calgary City Council",
-        "executive_item_id": "Q4145705",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    },
-    {
-        "comment": "Toronto City Council",
-        "executive_item_id": "Q2444341",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    },
-    {
-        "comment": "Edmonton City Council",
-        "executive_item_id": "Q5339025",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    },
-    {
-        "comment": "Winnipeg City Council",
-        "executive_item_id": "Q47489645",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    },
-    {
-        "comment": "Halifax Regional Council",
-        "executive_item_id": "Q17107607",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    },
-    {
-        "comment": "Vancouver City Council",
-        "executive_item_id": "Q47489643",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    },
-    {
-        "comment": "Quebec City Council",
-        "executive_item_id": "Q2994129",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    },
-    {
-        "comment": "Montreal City Council",
-        "executive_item_id": "Q2994131",
-        "positions": [
-            {
-                "comment": "mayor",
-                "position_item_id": "Q30185"
-            }
-        ]
-    }
+  {
+    "comment": "Cabinet of Canada",
+    "executive_item_id": "Q2458227",
+    "positions": [
+      {
+        "comment": "Prime Minister",
+        "position_item_id": "Q14212"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Ontario",
+    "executive_item_id": "Q5589283",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Quebec",
+    "executive_item_id": "Q3112634",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Nova Scotia",
+    "executive_item_id": "Q5589276",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of New Brunswick",
+    "executive_item_id": "Q3112626",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Manitoba",
+    "executive_item_id": "Q20552083",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of British Columbia",
+    "executive_item_id": "Q30295427",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Prince Edward Island",
+    "executive_item_id": "Q5589299",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Saskatchewan",
+    "executive_item_id": "Q30295437",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Alberta",
+    "executive_item_id": "Q33121932",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Newfoundland and Labrador",
+    "executive_item_id": "Q5589273",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Yukon",
+    "executive_item_id": "Q17108558",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "The Government of Nunavut",
+    "executive_item_id": "Q33121937",
+    "positions": [
+      {
+        "comment": "Premier",
+        "position_item_id": "Q2505921"
+      }
+    ]
+  },
+  {
+    "comment": "Calgary City Council",
+    "executive_item_id": "Q4145705",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  },
+  {
+    "comment": "Toronto City Council",
+    "executive_item_id": "Q2444341",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  },
+  {
+    "comment": "Edmonton City Council",
+    "executive_item_id": "Q5339025",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  },
+  {
+    "comment": "Winnipeg City Council",
+    "executive_item_id": "Q47489645",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  },
+  {
+    "comment": "Halifax Regional Council",
+    "executive_item_id": "Q17107607",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  },
+  {
+    "comment": "Vancouver City Council",
+    "executive_item_id": "Q47489643",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  },
+  {
+    "comment": "Quebec City Council",
+    "executive_item_id": "Q2994129",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  },
+  {
+    "comment": "Montreal City Council",
+    "executive_item_id": "Q2994131",
+    "positions": [
+      {
+        "comment": "mayor",
+        "position_item_id": "Q30185"
+      }
+    ]
+  }
 ]

--- a/legislative/index.json
+++ b/legislative/index.json
@@ -1,276 +1,276 @@
 [
-    {
-        "comment": "The House of Commons of Canada",
-        "house_item_id": "Q383590",
-        "position_item_id": "Q15964890",
-        "terms":  [
-            {
-                "term_item_id": "Q21157957"
-            }
-        ]
-    },
-    {
-        "comment": "The Senate of Canada",
-        "house_item_id": "Q841180",
-        "position_item_id": "Q18524027",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of Alberta",
-        "house_item_id": "Q1812866",
-        "position_item_id": "Q15964815",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of Manitoba",
-        "house_item_id": "Q1517320",
-        "position_item_id": "Q19007867",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "National Assembly of Quebec",
-        "house_item_id": "Q1492249",
-        "position_item_id": "Q3305338",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Newfoundland and Labrador House of Assembly",
-        "house_item_id": "Q258843",
-        "position_item_id": "Q19403853",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of Saskatchewan",
-        "house_item_id": "Q1537375",
-        "position_item_id": "Q18675661",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of Prince Edward Island",
-        "house_item_id": "Q825815",
-        "position_item_id": "Q21010685",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Nova Scotia House of Assembly",
-        "house_item_id": "Q320273",
-        "position_item_id": "Q18239264",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of the Northwest Territories",
-        "house_item_id": "Q2867078",
-        "position_item_id": "Q45308871",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of Nunavut",
-        "house_item_id": "Q2867082",
-        "position_item_id": "Q45308607",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Yukon Legislative Assembly",
-        "house_item_id": "Q908022",
-        "position_item_id": "Q18608478",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of Ontario",
-        "house_item_id": "Q1809086",
-        "position_item_id": "Q3305347",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Toronto City Council",
-        "house_item_id": "Q2444341",
-        "position_item_id": "Q45413990",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Calgary City Council",
-        "house_item_id": "Q4145705",
-        "position_item_id": "Q45414913",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Ottawa City Council",
-        "house_item_id": "Q2994125",
-        "position_item_id": "Q47487122",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Edmonton City Council",
-        "house_item_id": "Q5339025",
-        "position_item_id": "Q47490130",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Winnipeg City Council",
-        "house_item_id": "Q47489645",
-        "position_item_id": "Q47490128",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Halifax Regional Council",
-        "house_item_id": "Q17107607",
-        "position_item_id": "Q47490131",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Vancouver City Council",
-        "house_item_id": "Q47489643",
-        "position_item_id": "Q47490129",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Quebec City Council",
-        "house_item_id": "Q2994129",
-        "position_item_id": "Q47490318",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Montreal City Council",
-        "house_item_id": "Q2994131",
-        "position_item_id": "Q47450833",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Montreal City Council",
-        "house_item_id": "Q2994131",
-        "position_item_id": "Q45414411",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of British Columbia",
-        "house_item_id": "Q1323479",
-        "position_item_id": "Q19004821",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    },
-    {
-        "comment": "Legislative Assembly of New Brunswick",
-        "house_item_id": "Q1516914",
-        "position_item_id": "Q18984329",
-        "terms": [
-            {
-                "start_date": "2018-01-01",
-                "end_date": "2018-12-31"
-            }
-        ]
-    }
+  {
+    "comment": "The House of Commons of Canada",
+    "house_item_id": "Q383590",
+    "position_item_id": "Q15964890",
+    "terms": [
+      {
+        "term_item_id": "Q21157957"
+      }
+    ]
+  },
+  {
+    "comment": "The Senate of Canada",
+    "house_item_id": "Q841180",
+    "position_item_id": "Q18524027",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of Alberta",
+    "house_item_id": "Q1812866",
+    "position_item_id": "Q15964815",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of Manitoba",
+    "house_item_id": "Q1517320",
+    "position_item_id": "Q19007867",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "National Assembly of Quebec",
+    "house_item_id": "Q1492249",
+    "position_item_id": "Q3305338",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Newfoundland and Labrador House of Assembly",
+    "house_item_id": "Q258843",
+    "position_item_id": "Q19403853",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of Saskatchewan",
+    "house_item_id": "Q1537375",
+    "position_item_id": "Q18675661",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of Prince Edward Island",
+    "house_item_id": "Q825815",
+    "position_item_id": "Q21010685",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Nova Scotia House of Assembly",
+    "house_item_id": "Q320273",
+    "position_item_id": "Q18239264",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of the Northwest Territories",
+    "house_item_id": "Q2867078",
+    "position_item_id": "Q45308871",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of Nunavut",
+    "house_item_id": "Q2867082",
+    "position_item_id": "Q45308607",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Yukon Legislative Assembly",
+    "house_item_id": "Q908022",
+    "position_item_id": "Q18608478",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of Ontario",
+    "house_item_id": "Q1809086",
+    "position_item_id": "Q3305347",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Toronto City Council",
+    "house_item_id": "Q2444341",
+    "position_item_id": "Q45413990",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Calgary City Council",
+    "house_item_id": "Q4145705",
+    "position_item_id": "Q45414913",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Ottawa City Council",
+    "house_item_id": "Q2994125",
+    "position_item_id": "Q47487122",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Edmonton City Council",
+    "house_item_id": "Q5339025",
+    "position_item_id": "Q47490130",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Winnipeg City Council",
+    "house_item_id": "Q47489645",
+    "position_item_id": "Q47490128",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Halifax Regional Council",
+    "house_item_id": "Q17107607",
+    "position_item_id": "Q47490131",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Vancouver City Council",
+    "house_item_id": "Q47489643",
+    "position_item_id": "Q47490129",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Quebec City Council",
+    "house_item_id": "Q2994129",
+    "position_item_id": "Q47490318",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Montreal City Council",
+    "house_item_id": "Q2994131",
+    "position_item_id": "Q47450833",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Montreal City Council",
+    "house_item_id": "Q2994131",
+    "position_item_id": "Q45414411",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of British Columbia",
+    "house_item_id": "Q1323479",
+    "position_item_id": "Q19004821",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  },
+  {
+    "comment": "Legislative Assembly of New Brunswick",
+    "house_item_id": "Q1516914",
+    "position_item_id": "Q18984329",
+    "terms": [
+      {
+        "start_date": "2018-01-01",
+        "end_date": "2018-12-31"
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
There doesn't seem to be a global indentation
standard for JSON (see, for example
https://stackoverflow.com/questions/18698738/what-is-the-json-indentation-level-convention).
However, @chrismytton notes that ruby's JSON.pretty_generate
produces 2-space indentation, as does the Google JSON style
guide (https://google.github.io/styleguide/jsoncstyleguide.xml)
and most of Facebook's Graph API JSON example
(https://developers.facebook.com/docs/graph-api/using-graph-api/).