### PR TITLE
Move from locale codes to language codes for boundaries

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -9,8 +9,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_CA": "name_en",
-      "lang:fr_CA": "name_fr"
+      "lang:en": "name_en",
+      "lang:fr": "name_fr"
     }
   },
   {
@@ -23,8 +23,8 @@
     ],
     "area_type_wikidata_item_id": "Q17202187",
     "name_columns": {
-      "lang:en_CA": "ENNAME",
-      "lang:fr_CA": "FRNAME"
+      "lang:en": "ENNAME",
+      "lang:fr": "FRNAME"
     }
   },
   {
@@ -41,8 +41,8 @@
     ],
     "area_type_wikidata_item_id": "Q2879",
     "name_columns": {
-      "lang:en_CA": "name_en",
-      "lang:fr_CA": "name_fr"
+      "lang:en": "name_en",
+      "lang:fr": "name_fr"
     }
   },
   {
@@ -55,7 +55,7 @@
     ],
     "area_type_wikidata_item_id": "Q4711861",
     "name_columns": {
-      "lang:en_CA": "EDName2010"
+      "lang:en": "EDName2010"
     }
   },
   {
@@ -68,7 +68,7 @@
     ],
     "area_type_wikidata_item_id": "Q47455017",
     "name_columns": {
-      "lang:en_CA": "ED"
+      "lang:en": "ED"
     }
   },
   {
@@ -81,7 +81,7 @@
     ],
     "area_type_wikidata_item_id": "Q2973931",
     "name_columns": {
-      "lang:fr_CA": "NM_CEP"
+      "lang:fr": "NM_CEP"
     }
   },
   {
@@ -94,7 +94,7 @@
     ],
     "area_type_wikidata_item_id": "Q47454980",
     "name_columns": {
-      "lang:en_CA": "Name"
+      "lang:en": "Name"
     }
   },
   {
@@ -107,7 +107,7 @@
     ],
     "area_type_wikidata_item_id": "Q6596424",
     "name_columns": {
-      "lang:en_CA": "Con_Name"
+      "lang:en": "Con_Name"
     }
   },
   {
@@ -120,7 +120,7 @@
     ],
     "area_type_wikidata_item_id": "Q19823486",
     "name_columns": {
-      "lang:en_CA": "Descriptio"
+      "lang:en": "Descriptio"
     }
   },
   {
@@ -133,7 +133,7 @@
     ],
     "area_type_wikidata_item_id": "Q6592593",
     "name_columns": {
-      "lang:en_CA": "name"
+      "lang:en": "name"
     }
   },
   {
@@ -146,7 +146,7 @@
     ],
     "area_type_wikidata_item_id": "Q15896168",
     "name_columns": {
-      "lang:en_CA": "name"
+      "lang:en": "name"
     }
   },
   {
@@ -159,7 +159,7 @@
     ],
     "area_type_wikidata_item_id": "Q47454933",
     "name_columns": {
-      "lang:en_CA": "Name"
+      "lang:en": "Name"
     }
   },
   {
@@ -172,7 +172,7 @@
     ],
     "area_type_wikidata_item_id": "Q47454928",
     "name_columns": {
-      "lang:en_CA": "Name"
+      "lang:en": "Name"
     }
   },
   {
@@ -185,7 +185,7 @@
     ],
     "area_type_wikidata_item_id": "Q6593033",
     "name_columns": {
-      "lang:en_CA": "name"
+      "lang:en": "name"
     }
   },
   {
@@ -198,7 +198,7 @@
     ],
     "area_type_wikidata_item_id": "Q47455500",
     "name_columns": {
-      "lang:en_CA": "NAME"
+      "lang:en": "NAME"
     }
   },
   {
@@ -211,7 +211,7 @@
     ],
     "area_type_wikidata_item_id": "Q47455759",
     "name_columns": {
-      "lang:en_CA": "label"
+      "lang:en": "label"
     }
   },
   {
@@ -224,8 +224,8 @@
     ],
     "area_type_wikidata_item_id": "Q47486824",
     "name_columns": {
-      "lang:en_CA": "WARD_NAME_",
-      "lang:fr_CA": "WARD_NAME1"
+      "lang:en": "WARD_NAME_",
+      "lang:fr": "WARD_NAME1"
     }
   },
   {
@@ -238,7 +238,7 @@
     ],
     "area_type_wikidata_item_id": "Q47489972",
     "name_columns": {
-      "lang:en_CA": "name"
+      "lang:en": "name"
     }
   },
   {
@@ -251,7 +251,7 @@
     ],
     "area_type_wikidata_item_id": "Q47489974",
     "name_columns": {
-      "lang:en_CA": "name"
+      "lang:en": "name"
     }
   },
   {
@@ -264,7 +264,7 @@
     ],
     "area_type_wikidata_item_id": "Q47489973",
     "name_columns": {
-      "lang:en_CA": "DISTNAME"
+      "lang:en": "DISTNAME"
     }
   },
   {
@@ -277,7 +277,7 @@
     ],
     "area_type_wikidata_item_id": "Q47489971",
     "name_columns": {
-      "lang:en_CA": "Name"
+      "lang:en": "Name"
     }
   },
   {
@@ -290,7 +290,7 @@
     ],
     "area_type_wikidata_item_id": "Q6936314",
     "name_columns": {
-      "lang:fr_CA": "NOM"
+      "lang:fr": "NOM"
     }
   },
   {
@@ -303,7 +303,7 @@
     ],
     "area_type_wikidata_item_id": "Q578521",
     "name_columns": {
-      "lang:en_CA": "Name"
+      "lang:en": "Name"
     }
   },
   {
@@ -316,7 +316,7 @@
     ],
     "area_type_wikidata_item_id": "Q47456033",
     "name_columns": {
-      "lang:en_CA": "Name"
+      "lang:en": "Name"
     }
   },
   {
@@ -329,7 +329,7 @@
     ],
     "area_type_wikidata_item_id": "Q515",
     "name_columns": {
-      "lang:en_CA": "NAME"
+      "lang:en": "NAME"
     }
   },
   {
@@ -342,7 +342,7 @@
     ],
     "area_type_wikidata_item_id": "Q6564784",
     "name_columns": {
-      "lang:en_CA": "ED_NAME"
+      "lang:en": "ED_NAME"
     }
   },
   {
@@ -355,7 +355,7 @@
     ],
     "area_type_wikidata_item_id": "Q6591764",
     "name_columns": {
-      "lang:en_CA": "PED_Name_E"
+      "lang:en": "PED_Name_E"
     }
   }
 ]

--- a/executive/Q17107607/current/popolo-m17n.json
+++ b/executive/Q17107607/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -94,7 +94,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -119,8 +119,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -145,7 +145,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -169,7 +169,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -194,7 +194,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -219,8 +219,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -245,8 +245,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -271,8 +271,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -296,7 +296,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -320,7 +320,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -344,7 +344,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -368,7 +368,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -392,7 +392,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -416,7 +416,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -440,7 +440,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q17108558/current/popolo-m17n.json
+++ b/executive/Q17108558/current/popolo-m17n.json
@@ -101,8 +101,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -127,8 +127,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -153,7 +153,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -178,7 +178,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -203,8 +203,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -229,8 +229,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -255,8 +255,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -281,8 +281,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -307,8 +307,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -333,8 +333,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -359,8 +359,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -385,8 +385,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -411,7 +411,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -436,8 +436,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q20552083/current/popolo-m17n.json
+++ b/executive/Q20552083/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -78,7 +78,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -103,7 +103,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -128,8 +128,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -154,8 +154,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -180,8 +180,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -206,8 +206,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -232,8 +232,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -258,8 +258,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -284,8 +284,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -310,8 +310,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -336,7 +336,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -361,8 +361,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q2444341/current/popolo-m17n.json
+++ b/executive/Q2444341/current/popolo-m17n.json
@@ -118,8 +118,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -143,7 +143,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -168,8 +168,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -194,7 +194,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -218,7 +218,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -243,7 +243,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -268,8 +268,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -294,8 +294,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -320,8 +320,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -345,7 +345,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -369,7 +369,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -393,7 +393,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -417,7 +417,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -441,7 +441,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -465,7 +465,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -489,7 +489,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q2458227/current/popolo-m17n.json
+++ b/executive/Q2458227/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     }

--- a/executive/Q2994129/current/popolo-m17n.json
+++ b/executive/Q2994129/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -51,7 +51,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -76,8 +76,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -102,7 +102,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -126,7 +126,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -151,7 +151,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -176,8 +176,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -202,8 +202,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -228,8 +228,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -253,7 +253,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -277,7 +277,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -301,7 +301,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -325,7 +325,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -349,7 +349,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -373,7 +373,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -397,7 +397,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q2994131/current/popolo-m17n.json
+++ b/executive/Q2994131/current/popolo-m17n.json
@@ -132,8 +132,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -157,7 +157,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -182,8 +182,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -208,7 +208,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -232,7 +232,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -257,7 +257,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -282,8 +282,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -308,8 +308,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -334,8 +334,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -359,7 +359,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -383,7 +383,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -407,7 +407,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -431,7 +431,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -455,7 +455,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -479,7 +479,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -503,7 +503,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q30295427/current/popolo-m17n.json
+++ b/executive/Q30295427/current/popolo-m17n.json
@@ -87,8 +87,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -113,8 +113,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -139,7 +139,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -164,7 +164,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -189,8 +189,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -215,8 +215,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -241,8 +241,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -267,8 +267,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -293,8 +293,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -319,8 +319,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -345,8 +345,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -371,8 +371,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -397,7 +397,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -422,8 +422,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q30295437/current/popolo-m17n.json
+++ b/executive/Q30295437/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -78,7 +78,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -103,7 +103,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -128,8 +128,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -154,8 +154,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -180,8 +180,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -206,8 +206,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -232,8 +232,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -258,8 +258,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -284,8 +284,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -310,8 +310,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -336,7 +336,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -361,8 +361,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q3112626/current/popolo-m17n.json
+++ b/executive/Q3112626/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -78,7 +78,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -103,7 +103,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -128,8 +128,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -154,8 +154,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -180,8 +180,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -206,8 +206,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -232,8 +232,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -258,8 +258,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -284,8 +284,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -310,8 +310,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -336,7 +336,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -361,8 +361,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q3112634/current/popolo-m17n.json
+++ b/executive/Q3112634/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -98,8 +98,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -124,7 +124,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -149,7 +149,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -174,8 +174,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -200,8 +200,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -226,8 +226,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -252,8 +252,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -278,8 +278,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -304,8 +304,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -330,8 +330,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -356,8 +356,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -382,7 +382,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -407,8 +407,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q33121932/current/popolo-m17n.json
+++ b/executive/Q33121932/current/popolo-m17n.json
@@ -101,8 +101,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -127,8 +127,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -153,7 +153,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -178,7 +178,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -203,8 +203,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -229,8 +229,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -255,8 +255,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -281,8 +281,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -307,8 +307,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -333,8 +333,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -359,8 +359,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -385,8 +385,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -411,7 +411,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -436,8 +436,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q33121937/current/popolo-m17n.json
+++ b/executive/Q33121937/current/popolo-m17n.json
@@ -84,8 +84,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -110,8 +110,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -136,7 +136,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -161,7 +161,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -186,8 +186,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -212,8 +212,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -238,8 +238,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -264,8 +264,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -290,8 +290,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -316,8 +316,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -342,8 +342,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -368,8 +368,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -394,7 +394,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -419,8 +419,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q4145705/current/popolo-m17n.json
+++ b/executive/Q4145705/current/popolo-m17n.json
@@ -58,8 +58,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -83,7 +83,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -108,8 +108,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -134,7 +134,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -158,7 +158,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -183,7 +183,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -208,8 +208,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -234,8 +234,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -260,8 +260,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -285,7 +285,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -309,7 +309,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -333,7 +333,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -357,7 +357,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -381,7 +381,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -405,7 +405,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -429,7 +429,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q47489643/current/popolo-m17n.json
+++ b/executive/Q47489643/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -51,7 +51,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -76,8 +76,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -102,7 +102,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -126,7 +126,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -151,7 +151,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -176,8 +176,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -202,8 +202,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -228,8 +228,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -253,7 +253,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -277,7 +277,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -301,7 +301,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -325,7 +325,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -349,7 +349,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -373,7 +373,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -397,7 +397,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q47489645/current/popolo-m17n.json
+++ b/executive/Q47489645/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -51,7 +51,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -76,8 +76,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -102,7 +102,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -126,7 +126,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -151,7 +151,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -176,8 +176,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -202,8 +202,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -228,8 +228,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -253,7 +253,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -277,7 +277,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -301,7 +301,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -325,7 +325,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -349,7 +349,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -373,7 +373,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -397,7 +397,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q5339025/current/popolo-m17n.json
+++ b/executive/Q5339025/current/popolo-m17n.json
@@ -663,8 +663,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -688,7 +688,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -713,8 +713,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -739,7 +739,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -763,7 +763,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -788,7 +788,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -813,8 +813,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -839,8 +839,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -865,8 +865,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -890,7 +890,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -914,7 +914,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -938,7 +938,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -962,7 +962,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -986,7 +986,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -1010,7 +1010,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -1034,7 +1034,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     }

--- a/executive/Q5589273/current/popolo-m17n.json
+++ b/executive/Q5589273/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -78,7 +78,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -103,7 +103,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -128,8 +128,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -154,8 +154,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -180,8 +180,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -206,8 +206,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -232,8 +232,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -258,8 +258,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -284,8 +284,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -310,8 +310,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -336,7 +336,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -361,8 +361,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q5589276/current/popolo-m17n.json
+++ b/executive/Q5589276/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -78,7 +78,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -103,7 +103,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -128,8 +128,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -154,8 +154,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -180,8 +180,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -206,8 +206,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -232,8 +232,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -258,8 +258,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -284,8 +284,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -310,8 +310,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -336,7 +336,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -361,8 +361,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q5589283/current/popolo-m17n.json
+++ b/executive/Q5589283/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -98,8 +98,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -124,7 +124,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -149,7 +149,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -174,8 +174,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -200,8 +200,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -226,8 +226,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -252,8 +252,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -278,8 +278,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -304,8 +304,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -330,8 +330,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -356,8 +356,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -382,7 +382,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -407,8 +407,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/executive/Q5589299/current/popolo-m17n.json
+++ b/executive/Q5589299/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -78,7 +78,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -103,7 +103,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -128,8 +128,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -154,8 +154,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -180,8 +180,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -206,8 +206,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -232,8 +232,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -258,8 +258,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -284,8 +284,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -310,8 +310,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -336,7 +336,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -361,8 +361,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/legislative/Q1323479/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1323479/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -1768,7 +1768,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Nanaimo"
+        "lang:en": "Nanaimo"
       },
       "parent_id": "Q1974"
     },
@@ -1791,7 +1791,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "North Vancouver-Seymour"
+        "lang:en": "North Vancouver-Seymour"
       },
       "parent_id": "Q1974"
     },
@@ -1815,8 +1815,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -1839,7 +1839,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Coquitlam-Maillardville"
+        "lang:en": "Coquitlam-Maillardville"
       },
       "parent_id": "Q1974"
     },
@@ -1862,7 +1862,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Shuswap"
+        "lang:en": "Shuswap"
       },
       "parent_id": "Q1974"
     },
@@ -1885,7 +1885,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Nechako Lakes"
+        "lang:en": "Nechako Lakes"
       },
       "parent_id": "Q1974"
     },
@@ -1908,7 +1908,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Victoria-Swan Lake"
+        "lang:en": "Victoria-Swan Lake"
       },
       "parent_id": "Q1974"
     },
@@ -1931,7 +1931,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Langley"
+        "lang:en": "Langley"
       },
       "parent_id": "Q1974"
     },
@@ -1954,7 +1954,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Mount Pleasant"
+        "lang:en": "Vancouver-Mount Pleasant"
       },
       "parent_id": "Q1974"
     },
@@ -1979,8 +1979,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -2003,7 +2003,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Langley East"
+        "lang:en": "Langley East"
       },
       "parent_id": "Q1974"
     },
@@ -2026,7 +2026,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Richmond North Centre"
+        "lang:en": "Richmond North Centre"
       },
       "parent_id": "Q1974"
     },
@@ -2049,7 +2049,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Richmond-Queensborough"
+        "lang:en": "Richmond-Queensborough"
       },
       "parent_id": "Q1974"
     },
@@ -2072,7 +2072,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Richmond South Centre"
+        "lang:en": "Richmond South Centre"
       },
       "parent_id": "Q1974"
     },
@@ -2095,7 +2095,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-Guildford"
+        "lang:en": "Surrey-Guildford"
       },
       "parent_id": "Q1974"
     },
@@ -2118,7 +2118,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey South"
+        "lang:en": "Surrey South"
       },
       "parent_id": "Q1974"
     },
@@ -2141,7 +2141,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Courtenay-Comox"
+        "lang:en": "Courtenay-Comox"
       },
       "parent_id": "Q1974"
     },
@@ -2164,7 +2164,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Langford-Juan de Fuca"
+        "lang:en": "Langford-Juan de Fuca"
       },
       "parent_id": "Q1974"
     },
@@ -2187,7 +2187,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Mid Island-Pacific Rim"
+        "lang:en": "Mid Island-Pacific Rim"
       },
       "parent_id": "Q1974"
     },
@@ -2210,7 +2210,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Abbotsford-Mission"
+        "lang:en": "Abbotsford-Mission"
       },
       "parent_id": "Q1974"
     },
@@ -2233,7 +2233,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Abbotsford South"
+        "lang:en": "Abbotsford South"
       },
       "parent_id": "Q1974"
     },
@@ -2256,7 +2256,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Abbotsford West"
+        "lang:en": "Abbotsford West"
       },
       "parent_id": "Q1974"
     },
@@ -2279,7 +2279,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Boundary-Similkameen"
+        "lang:en": "Boundary-Similkameen"
       },
       "parent_id": "Q1974"
     },
@@ -2302,7 +2302,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Burnaby-Deer Lake"
+        "lang:en": "Burnaby-Deer Lake"
       },
       "parent_id": "Q1974"
     },
@@ -2325,7 +2325,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Burnaby-Lougheed"
+        "lang:en": "Burnaby-Lougheed"
       },
       "parent_id": "Q1974"
     },
@@ -2348,7 +2348,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Burnaby-Edmonds"
+        "lang:en": "Burnaby-Edmonds"
       },
       "parent_id": "Q1974"
     },
@@ -2371,7 +2371,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Burnaby North"
+        "lang:en": "Burnaby North"
       },
       "parent_id": "Q1974"
     },
@@ -2394,7 +2394,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Cariboo-Chilcotin"
+        "lang:en": "Cariboo-Chilcotin"
       },
       "parent_id": "Q1974"
     },
@@ -2417,7 +2417,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Cariboo North"
+        "lang:en": "Cariboo North"
       },
       "parent_id": "Q1974"
     },
@@ -2440,7 +2440,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Chilliwack-Kent"
+        "lang:en": "Chilliwack-Kent"
       },
       "parent_id": "Q1974"
     },
@@ -2463,7 +2463,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Chilliwack"
+        "lang:en": "Chilliwack"
       },
       "parent_id": "Q1974"
     },
@@ -2486,7 +2486,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Columbia River-Revelstoke"
+        "lang:en": "Columbia River-Revelstoke"
       },
       "parent_id": "Q1974"
     },
@@ -2509,7 +2509,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Coquitlam-Burke Mountain"
+        "lang:en": "Coquitlam-Burke Mountain"
       },
       "parent_id": "Q1974"
     },
@@ -2532,7 +2532,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Cowichan Valley"
+        "lang:en": "Cowichan Valley"
       },
       "parent_id": "Q1974"
     },
@@ -2555,7 +2555,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Delta North"
+        "lang:en": "Delta North"
       },
       "parent_id": "Q1974"
     },
@@ -2578,7 +2578,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Delta South"
+        "lang:en": "Delta South"
       },
       "parent_id": "Q1974"
     },
@@ -2601,7 +2601,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Esquimalt-Metchosin"
+        "lang:en": "Esquimalt-Metchosin"
       },
       "parent_id": "Q1974"
     },
@@ -2624,7 +2624,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Fraser-Nicola"
+        "lang:en": "Fraser-Nicola"
       },
       "parent_id": "Q1974"
     },
@@ -2647,7 +2647,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Kamloops-South Thompson"
+        "lang:en": "Kamloops-South Thompson"
       },
       "parent_id": "Q1974"
     },
@@ -2670,7 +2670,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Kamloops-North Thompson"
+        "lang:en": "Kamloops-North Thompson"
       },
       "parent_id": "Q1974"
     },
@@ -2693,7 +2693,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Kelowna-Mission"
+        "lang:en": "Kelowna-Mission"
       },
       "parent_id": "Q1974"
     },
@@ -2716,7 +2716,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Kelowna-Lake Country"
+        "lang:en": "Kelowna-Lake Country"
       },
       "parent_id": "Q1974"
     },
@@ -2739,7 +2739,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Kootenay East"
+        "lang:en": "Kootenay East"
       },
       "parent_id": "Q1974"
     },
@@ -2762,7 +2762,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Kootenay West"
+        "lang:en": "Kootenay West"
       },
       "parent_id": "Q1974"
     },
@@ -2785,7 +2785,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Maple Ridge-Mission"
+        "lang:en": "Maple Ridge-Mission"
       },
       "parent_id": "Q1974"
     },
@@ -2808,7 +2808,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Maple Ridge-Pitt Meadows"
+        "lang:en": "Maple Ridge-Pitt Meadows"
       },
       "parent_id": "Q1974"
     },
@@ -2831,7 +2831,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Nanaimo-North Cowichan"
+        "lang:en": "Nanaimo-North Cowichan"
       },
       "parent_id": "Q1974"
     },
@@ -2854,7 +2854,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Nelson-Creston"
+        "lang:en": "Nelson-Creston"
       },
       "parent_id": "Q1974"
     },
@@ -2877,7 +2877,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "New Westminster"
+        "lang:en": "New Westminster"
       },
       "parent_id": "Q1974"
     },
@@ -2900,7 +2900,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "North Coast"
+        "lang:en": "North Coast"
       },
       "parent_id": "Q1974"
     },
@@ -2923,7 +2923,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "North Island"
+        "lang:en": "North Island"
       },
       "parent_id": "Q1974"
     },
@@ -2946,7 +2946,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "North Vancouver-Lonsdale"
+        "lang:en": "North Vancouver-Lonsdale"
       },
       "parent_id": "Q1974"
     },
@@ -2969,7 +2969,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Oak Bay-Gordon Head"
+        "lang:en": "Oak Bay-Gordon Head"
       },
       "parent_id": "Q1974"
     },
@@ -2992,7 +2992,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Parksville-Qualicum"
+        "lang:en": "Parksville-Qualicum"
       },
       "parent_id": "Q1974"
     },
@@ -3015,7 +3015,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Peace River North"
+        "lang:en": "Peace River North"
       },
       "parent_id": "Q1974"
     },
@@ -3038,7 +3038,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Peace River South"
+        "lang:en": "Peace River South"
       },
       "parent_id": "Q1974"
     },
@@ -3061,7 +3061,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Penticton"
+        "lang:en": "Penticton"
       },
       "parent_id": "Q1974"
     },
@@ -3084,7 +3084,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Port Coquitlam"
+        "lang:en": "Port Coquitlam"
       },
       "parent_id": "Q1974"
     },
@@ -3107,7 +3107,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Port Moody-Coquitlam"
+        "lang:en": "Port Moody-Coquitlam"
       },
       "parent_id": "Q1974"
     },
@@ -3130,7 +3130,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Powell River-Sunshine Coast"
+        "lang:en": "Powell River-Sunshine Coast"
       },
       "parent_id": "Q1974"
     },
@@ -3153,7 +3153,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Prince George-Mackenzie"
+        "lang:en": "Prince George-Mackenzie"
       },
       "parent_id": "Q1974"
     },
@@ -3176,7 +3176,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Prince George-Valemount"
+        "lang:en": "Prince George-Valemount"
       },
       "parent_id": "Q1974"
     },
@@ -3199,7 +3199,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Richmond-Steveston"
+        "lang:en": "Richmond-Steveston"
       },
       "parent_id": "Q1974"
     },
@@ -3222,7 +3222,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Saanich North and the Islands"
+        "lang:en": "Saanich North and the Islands"
       },
       "parent_id": "Q1974"
     },
@@ -3245,7 +3245,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Saanich South"
+        "lang:en": "Saanich South"
       },
       "parent_id": "Q1974"
     },
@@ -3268,7 +3268,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Skeena"
+        "lang:en": "Skeena"
       },
       "parent_id": "Q1974"
     },
@@ -3291,7 +3291,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Stikine"
+        "lang:en": "Stikine"
       },
       "parent_id": "Q1974"
     },
@@ -3314,7 +3314,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-Cloverdale"
+        "lang:en": "Surrey-Cloverdale"
       },
       "parent_id": "Q1974"
     },
@@ -3337,7 +3337,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-Fleetwood"
+        "lang:en": "Surrey-Fleetwood"
       },
       "parent_id": "Q1974"
     },
@@ -3360,7 +3360,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-Green Timbers"
+        "lang:en": "Surrey-Green Timbers"
       },
       "parent_id": "Q1974"
     },
@@ -3383,7 +3383,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-Newton"
+        "lang:en": "Surrey-Newton"
       },
       "parent_id": "Q1974"
     },
@@ -3406,7 +3406,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-Panorama"
+        "lang:en": "Surrey-Panorama"
       },
       "parent_id": "Q1974"
     },
@@ -3429,7 +3429,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-Whalley"
+        "lang:en": "Surrey-Whalley"
       },
       "parent_id": "Q1974"
     },
@@ -3452,7 +3452,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Surrey-White Rock"
+        "lang:en": "Surrey-White Rock"
       },
       "parent_id": "Q1974"
     },
@@ -3475,7 +3475,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Fairview"
+        "lang:en": "Vancouver-Fairview"
       },
       "parent_id": "Q1974"
     },
@@ -3498,7 +3498,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-False Creek"
+        "lang:en": "Vancouver-False Creek"
       },
       "parent_id": "Q1974"
     },
@@ -3521,7 +3521,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Fraserview"
+        "lang:en": "Vancouver-Fraserview"
       },
       "parent_id": "Q1974"
     },
@@ -3544,7 +3544,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Hastings"
+        "lang:en": "Vancouver-Hastings"
       },
       "parent_id": "Q1974"
     },
@@ -3567,7 +3567,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Kensington"
+        "lang:en": "Vancouver-Kensington"
       },
       "parent_id": "Q1974"
     },
@@ -3590,7 +3590,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Kingsway"
+        "lang:en": "Vancouver-Kingsway"
       },
       "parent_id": "Q1974"
     },
@@ -3613,7 +3613,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Langara"
+        "lang:en": "Vancouver-Langara"
       },
       "parent_id": "Q1974"
     },
@@ -3636,7 +3636,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Quilchena"
+        "lang:en": "Vancouver-Quilchena"
       },
       "parent_id": "Q1974"
     },
@@ -3659,7 +3659,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-Point Grey"
+        "lang:en": "Vancouver-Point Grey"
       },
       "parent_id": "Q1974"
     },
@@ -3682,7 +3682,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vancouver-West End"
+        "lang:en": "Vancouver-West End"
       },
       "parent_id": "Q1974"
     },
@@ -3705,7 +3705,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Vernon-Monashee"
+        "lang:en": "Vernon-Monashee"
       },
       "parent_id": "Q1974"
     },
@@ -3728,7 +3728,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Victoria-Beacon Hill"
+        "lang:en": "Victoria-Beacon Hill"
       },
       "parent_id": "Q1974"
     },
@@ -3751,7 +3751,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "West Vancouver-Capilano"
+        "lang:en": "West Vancouver-Capilano"
       },
       "parent_id": "Q1974"
     },
@@ -3774,7 +3774,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "West Vancouver-Sea to Sky"
+        "lang:en": "West Vancouver-Sea to Sky"
       },
       "parent_id": "Q1974"
     },
@@ -3797,7 +3797,7 @@
         "lang:en": "provincial electoral district of British Columbia"
       },
       "name": {
-        "lang:en_CA": "Kelowna West"
+        "lang:en": "Kelowna West"
       },
       "parent_id": "Q1974"
     }

--- a/legislative/Q1492249/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1492249/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -18827,8 +18827,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -18853,8 +18853,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -18878,7 +18878,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Berthier"
+        "lang:fr": "Berthier"
       },
       "parent_id": "Q176"
     },
@@ -18902,7 +18902,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Roberval"
+        "lang:fr": "Roberval"
       },
       "parent_id": "Q176"
     },
@@ -18926,7 +18926,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Huntingdon"
+        "lang:fr": "Huntingdon"
       },
       "parent_id": "Q176"
     },
@@ -18950,7 +18950,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Rimouski"
+        "lang:fr": "Rimouski"
       },
       "parent_id": "Q176"
     },
@@ -18974,7 +18974,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Marguerite-Bourgeoys"
+        "lang:fr": "Marguerite-Bourgeoys"
       },
       "parent_id": "Q176"
     },
@@ -18998,7 +18998,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Abitibi-Est"
+        "lang:fr": "Abitibi-Est"
       },
       "parent_id": "Q176"
     },
@@ -19022,7 +19022,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Abitibi-Ouest"
+        "lang:fr": "Abitibi-Ouest"
       },
       "parent_id": "Q176"
     },
@@ -19046,7 +19046,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Acadie"
+        "lang:fr": "Acadie"
       },
       "parent_id": "Q176"
     },
@@ -19070,7 +19070,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Anjou–Louis-Riel"
+        "lang:fr": "Anjou–Louis-Riel"
       },
       "parent_id": "Q176"
     },
@@ -19094,7 +19094,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Argenteuil"
+        "lang:fr": "Argenteuil"
       },
       "parent_id": "Q176"
     },
@@ -19118,7 +19118,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Arthabaska"
+        "lang:fr": "Arthabaska"
       },
       "parent_id": "Q176"
     },
@@ -19142,7 +19142,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Lévis"
+        "lang:fr": "Lévis"
       },
       "parent_id": "Q176"
     },
@@ -19166,7 +19166,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Beauce-Nord"
+        "lang:fr": "Beauce-Nord"
       },
       "parent_id": "Q176"
     },
@@ -19190,7 +19190,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Beauce-Sud"
+        "lang:fr": "Beauce-Sud"
       },
       "parent_id": "Q176"
     },
@@ -19214,7 +19214,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Beauharnois"
+        "lang:fr": "Beauharnois"
       },
       "parent_id": "Q176"
     },
@@ -19238,7 +19238,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Bellechasse"
+        "lang:fr": "Bellechasse"
       },
       "parent_id": "Q176"
     },
@@ -19262,7 +19262,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Bertrand"
+        "lang:fr": "Bertrand"
       },
       "parent_id": "Q176"
     },
@@ -19286,7 +19286,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Blainville"
+        "lang:fr": "Blainville"
       },
       "parent_id": "Q176"
     },
@@ -19310,7 +19310,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Bonaventure"
+        "lang:fr": "Bonaventure"
       },
       "parent_id": "Q176"
     },
@@ -19334,7 +19334,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Borduas"
+        "lang:fr": "Borduas"
       },
       "parent_id": "Q176"
     },
@@ -19358,7 +19358,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Bourget"
+        "lang:fr": "Bourget"
       },
       "parent_id": "Q176"
     },
@@ -19382,7 +19382,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Brome-Missisquoi"
+        "lang:fr": "Brome-Missisquoi"
       },
       "parent_id": "Q176"
     },
@@ -19406,7 +19406,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Chambly"
+        "lang:fr": "Chambly"
       },
       "parent_id": "Q176"
     },
@@ -19430,7 +19430,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Champlain"
+        "lang:fr": "Champlain"
       },
       "parent_id": "Q176"
     },
@@ -19454,7 +19454,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Chapleau"
+        "lang:fr": "Chapleau"
       },
       "parent_id": "Q176"
     },
@@ -19478,7 +19478,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Charlesbourg"
+        "lang:fr": "Charlesbourg"
       },
       "parent_id": "Q176"
     },
@@ -19502,7 +19502,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Charlevoix–Côte-de-Beaupré"
+        "lang:fr": "Charlevoix–Côte-de-Beaupré"
       },
       "parent_id": "Q176"
     },
@@ -19526,7 +19526,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Chauveau"
+        "lang:fr": "Chauveau"
       },
       "parent_id": "Q176"
     },
@@ -19550,7 +19550,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Chicoutimi"
+        "lang:fr": "Chicoutimi"
       },
       "parent_id": "Q176"
     },
@@ -19574,7 +19574,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Chomedey"
+        "lang:fr": "Chomedey"
       },
       "parent_id": "Q176"
     },
@@ -19598,7 +19598,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Chutes-de-la-Chaudière"
+        "lang:fr": "Chutes-de-la-Chaudière"
       },
       "parent_id": "Q176"
     },
@@ -19622,7 +19622,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Châteauguay"
+        "lang:fr": "Châteauguay"
       },
       "parent_id": "Q176"
     },
@@ -19646,7 +19646,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Crémazie"
+        "lang:fr": "Crémazie"
       },
       "parent_id": "Q176"
     },
@@ -19670,7 +19670,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Côte-du-Sud"
+        "lang:fr": "Côte-du-Sud"
       },
       "parent_id": "Q176"
     },
@@ -19694,7 +19694,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "D'Arcy-McGee"
+        "lang:fr": "D'Arcy-McGee"
       },
       "parent_id": "Q176"
     },
@@ -19718,7 +19718,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Deux-Montagnes"
+        "lang:fr": "Deux-Montagnes"
       },
       "parent_id": "Q176"
     },
@@ -19742,7 +19742,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Drummond–Bois-Francs"
+        "lang:fr": "Drummond–Bois-Francs"
       },
       "parent_id": "Q176"
     },
@@ -19766,7 +19766,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Dubuc"
+        "lang:fr": "Dubuc"
       },
       "parent_id": "Q176"
     },
@@ -19790,7 +19790,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Duplessis"
+        "lang:fr": "Duplessis"
       },
       "parent_id": "Q176"
     },
@@ -19814,7 +19814,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Fabre"
+        "lang:fr": "Fabre"
       },
       "parent_id": "Q176"
     },
@@ -19838,7 +19838,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Montmorency"
+        "lang:fr": "Montmorency"
       },
       "parent_id": "Q176"
     },
@@ -19862,7 +19862,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Gaspé"
+        "lang:fr": "Gaspé"
       },
       "parent_id": "Q176"
     },
@@ -19886,7 +19886,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Gatineau"
+        "lang:fr": "Gatineau"
       },
       "parent_id": "Q176"
     },
@@ -19910,7 +19910,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Gouin"
+        "lang:fr": "Gouin"
       },
       "parent_id": "Q176"
     },
@@ -19934,7 +19934,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Granby"
+        "lang:fr": "Granby"
       },
       "parent_id": "Q176"
     },
@@ -19958,7 +19958,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Groulx"
+        "lang:fr": "Groulx"
       },
       "parent_id": "Q176"
     },
@@ -19982,7 +19982,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Hochelaga-Maisonneuve"
+        "lang:fr": "Hochelaga-Maisonneuve"
       },
       "parent_id": "Q176"
     },
@@ -20006,7 +20006,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Hull"
+        "lang:fr": "Hull"
       },
       "parent_id": "Q176"
     },
@@ -20030,7 +20030,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Jacques-Cartier"
+        "lang:fr": "Jacques-Cartier"
       },
       "parent_id": "Q176"
     },
@@ -20054,7 +20054,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Jean-Lesage"
+        "lang:fr": "Jean-Lesage"
       },
       "parent_id": "Q176"
     },
@@ -20078,7 +20078,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Jean-Talon"
+        "lang:fr": "Jean-Talon"
       },
       "parent_id": "Q176"
     },
@@ -20102,7 +20102,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Jeanne-Mance–Viger"
+        "lang:fr": "Jeanne-Mance–Viger"
       },
       "parent_id": "Q176"
     },
@@ -20126,7 +20126,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Johnson"
+        "lang:fr": "Johnson"
       },
       "parent_id": "Q176"
     },
@@ -20150,7 +20150,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Joliette"
+        "lang:fr": "Joliette"
       },
       "parent_id": "Q176"
     },
@@ -20174,7 +20174,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Jonquière"
+        "lang:fr": "Jonquière"
       },
       "parent_id": "Q176"
     },
@@ -20198,7 +20198,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "L'Assomption"
+        "lang:fr": "L'Assomption"
       },
       "parent_id": "Q176"
     },
@@ -20222,7 +20222,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "LaFontaine"
+        "lang:fr": "LaFontaine"
       },
       "parent_id": "Q176"
     },
@@ -20246,7 +20246,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "La Peltrie"
+        "lang:fr": "La Peltrie"
       },
       "parent_id": "Q176"
     },
@@ -20270,7 +20270,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "La Pinière"
+        "lang:fr": "La Pinière"
       },
       "parent_id": "Q176"
     },
@@ -20294,7 +20294,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "La Prairie"
+        "lang:fr": "La Prairie"
       },
       "parent_id": "Q176"
     },
@@ -20318,7 +20318,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Labelle"
+        "lang:fr": "Labelle"
       },
       "parent_id": "Q176"
     },
@@ -20342,7 +20342,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Lac-Saint-Jean"
+        "lang:fr": "Lac-Saint-Jean"
       },
       "parent_id": "Q176"
     },
@@ -20366,7 +20366,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Laporte"
+        "lang:fr": "Laporte"
       },
       "parent_id": "Q176"
     },
@@ -20390,7 +20390,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Laurier-Dorion"
+        "lang:fr": "Laurier-Dorion"
       },
       "parent_id": "Q176"
     },
@@ -20414,7 +20414,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Laval-des-Rapides"
+        "lang:fr": "Laval-des-Rapides"
       },
       "parent_id": "Q176"
     },
@@ -20438,7 +20438,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Laviolette"
+        "lang:fr": "Laviolette"
       },
       "parent_id": "Q176"
     },
@@ -20462,7 +20462,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Lotbinière-Frontenac"
+        "lang:fr": "Lotbinière-Frontenac"
       },
       "parent_id": "Q176"
     },
@@ -20486,7 +20486,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Louis-Hébert"
+        "lang:fr": "Louis-Hébert"
       },
       "parent_id": "Q176"
     },
@@ -20510,7 +20510,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Marie-Victorin"
+        "lang:fr": "Marie-Victorin"
       },
       "parent_id": "Q176"
     },
@@ -20534,7 +20534,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Marquette"
+        "lang:fr": "Marquette"
       },
       "parent_id": "Q176"
     },
@@ -20558,7 +20558,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Maskinongé"
+        "lang:fr": "Maskinongé"
       },
       "parent_id": "Q176"
     },
@@ -20582,7 +20582,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Masson"
+        "lang:fr": "Masson"
       },
       "parent_id": "Q176"
     },
@@ -20606,7 +20606,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Matane-Matapédia"
+        "lang:fr": "Matane-Matapédia"
       },
       "parent_id": "Q176"
     },
@@ -20630,7 +20630,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Mercier"
+        "lang:fr": "Mercier"
       },
       "parent_id": "Q176"
     },
@@ -20654,7 +20654,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Mille-Îles"
+        "lang:fr": "Mille-Îles"
       },
       "parent_id": "Q176"
     },
@@ -20678,7 +20678,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Mirabel"
+        "lang:fr": "Mirabel"
       },
       "parent_id": "Q176"
     },
@@ -20702,7 +20702,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Mont-Royal"
+        "lang:fr": "Mont-Royal"
       },
       "parent_id": "Q176"
     },
@@ -20726,7 +20726,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Montarville"
+        "lang:fr": "Montarville"
       },
       "parent_id": "Q176"
     },
@@ -20750,7 +20750,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Mégantic"
+        "lang:fr": "Mégantic"
       },
       "parent_id": "Q176"
     },
@@ -20774,7 +20774,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Nelligan"
+        "lang:fr": "Nelligan"
       },
       "parent_id": "Q176"
     },
@@ -20798,7 +20798,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Nicolet-Bécancour"
+        "lang:fr": "Nicolet-Bécancour"
       },
       "parent_id": "Q176"
     },
@@ -20822,7 +20822,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Notre-Dame-de-Grâce"
+        "lang:fr": "Notre-Dame-de-Grâce"
       },
       "parent_id": "Q176"
     },
@@ -20846,7 +20846,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Orford"
+        "lang:fr": "Orford"
       },
       "parent_id": "Q176"
     },
@@ -20870,7 +20870,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Outremont"
+        "lang:fr": "Outremont"
       },
       "parent_id": "Q176"
     },
@@ -20894,7 +20894,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Papineau"
+        "lang:fr": "Papineau"
       },
       "parent_id": "Q176"
     },
@@ -20918,7 +20918,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Pointe-aux-Trembles"
+        "lang:fr": "Pointe-aux-Trembles"
       },
       "parent_id": "Q176"
     },
@@ -20942,7 +20942,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Pontiac"
+        "lang:fr": "Pontiac"
       },
       "parent_id": "Q176"
     },
@@ -20966,7 +20966,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Portneuf"
+        "lang:fr": "Portneuf"
       },
       "parent_id": "Q176"
     },
@@ -20990,7 +20990,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "René-Lévesque"
+        "lang:fr": "René-Lévesque"
       },
       "parent_id": "Q176"
     },
@@ -21014,7 +21014,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Repentigny"
+        "lang:fr": "Repentigny"
       },
       "parent_id": "Q176"
     },
@@ -21038,7 +21038,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Richelieu"
+        "lang:fr": "Richelieu"
       },
       "parent_id": "Q176"
     },
@@ -21062,7 +21062,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Richmond"
+        "lang:fr": "Richmond"
       },
       "parent_id": "Q176"
     },
@@ -21086,7 +21086,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Rivière-du-Loup–Témiscouata"
+        "lang:fr": "Rivière-du-Loup–Témiscouata"
       },
       "parent_id": "Q176"
     },
@@ -21110,7 +21110,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Robert-Baldwin"
+        "lang:fr": "Robert-Baldwin"
       },
       "parent_id": "Q176"
     },
@@ -21134,7 +21134,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Rousseau"
+        "lang:fr": "Rousseau"
       },
       "parent_id": "Q176"
     },
@@ -21158,7 +21158,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Rouyn-Noranda–Témiscamingue"
+        "lang:fr": "Rouyn-Noranda–Témiscamingue"
       },
       "parent_id": "Q176"
     },
@@ -21182,7 +21182,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Saint-François"
+        "lang:fr": "Saint-François"
       },
       "parent_id": "Q176"
     },
@@ -21206,7 +21206,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Henri–Sainte-Anne"
+        "lang:fr": "Saint-Henri–Sainte-Anne"
       },
       "parent_id": "Q176"
     },
@@ -21230,7 +21230,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Hyacinthe"
+        "lang:fr": "Saint-Hyacinthe"
       },
       "parent_id": "Q176"
     },
@@ -21254,7 +21254,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Jean"
+        "lang:fr": "Saint-Jean"
       },
       "parent_id": "Q176"
     },
@@ -21278,7 +21278,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Jérôme"
+        "lang:fr": "Saint-Jérôme"
       },
       "parent_id": "Q176"
     },
@@ -21302,7 +21302,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Laurent"
+        "lang:fr": "Saint-Laurent"
       },
       "parent_id": "Q176"
     },
@@ -21326,7 +21326,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Maurice"
+        "lang:fr": "Saint-Maurice"
       },
       "parent_id": "Q176"
     },
@@ -21350,7 +21350,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Sainte-Marie–Saint-Jacques"
+        "lang:fr": "Sainte-Marie–Saint-Jacques"
       },
       "parent_id": "Q176"
     },
@@ -21374,7 +21374,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Sainte-Rose"
+        "lang:fr": "Sainte-Rose"
       },
       "parent_id": "Q176"
     },
@@ -21398,7 +21398,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Sanguinet"
+        "lang:fr": "Sanguinet"
       },
       "parent_id": "Q176"
     },
@@ -21422,7 +21422,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Sherbrooke"
+        "lang:fr": "Sherbrooke"
       },
       "parent_id": "Q176"
     },
@@ -21446,7 +21446,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Soulanges"
+        "lang:fr": "Soulanges"
       },
       "parent_id": "Q176"
     },
@@ -21470,7 +21470,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Taillon"
+        "lang:fr": "Taillon"
       },
       "parent_id": "Q176"
     },
@@ -21494,7 +21494,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Taschereau"
+        "lang:fr": "Taschereau"
       },
       "parent_id": "Q176"
     },
@@ -21518,7 +21518,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Terrebonne"
+        "lang:fr": "Terrebonne"
       },
       "parent_id": "Q176"
     },
@@ -21542,7 +21542,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Trois-Rivières"
+        "lang:fr": "Trois-Rivières"
       },
       "parent_id": "Q176"
     },
@@ -21566,7 +21566,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Ungava"
+        "lang:fr": "Ungava"
       },
       "parent_id": "Q176"
     },
@@ -21590,7 +21590,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Vachon"
+        "lang:fr": "Vachon"
       },
       "parent_id": "Q176"
     },
@@ -21614,7 +21614,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Vanier-Les Rivières"
+        "lang:fr": "Vanier-Les Rivières"
       },
       "parent_id": "Q176"
     },
@@ -21638,7 +21638,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Verchères"
+        "lang:fr": "Verchères"
       },
       "parent_id": "Q176"
     },
@@ -21662,7 +21662,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Verdun"
+        "lang:fr": "Verdun"
       },
       "parent_id": "Q176"
     },
@@ -21686,7 +21686,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Viau"
+        "lang:fr": "Viau"
       },
       "parent_id": "Q176"
     },
@@ -21710,7 +21710,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Vimont"
+        "lang:fr": "Vimont"
       },
       "parent_id": "Q176"
     },
@@ -21734,7 +21734,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Westmount–Saint-Louis"
+        "lang:fr": "Westmount–Saint-Louis"
       },
       "parent_id": "Q176"
     },
@@ -21758,7 +21758,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Îles-de-la-Madeleine"
+        "lang:fr": "Îles-de-la-Madeleine"
       },
       "parent_id": "Q176"
     },
@@ -21782,7 +21782,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Iberville"
+        "lang:fr": "Iberville"
       },
       "parent_id": "Q176"
     },
@@ -21806,7 +21806,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Bourassa-Sauvé"
+        "lang:fr": "Bourassa-Sauvé"
       },
       "parent_id": "Q176"
     },
@@ -21830,7 +21830,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Vaudreuil"
+        "lang:fr": "Vaudreuil"
       },
       "parent_id": "Q176"
     },
@@ -21854,7 +21854,7 @@
         "lang:fr": "circonscription électorale du Québec"
       },
       "name": {
-        "lang:fr_CA": "Rosemont"
+        "lang:fr": "Rosemont"
       },
       "parent_id": "Q176"
     }

--- a/legislative/Q1516914/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1516914/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -9401,8 +9401,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -9425,7 +9425,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Bathurst East-Nepisiguit-Saint-Isidore"
+        "lang:en": "Bathurst East-Nepisiguit-Saint-Isidore"
       },
       "parent_id": "Q1965"
     },
@@ -9448,7 +9448,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Campbellton-Dalhousie"
+        "lang:en": "Campbellton-Dalhousie"
       },
       "parent_id": "Q1965"
     },
@@ -9471,7 +9471,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Carleton"
+        "lang:en": "Carleton"
       },
       "parent_id": "Q1965"
     },
@@ -9494,7 +9494,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Bathurst West-Beresford"
+        "lang:en": "Bathurst West-Beresford"
       },
       "parent_id": "Q1965"
     },
@@ -9517,7 +9517,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Carleton-Victoria"
+        "lang:en": "Carleton-Victoria"
       },
       "parent_id": "Q1965"
     },
@@ -9540,7 +9540,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Fredericton South"
+        "lang:en": "Fredericton South"
       },
       "parent_id": "Q1965"
     },
@@ -9563,7 +9563,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Fredericton West-Hanwell"
+        "lang:en": "Fredericton West-Hanwell"
       },
       "parent_id": "Q1965"
     },
@@ -9586,7 +9586,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Fredericton-Grand Lake"
+        "lang:en": "Fredericton-Grand Lake"
       },
       "parent_id": "Q1965"
     },
@@ -9609,7 +9609,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Fredericton-York"
+        "lang:en": "Fredericton-York"
       },
       "parent_id": "Q1965"
     },
@@ -9632,7 +9632,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Gagetown-Petitcodiac"
+        "lang:en": "Gagetown-Petitcodiac"
       },
       "parent_id": "Q1965"
     },
@@ -9655,7 +9655,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Hampton"
+        "lang:en": "Hampton"
       },
       "parent_id": "Q1965"
     },
@@ -9678,7 +9678,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Kings Centre"
+        "lang:en": "Kings Centre"
       },
       "parent_id": "Q1965"
     },
@@ -9701,7 +9701,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Oromocto-Lincoln"
+        "lang:en": "Oromocto-Lincoln"
       },
       "parent_id": "Q1965"
     },
@@ -9724,7 +9724,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Carleton-York"
+        "lang:en": "Carleton-York"
       },
       "parent_id": "Q1965"
     },
@@ -9747,7 +9747,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Miramichi"
+        "lang:en": "Miramichi"
       },
       "parent_id": "Q1965"
     },
@@ -9770,7 +9770,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Moncton Centre"
+        "lang:en": "Moncton Centre"
       },
       "parent_id": "Q1965"
     },
@@ -9793,7 +9793,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Moncton East"
+        "lang:en": "Moncton East"
       },
       "parent_id": "Q1965"
     },
@@ -9816,7 +9816,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Moncton Southwest"
+        "lang:en": "Moncton Southwest"
       },
       "parent_id": "Q1965"
     },
@@ -9839,7 +9839,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Shediac Bay-Dieppe"
+        "lang:en": "Shediac Bay-Dieppe"
       },
       "parent_id": "Q1965"
     },
@@ -9864,8 +9864,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -9888,7 +9888,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "New Maryland-Sunbury"
+        "lang:en": "New Maryland-Sunbury"
       },
       "parent_id": "Q1965"
     },
@@ -9911,7 +9911,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Albert"
+        "lang:en": "Albert"
       },
       "parent_id": "Q1965"
     },
@@ -9934,7 +9934,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Miramichi Bay-Neguac"
+        "lang:en": "Miramichi Bay-Neguac"
       },
       "parent_id": "Q1965"
     },
@@ -9957,7 +9957,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Caraquet"
+        "lang:en": "Caraquet"
       },
       "parent_id": "Q1965"
     },
@@ -9980,7 +9980,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Charlotte-Campobello"
+        "lang:en": "Charlotte-Campobello"
       },
       "parent_id": "Q1965"
     },
@@ -10003,7 +10003,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Fundy-The Isles-Saint John West"
+        "lang:en": "Fundy-The Isles-Saint John West"
       },
       "parent_id": "Q1965"
     },
@@ -10026,7 +10026,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Dieppe"
+        "lang:en": "Dieppe"
       },
       "parent_id": "Q1965"
     },
@@ -10049,7 +10049,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Edmundston-Madawaska Centre"
+        "lang:en": "Edmundston-Madawaska Centre"
       },
       "parent_id": "Q1965"
     },
@@ -10072,7 +10072,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Victoria-La Valle"
+        "lang:en": "Victoria-La Valle"
       },
       "parent_id": "Q1965"
     },
@@ -10095,7 +10095,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Kent South"
+        "lang:en": "Kent South"
       },
       "parent_id": "Q1965"
     },
@@ -10118,7 +10118,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Sussex-Fundy-St. Martins"
+        "lang:en": "Sussex-Fundy-St. Martins"
       },
       "parent_id": "Q1965"
     },
@@ -10141,7 +10141,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Shippagan-Lamque-Miscou"
+        "lang:en": "Shippagan-Lamque-Miscou"
       },
       "parent_id": "Q1965"
     },
@@ -10164,7 +10164,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Madawaska Les Lacs-Edmundston"
+        "lang:en": "Madawaska Les Lacs-Edmundston"
       },
       "parent_id": "Q1965"
     },
@@ -10187,7 +10187,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Southwest Miramichi-Bay du Vin"
+        "lang:en": "Southwest Miramichi-Bay du Vin"
       },
       "parent_id": "Q1965"
     },
@@ -10210,7 +10210,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Restigouche-Chaleur"
+        "lang:en": "Restigouche-Chaleur"
       },
       "parent_id": "Q1965"
     },
@@ -10233,7 +10233,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Riverview"
+        "lang:en": "Riverview"
       },
       "parent_id": "Q1965"
     },
@@ -10256,7 +10256,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Kent North"
+        "lang:en": "Kent North"
       },
       "parent_id": "Q1965"
     },
@@ -10279,7 +10279,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Rothesay"
+        "lang:en": "Rothesay"
       },
       "parent_id": "Q1965"
     },
@@ -10302,7 +10302,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Saint John East"
+        "lang:en": "Saint John East"
       },
       "parent_id": "Q1965"
     },
@@ -10325,7 +10325,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Saint John Harbour"
+        "lang:en": "Saint John Harbour"
       },
       "parent_id": "Q1965"
     },
@@ -10348,7 +10348,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Saint John Lancaster"
+        "lang:en": "Saint John Lancaster"
       },
       "parent_id": "Q1965"
     },
@@ -10371,7 +10371,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Portland-Simonds"
+        "lang:en": "Portland-Simonds"
       },
       "parent_id": "Q1965"
     },
@@ -10394,7 +10394,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Shediac-Beaubassin-Cap-Pel"
+        "lang:en": "Shediac-Beaubassin-Cap-Pel"
       },
       "parent_id": "Q1965"
     },
@@ -10417,7 +10417,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Memramcook-Tantramar"
+        "lang:en": "Memramcook-Tantramar"
       },
       "parent_id": "Q1965"
     },
@@ -10440,7 +10440,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Tracadie-Sheila"
+        "lang:en": "Tracadie-Sheila"
       },
       "parent_id": "Q1965"
     },
@@ -10463,7 +10463,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Moncton South"
+        "lang:en": "Moncton South"
       },
       "parent_id": "Q1965"
     },
@@ -10486,7 +10486,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Moncton Northwest"
+        "lang:en": "Moncton Northwest"
       },
       "parent_id": "Q1965"
     },
@@ -10509,7 +10509,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Fredericton North"
+        "lang:en": "Fredericton North"
       },
       "parent_id": "Q1965"
     },
@@ -10532,7 +10532,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Restigouche West"
+        "lang:en": "Restigouche West"
       },
       "parent_id": "Q1965"
     },
@@ -10555,7 +10555,7 @@
         "lang:en": "provincial electoral district of New Brunswick"
       },
       "name": {
-        "lang:en_CA": "Quispamsis"
+        "lang:en": "Quispamsis"
       },
       "parent_id": "Q1965"
     }

--- a/legislative/Q1517320/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1517320/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -503,8 +503,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -529,7 +529,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -552,7 +552,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Southdale"
+        "lang:en": "Southdale"
       },
       "parent_id": "Q1948"
     },
@@ -575,7 +575,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Riel"
+        "lang:en": "Riel"
       },
       "parent_id": "Q1948"
     },
@@ -598,7 +598,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Agassiz"
+        "lang:en": "Agassiz"
       },
       "parent_id": "Q1948"
     },
@@ -621,7 +621,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Assiniboia"
+        "lang:en": "Assiniboia"
       },
       "parent_id": "Q1948"
     },
@@ -644,7 +644,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Arthur-Virden"
+        "lang:en": "Arthur-Virden"
       },
       "parent_id": "Q1948"
     },
@@ -667,7 +667,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Brandon East"
+        "lang:en": "Brandon East"
       },
       "parent_id": "Q1948"
     },
@@ -690,7 +690,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Brandon West"
+        "lang:en": "Brandon West"
       },
       "parent_id": "Q1948"
     },
@@ -713,7 +713,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Burrows"
+        "lang:en": "Burrows"
       },
       "parent_id": "Q1948"
     },
@@ -736,7 +736,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Charleswood"
+        "lang:en": "Charleswood"
       },
       "parent_id": "Q1948"
     },
@@ -759,7 +759,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Dawson Trail"
+        "lang:en": "Dawson Trail"
       },
       "parent_id": "Q1948"
     },
@@ -782,7 +782,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Concordia"
+        "lang:en": "Concordia"
       },
       "parent_id": "Q1948"
     },
@@ -805,7 +805,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Dauphin"
+        "lang:en": "Dauphin"
       },
       "parent_id": "Q1948"
     },
@@ -828,7 +828,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Elmwood"
+        "lang:en": "Elmwood"
       },
       "parent_id": "Q1948"
     },
@@ -851,7 +851,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Emerson"
+        "lang:en": "Emerson"
       },
       "parent_id": "Q1948"
     },
@@ -874,7 +874,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Interlake"
+        "lang:en": "Interlake"
       },
       "parent_id": "Q1948"
     },
@@ -897,7 +897,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Flin Flon"
+        "lang:en": "Flin Flon"
       },
       "parent_id": "Q1948"
     },
@@ -920,7 +920,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Fort Garry-Riverview"
+        "lang:en": "Fort Garry-Riverview"
       },
       "parent_id": "Q1948"
     },
@@ -943,7 +943,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Fort Richmond"
+        "lang:en": "Fort Richmond"
       },
       "parent_id": "Q1948"
     },
@@ -966,7 +966,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Fort Rouge"
+        "lang:en": "Fort Rouge"
       },
       "parent_id": "Q1948"
     },
@@ -989,7 +989,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Fort Whyte"
+        "lang:en": "Fort Whyte"
       },
       "parent_id": "Q1948"
     },
@@ -1012,7 +1012,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Gimli"
+        "lang:en": "Gimli"
       },
       "parent_id": "Q1948"
     },
@@ -1035,7 +1035,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Kewatinook"
+        "lang:en": "Kewatinook"
       },
       "parent_id": "Q1948"
     },
@@ -1058,7 +1058,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Kildonan"
+        "lang:en": "Kildonan"
       },
       "parent_id": "Q1948"
     },
@@ -1081,7 +1081,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Kirkfield Park"
+        "lang:en": "Kirkfield Park"
       },
       "parent_id": "Q1948"
     },
@@ -1104,7 +1104,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "La Verendrye"
+        "lang:en": "La Verendrye"
       },
       "parent_id": "Q1948"
     },
@@ -1127,7 +1127,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Lac du Bonnet"
+        "lang:en": "Lac du Bonnet"
       },
       "parent_id": "Q1948"
     },
@@ -1150,7 +1150,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Lakeside"
+        "lang:en": "Lakeside"
       },
       "parent_id": "Q1948"
     },
@@ -1173,7 +1173,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "The Pas"
+        "lang:en": "The Pas"
       },
       "parent_id": "Q1948"
     },
@@ -1196,7 +1196,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Logan"
+        "lang:en": "Logan"
       },
       "parent_id": "Q1948"
     },
@@ -1219,7 +1219,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Minto"
+        "lang:en": "Minto"
       },
       "parent_id": "Q1948"
     },
@@ -1242,7 +1242,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Riding Mountain"
+        "lang:en": "Riding Mountain"
       },
       "parent_id": "Q1948"
     },
@@ -1265,7 +1265,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Morden-Winkler"
+        "lang:en": "Morden-Winkler"
       },
       "parent_id": "Q1948"
     },
@@ -1288,7 +1288,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Morris"
+        "lang:en": "Morris"
       },
       "parent_id": "Q1948"
     },
@@ -1311,7 +1311,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Point Douglas"
+        "lang:en": "Point Douglas"
       },
       "parent_id": "Q1948"
     },
@@ -1334,7 +1334,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Portage La Prairie"
+        "lang:en": "Portage La Prairie"
       },
       "parent_id": "Q1948"
     },
@@ -1357,7 +1357,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Radisson"
+        "lang:en": "Radisson"
       },
       "parent_id": "Q1948"
     },
@@ -1380,7 +1380,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "River East"
+        "lang:en": "River East"
       },
       "parent_id": "Q1948"
     },
@@ -1403,7 +1403,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "River Heights"
+        "lang:en": "River Heights"
       },
       "parent_id": "Q1948"
     },
@@ -1426,7 +1426,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Seine River"
+        "lang:en": "Seine River"
       },
       "parent_id": "Q1948"
     },
@@ -1449,7 +1449,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "St. Boniface"
+        "lang:en": "St. Boniface"
       },
       "parent_id": "Q1948"
     },
@@ -1472,7 +1472,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "St. Norbert"
+        "lang:en": "St. Norbert"
       },
       "parent_id": "Q1948"
     },
@@ -1495,7 +1495,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "St. Paul"
+        "lang:en": "St. Paul"
       },
       "parent_id": "Q1948"
     },
@@ -1518,7 +1518,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "St. Vital"
+        "lang:en": "St. Vital"
       },
       "parent_id": "Q1948"
     },
@@ -1541,7 +1541,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "St. James"
+        "lang:en": "St. James"
       },
       "parent_id": "Q1948"
     },
@@ -1564,7 +1564,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "St. Johns"
+        "lang:en": "St. Johns"
       },
       "parent_id": "Q1948"
     },
@@ -1587,7 +1587,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Selkirk"
+        "lang:en": "Selkirk"
       },
       "parent_id": "Q1948"
     },
@@ -1610,7 +1610,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Steinbach"
+        "lang:en": "Steinbach"
       },
       "parent_id": "Q1948"
     },
@@ -1633,7 +1633,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Swan River"
+        "lang:en": "Swan River"
       },
       "parent_id": "Q1948"
     },
@@ -1656,7 +1656,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "The Maples"
+        "lang:en": "The Maples"
       },
       "parent_id": "Q1948"
     },
@@ -1679,7 +1679,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Thompson"
+        "lang:en": "Thompson"
       },
       "parent_id": "Q1948"
     },
@@ -1702,7 +1702,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Transcona"
+        "lang:en": "Transcona"
       },
       "parent_id": "Q1948"
     },
@@ -1725,7 +1725,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Tuxedo"
+        "lang:en": "Tuxedo"
       },
       "parent_id": "Q1948"
     },
@@ -1748,7 +1748,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Tyndall Park"
+        "lang:en": "Tyndall Park"
       },
       "parent_id": "Q1948"
     },
@@ -1771,7 +1771,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Wolseley"
+        "lang:en": "Wolseley"
       },
       "parent_id": "Q1948"
     },
@@ -1794,7 +1794,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Midland"
+        "lang:en": "Midland"
       },
       "parent_id": "Q1948"
     },
@@ -1817,7 +1817,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Spruce Woods"
+        "lang:en": "Spruce Woods"
       },
       "parent_id": "Q1948"
     },
@@ -1840,7 +1840,7 @@
         "lang:en": "provincial electoral district of Manitoba"
       },
       "name": {
-        "lang:en_CA": "Rossmere"
+        "lang:en": "Rossmere"
       },
       "parent_id": "Q1948"
     }

--- a/legislative/Q1537375/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1537375/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -9918,7 +9918,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Moose Jaw North"
+        "lang:en": "Moose Jaw North"
       },
       "parent_id": "Q1989"
     },
@@ -9941,7 +9941,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Rosetown-Elrose"
+        "lang:en": "Rosetown-Elrose"
       },
       "parent_id": "Q1989"
     },
@@ -9964,7 +9964,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Wood River (electoral district)"
+        "lang:en": "Wood River (electoral district)"
       },
       "parent_id": "Q1989"
     },
@@ -9988,8 +9988,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -10014,8 +10014,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -10038,7 +10038,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Walsh Acres"
+        "lang:en": "Regina Walsh Acres"
       },
       "parent_id": "Q1989"
     },
@@ -10061,7 +10061,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Biggar-Sask Valley"
+        "lang:en": "Biggar-Sask Valley"
       },
       "parent_id": "Q1989"
     },
@@ -10084,7 +10084,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Humboldt-Watrous"
+        "lang:en": "Humboldt-Watrous"
       },
       "parent_id": "Q1989"
     },
@@ -10107,7 +10107,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Martensville-Warman"
+        "lang:en": "Martensville-Warman"
       },
       "parent_id": "Q1989"
     },
@@ -10130,7 +10130,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Lumsden-Morse"
+        "lang:en": "Lumsden-Morse"
       },
       "parent_id": "Q1989"
     },
@@ -10153,7 +10153,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Churchill-Wildwood"
+        "lang:en": "Saskatoon Churchill-Wildwood"
       },
       "parent_id": "Q1989"
     },
@@ -10176,7 +10176,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Silverspring-Sutherland"
+        "lang:en": "Saskatoon Silverspring-Sutherland"
       },
       "parent_id": "Q1989"
     },
@@ -10199,7 +10199,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Stonebridge-Dakota"
+        "lang:en": "Saskatoon Stonebridge-Dakota"
       },
       "parent_id": "Q1989"
     },
@@ -10222,7 +10222,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Westview"
+        "lang:en": "Saskatoon Westview"
       },
       "parent_id": "Q1989"
     },
@@ -10245,7 +10245,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Willowgrove"
+        "lang:en": "Saskatoon Willowgrove"
       },
       "parent_id": "Q1989"
     },
@@ -10268,7 +10268,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Gardiner Park"
+        "lang:en": "Regina Gardiner Park"
       },
       "parent_id": "Q1989"
     },
@@ -10291,7 +10291,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Pasqua"
+        "lang:en": "Regina Pasqua"
       },
       "parent_id": "Q1989"
     },
@@ -10314,7 +10314,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Rochdale"
+        "lang:en": "Regina Rochdale"
       },
       "parent_id": "Q1989"
     },
@@ -10337,7 +10337,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina University"
+        "lang:en": "Regina University"
       },
       "parent_id": "Q1989"
     },
@@ -10360,7 +10360,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Meadow Lake"
+        "lang:en": "Meadow Lake"
       },
       "parent_id": "Q1989"
     },
@@ -10383,7 +10383,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Last Mountain-Touchwood"
+        "lang:en": "Last Mountain-Touchwood"
       },
       "parent_id": "Q1989"
     },
@@ -10406,7 +10406,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Melfort"
+        "lang:en": "Melfort"
       },
       "parent_id": "Q1989"
     },
@@ -10429,7 +10429,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Moose Jaw Wakamow"
+        "lang:en": "Moose Jaw Wakamow"
       },
       "parent_id": "Q1989"
     },
@@ -10452,7 +10452,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Coronation Park"
+        "lang:en": "Regina Coronation Park"
       },
       "parent_id": "Q1989"
     },
@@ -10475,7 +10475,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Douglas Park"
+        "lang:en": "Regina Douglas Park"
       },
       "parent_id": "Q1989"
     },
@@ -10498,7 +10498,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Prince Albert Northcote"
+        "lang:en": "Prince Albert Northcote"
       },
       "parent_id": "Q1989"
     },
@@ -10521,7 +10521,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Lakeview"
+        "lang:en": "Regina Lakeview"
       },
       "parent_id": "Q1989"
     },
@@ -10544,7 +10544,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Rosemont"
+        "lang:en": "Regina Rosemont"
       },
       "parent_id": "Q1989"
     },
@@ -10567,7 +10567,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Centre"
+        "lang:en": "Saskatoon Centre"
       },
       "parent_id": "Q1989"
     },
@@ -10590,7 +10590,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Fairview"
+        "lang:en": "Saskatoon Fairview"
       },
       "parent_id": "Q1989"
     },
@@ -10613,7 +10613,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Meewasin"
+        "lang:en": "Saskatoon Meewasin"
       },
       "parent_id": "Q1989"
     },
@@ -10636,7 +10636,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Arm River"
+        "lang:en": "Arm River"
       },
       "parent_id": "Q1989"
     },
@@ -10659,7 +10659,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Athabasca"
+        "lang:en": "Athabasca"
       },
       "parent_id": "Q1989"
     },
@@ -10682,7 +10682,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Batoche"
+        "lang:en": "Batoche"
       },
       "parent_id": "Q1989"
     },
@@ -10705,7 +10705,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Cannington"
+        "lang:en": "Cannington"
       },
       "parent_id": "Q1989"
     },
@@ -10728,7 +10728,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Canora-Pelly"
+        "lang:en": "Canora-Pelly"
       },
       "parent_id": "Q1989"
     },
@@ -10751,7 +10751,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Carrot River Valley"
+        "lang:en": "Carrot River Valley"
       },
       "parent_id": "Q1989"
     },
@@ -10774,7 +10774,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Cumberland"
+        "lang:en": "Cumberland"
       },
       "parent_id": "Q1989"
     },
@@ -10797,7 +10797,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Cut Knife-Turtleford"
+        "lang:en": "Cut Knife-Turtleford"
       },
       "parent_id": "Q1989"
     },
@@ -10820,7 +10820,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Cypress Hills"
+        "lang:en": "Cypress Hills"
       },
       "parent_id": "Q1989"
     },
@@ -10843,7 +10843,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Estevan"
+        "lang:en": "Estevan"
       },
       "parent_id": "Q1989"
     },
@@ -10866,7 +10866,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Indian Head-Milestone"
+        "lang:en": "Indian Head-Milestone"
       },
       "parent_id": "Q1989"
     },
@@ -10889,7 +10889,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Kelvington-Wadena"
+        "lang:en": "Kelvington-Wadena"
       },
       "parent_id": "Q1989"
     },
@@ -10912,7 +10912,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Kindersley"
+        "lang:en": "Kindersley"
       },
       "parent_id": "Q1989"
     },
@@ -10935,7 +10935,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Lloydminster"
+        "lang:en": "Lloydminster"
       },
       "parent_id": "Q1989"
     },
@@ -10958,7 +10958,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Melville-Saltcoats"
+        "lang:en": "Melville-Saltcoats"
       },
       "parent_id": "Q1989"
     },
@@ -10981,7 +10981,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Moosomin"
+        "lang:en": "Moosomin"
       },
       "parent_id": "Q1989"
     },
@@ -11004,7 +11004,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Elphinstone-Centre"
+        "lang:en": "Regina Elphinstone-Centre"
       },
       "parent_id": "Q1989"
     },
@@ -11027,7 +11027,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Northeast"
+        "lang:en": "Regina Northeast"
       },
       "parent_id": "Q1989"
     },
@@ -11050,7 +11050,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Regina Wascana Plains"
+        "lang:en": "Regina Wascana Plains"
       },
       "parent_id": "Q1989"
     },
@@ -11073,7 +11073,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Rosthern-Shellbrook"
+        "lang:en": "Rosthern-Shellbrook"
       },
       "parent_id": "Q1989"
     },
@@ -11096,7 +11096,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan Rivers"
+        "lang:en": "Saskatchewan Rivers"
       },
       "parent_id": "Q1989"
     },
@@ -11119,7 +11119,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Eastview"
+        "lang:en": "Saskatoon Eastview"
       },
       "parent_id": "Q1989"
     },
@@ -11142,7 +11142,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Northwest"
+        "lang:en": "Saskatoon Northwest"
       },
       "parent_id": "Q1989"
     },
@@ -11165,7 +11165,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Nutana"
+        "lang:en": "Saskatoon Nutana"
       },
       "parent_id": "Q1989"
     },
@@ -11188,7 +11188,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Riversdale"
+        "lang:en": "Saskatoon Riversdale"
       },
       "parent_id": "Q1989"
     },
@@ -11211,7 +11211,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon Southeast"
+        "lang:en": "Saskatoon Southeast"
       },
       "parent_id": "Q1989"
     },
@@ -11234,7 +11234,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Saskatoon University"
+        "lang:en": "Saskatoon University"
       },
       "parent_id": "Q1989"
     },
@@ -11257,7 +11257,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Swift Current"
+        "lang:en": "Swift Current"
       },
       "parent_id": "Q1989"
     },
@@ -11280,7 +11280,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "The Battlefords"
+        "lang:en": "The Battlefords"
       },
       "parent_id": "Q1989"
     },
@@ -11303,7 +11303,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Weyburn-Big Muddy"
+        "lang:en": "Weyburn-Big Muddy"
       },
       "parent_id": "Q1989"
     },
@@ -11326,7 +11326,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Yorkton"
+        "lang:en": "Yorkton"
       },
       "parent_id": "Q1989"
     },
@@ -11349,7 +11349,7 @@
         "lang:en": "provincial electoral district of Saskatchewan"
       },
       "name": {
-        "lang:en_CA": "Prince Albert Carlton"
+        "lang:en": "Prince Albert Carlton"
       },
       "parent_id": "Q1989"
     }

--- a/legislative/Q17107607/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q17107607/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -77,7 +77,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Halifax"
+        "lang:en": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -100,7 +100,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Waverley - Fall River - Musquodoboit Valley"
+        "lang:en": "Waverley - Fall River - Musquodoboit Valley"
       },
       "parent_id": "Q2141"
     },
@@ -123,7 +123,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Preston - Chezzetcook - Eastern Shore"
+        "lang:en": "Preston - Chezzetcook - Eastern Shore"
       },
       "parent_id": "Q2141"
     },
@@ -146,7 +146,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Dartmouth South - Eastern Passage"
+        "lang:en": "Dartmouth South - Eastern Passage"
       },
       "parent_id": "Q2141"
     },
@@ -169,7 +169,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Cole Harbour - Westphal"
+        "lang:en": "Cole Harbour - Westphal"
       },
       "parent_id": "Q2141"
     },
@@ -192,7 +192,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Dartmouth Centre"
+        "lang:en": "Dartmouth Centre"
       },
       "parent_id": "Q2141"
     },
@@ -215,7 +215,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Harbourview - Burnside - Dartmouth East"
+        "lang:en": "Harbourview - Burnside - Dartmouth East"
       },
       "parent_id": "Q2141"
     },
@@ -238,7 +238,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Halifax South Downtown"
+        "lang:en": "Halifax South Downtown"
       },
       "parent_id": "Q2141"
     },
@@ -261,7 +261,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Halifax Peninsula North"
+        "lang:en": "Halifax Peninsula North"
       },
       "parent_id": "Q2141"
     },
@@ -284,7 +284,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Halifax West Armdale"
+        "lang:en": "Halifax West Armdale"
       },
       "parent_id": "Q2141"
     },
@@ -307,7 +307,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Halifax - Bedford Basin West"
+        "lang:en": "Halifax - Bedford Basin West"
       },
       "parent_id": "Q2141"
     },
@@ -330,7 +330,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Spryfield - Sambro Loop - Prospect Road"
+        "lang:en": "Spryfield - Sambro Loop - Prospect Road"
       },
       "parent_id": "Q2141"
     },
@@ -353,7 +353,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Timberlea - Beechville - Clayton Park - Wedgewood"
+        "lang:en": "Timberlea - Beechville - Clayton Park - Wedgewood"
       },
       "parent_id": "Q2141"
     },
@@ -376,7 +376,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Hammonds Plains - St. Margarets"
+        "lang:en": "Hammonds Plains - St. Margarets"
       },
       "parent_id": "Q2141"
     },
@@ -399,7 +399,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Middle/Upper Sackville - Beaver Bank - Lucasville"
+        "lang:en": "Middle/Upper Sackville - Beaver Bank - Lucasville"
       },
       "parent_id": "Q2141"
     },
@@ -422,7 +422,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Lower Sackville"
+        "lang:en": "Lower Sackville"
       },
       "parent_id": "Q2141"
     },
@@ -445,7 +445,7 @@
         "lang:en": "municipal electoral district of Halifax"
       },
       "name": {
-        "lang:en_CA": "Bedford - Wentworth"
+        "lang:en": "Bedford - Wentworth"
       },
       "parent_id": "Q2141"
     }

--- a/legislative/Q1809086/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1809086/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -22997,7 +22997,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Scarborough—Guildwood"
+        "lang:en": "Scarborough—Guildwood"
       },
       "parent_id": "Q1904"
     },
@@ -23021,7 +23021,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Haldimand—Norfolk"
+        "lang:en": "Haldimand—Norfolk"
       },
       "parent_id": "Q1904"
     },
@@ -23045,7 +23045,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Hamilton Centre"
+        "lang:en": "Hamilton Centre"
       },
       "parent_id": "Q1904"
     },
@@ -23069,7 +23069,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Hamilton East—Stoney Creek"
+        "lang:en": "Hamilton East—Stoney Creek"
       },
       "parent_id": "Q1904"
     },
@@ -23093,7 +23093,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Huron—Bruce"
+        "lang:en": "Huron—Bruce"
       },
       "parent_id": "Q1904"
     },
@@ -23117,7 +23117,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Lanark—Frontenac—Lennox and Addington"
+        "lang:en": "Lanark—Frontenac—Lennox and Addington"
       },
       "parent_id": "Q1904"
     },
@@ -23141,7 +23141,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "London North Centre"
+        "lang:en": "London North Centre"
       },
       "parent_id": "Q1904"
     },
@@ -23165,7 +23165,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "London West"
+        "lang:en": "London West"
       },
       "parent_id": "Q1904"
     },
@@ -23189,7 +23189,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Mississauga East—Cooksville"
+        "lang:en": "Mississauga East—Cooksville"
       },
       "parent_id": "Q1904"
     },
@@ -23213,7 +23213,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Mississauga South"
+        "lang:en": "Mississauga South"
       },
       "parent_id": "Q1904"
     },
@@ -23237,7 +23237,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Mississauga—Brampton South"
+        "lang:en": "Mississauga—Brampton South"
       },
       "parent_id": "Q1904"
     },
@@ -23261,7 +23261,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Mississauga—Erindale"
+        "lang:en": "Mississauga—Erindale"
       },
       "parent_id": "Q1904"
     },
@@ -23285,7 +23285,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Mississauga—Streetsville"
+        "lang:en": "Mississauga—Streetsville"
       },
       "parent_id": "Q1904"
     },
@@ -23309,7 +23309,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Newmarket—Aurora"
+        "lang:en": "Newmarket—Aurora"
       },
       "parent_id": "Q1904"
     },
@@ -23333,7 +23333,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Oak Ridges—Markham"
+        "lang:en": "Oak Ridges—Markham"
       },
       "parent_id": "Q1904"
     },
@@ -23357,7 +23357,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Oshawa"
+        "lang:en": "Oshawa"
       },
       "parent_id": "Q1904"
     },
@@ -23381,7 +23381,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Perth—Wellington"
+        "lang:en": "Perth—Wellington"
       },
       "parent_id": "Q1904"
     },
@@ -23405,7 +23405,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Peterborough"
+        "lang:en": "Peterborough"
       },
       "parent_id": "Q1904"
     },
@@ -23429,7 +23429,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Pickering—Scarborough East"
+        "lang:en": "Pickering—Scarborough East"
       },
       "parent_id": "Q1904"
     },
@@ -23453,7 +23453,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Prince Edward—Hastings"
+        "lang:en": "Prince Edward—Hastings"
       },
       "parent_id": "Q1904"
     },
@@ -23477,7 +23477,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Renfrew—Nipissing—Pembroke"
+        "lang:en": "Renfrew—Nipissing—Pembroke"
       },
       "parent_id": "Q1904"
     },
@@ -23501,7 +23501,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Richmond Hill"
+        "lang:en": "Richmond Hill"
       },
       "parent_id": "Q1904"
     },
@@ -23525,7 +23525,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Scarborough Centre"
+        "lang:en": "Scarborough Centre"
       },
       "parent_id": "Q1904"
     },
@@ -23549,7 +23549,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Scarborough Southwest"
+        "lang:en": "Scarborough Southwest"
       },
       "parent_id": "Q1904"
     },
@@ -23573,7 +23573,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Scarborough—Agincourt"
+        "lang:en": "Scarborough—Agincourt"
       },
       "parent_id": "Q1904"
     },
@@ -23597,7 +23597,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Scarborough—Rouge River"
+        "lang:en": "Scarborough—Rouge River"
       },
       "parent_id": "Q1904"
     },
@@ -23621,7 +23621,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Simcoe North"
+        "lang:en": "Simcoe North"
       },
       "parent_id": "Q1904"
     },
@@ -23645,7 +23645,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Simcoe—Grey"
+        "lang:en": "Simcoe—Grey"
       },
       "parent_id": "Q1904"
     },
@@ -23669,7 +23669,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "St. Catharines"
+        "lang:en": "St. Catharines"
       },
       "parent_id": "Q1904"
     },
@@ -23693,7 +23693,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Thornhill"
+        "lang:en": "Thornhill"
       },
       "parent_id": "Q1904"
     },
@@ -23717,7 +23717,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Toronto—Danforth"
+        "lang:en": "Toronto—Danforth"
       },
       "parent_id": "Q1904"
     },
@@ -23741,7 +23741,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Trinity—Spadina"
+        "lang:en": "Trinity—Spadina"
       },
       "parent_id": "Q1904"
     },
@@ -23765,7 +23765,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Welland"
+        "lang:en": "Welland"
       },
       "parent_id": "Q1904"
     },
@@ -23789,7 +23789,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Whitby—Oshawa"
+        "lang:en": "Whitby—Oshawa"
       },
       "parent_id": "Q1904"
     },
@@ -23813,7 +23813,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Windsor West"
+        "lang:en": "Windsor West"
       },
       "parent_id": "Q1904"
     },
@@ -23837,7 +23837,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Windsor—Tecumseh"
+        "lang:en": "Windsor—Tecumseh"
       },
       "parent_id": "Q1904"
     },
@@ -23861,7 +23861,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "York Centre"
+        "lang:en": "York Centre"
       },
       "parent_id": "Q1904"
     },
@@ -23885,7 +23885,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "York South—Weston"
+        "lang:en": "York South—Weston"
       },
       "parent_id": "Q1904"
     },
@@ -23909,7 +23909,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "York West"
+        "lang:en": "York West"
       },
       "parent_id": "Q1904"
     },
@@ -23933,7 +23933,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "York—Simcoe"
+        "lang:en": "York—Simcoe"
       },
       "parent_id": "Q1904"
     },
@@ -23957,8 +23957,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -23982,7 +23982,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Hamilton Mountain"
+        "lang:en": "Hamilton Mountain"
       },
       "parent_id": "Q1904"
     },
@@ -24006,7 +24006,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Kingston and the Islands"
+        "lang:en": "Kingston and the Islands"
       },
       "parent_id": "Q1904"
     },
@@ -24030,7 +24030,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Kitchener—Conestoga"
+        "lang:en": "Kitchener—Conestoga"
       },
       "parent_id": "Q1904"
     },
@@ -24054,7 +24054,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "London—Fanshawe"
+        "lang:en": "London—Fanshawe"
       },
       "parent_id": "Q1904"
     },
@@ -24078,7 +24078,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Markham—Unionville"
+        "lang:en": "Markham—Unionville"
       },
       "parent_id": "Q1904"
     },
@@ -24102,7 +24102,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Northumberland—Quinte West"
+        "lang:en": "Northumberland—Quinte West"
       },
       "parent_id": "Q1904"
     },
@@ -24126,7 +24126,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Oxford"
+        "lang:en": "Oxford"
       },
       "parent_id": "Q1904"
     },
@@ -24150,7 +24150,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Timmins—James Bay"
+        "lang:en": "Timmins—James Bay"
       },
       "parent_id": "Q1904"
     },
@@ -24175,7 +24175,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -24199,7 +24199,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Niagara West—Glanbrook"
+        "lang:en": "Niagara West—Glanbrook"
       },
       "parent_id": "Q1904"
     },
@@ -24223,7 +24223,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Oakville"
+        "lang:en": "Oakville"
       },
       "parent_id": "Q1904"
     },
@@ -24247,7 +24247,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Glengarry—Prescott—Russell"
+        "lang:en": "Glengarry—Prescott—Russell"
       },
       "parent_id": "Q1904"
     },
@@ -24271,7 +24271,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Ottawa South"
+        "lang:en": "Ottawa South"
       },
       "parent_id": "Q1904"
     },
@@ -24295,7 +24295,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Ottawa—Vanier"
+        "lang:en": "Ottawa—Vanier"
       },
       "parent_id": "Q1904"
     },
@@ -24319,7 +24319,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Ajax—Pickering"
+        "lang:en": "Ajax—Pickering"
       },
       "parent_id": "Q1904"
     },
@@ -24343,7 +24343,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Algoma—Manitoulin"
+        "lang:en": "Algoma—Manitoulin"
       },
       "parent_id": "Q1904"
     },
@@ -24367,7 +24367,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Ancaster—Dundas—Flamborough—Westdale"
+        "lang:en": "Ancaster—Dundas—Flamborough—Westdale"
       },
       "parent_id": "Q1904"
     },
@@ -24391,7 +24391,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Barrie"
+        "lang:en": "Barrie"
       },
       "parent_id": "Q1904"
     },
@@ -24415,7 +24415,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Beaches—East York"
+        "lang:en": "Beaches—East York"
       },
       "parent_id": "Q1904"
     },
@@ -24439,7 +24439,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Bramalea—Gore—Malton"
+        "lang:en": "Bramalea—Gore—Malton"
       },
       "parent_id": "Q1904"
     },
@@ -24463,7 +24463,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Brampton West"
+        "lang:en": "Brampton West"
       },
       "parent_id": "Q1904"
     },
@@ -24487,7 +24487,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Brampton—Springdale"
+        "lang:en": "Brampton—Springdale"
       },
       "parent_id": "Q1904"
     },
@@ -24511,7 +24511,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Brant"
+        "lang:en": "Brant"
       },
       "parent_id": "Q1904"
     },
@@ -24535,7 +24535,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Bruce—Grey—Owen Sound"
+        "lang:en": "Bruce—Grey—Owen Sound"
       },
       "parent_id": "Q1904"
     },
@@ -24559,7 +24559,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Burlington"
+        "lang:en": "Burlington"
       },
       "parent_id": "Q1904"
     },
@@ -24583,7 +24583,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Cambridge"
+        "lang:en": "Cambridge"
       },
       "parent_id": "Q1904"
     },
@@ -24607,7 +24607,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Carleton—Mississippi Mills"
+        "lang:en": "Carleton—Mississippi Mills"
       },
       "parent_id": "Q1904"
     },
@@ -24631,7 +24631,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Chatham-Kent—Essex"
+        "lang:en": "Chatham-Kent—Essex"
       },
       "parent_id": "Q1904"
     },
@@ -24655,7 +24655,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Davenport"
+        "lang:en": "Davenport"
       },
       "parent_id": "Q1904"
     },
@@ -24679,7 +24679,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Don Valley East"
+        "lang:en": "Don Valley East"
       },
       "parent_id": "Q1904"
     },
@@ -24703,7 +24703,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Don Valley West"
+        "lang:en": "Don Valley West"
       },
       "parent_id": "Q1904"
     },
@@ -24727,7 +24727,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Dufferin—Caledon"
+        "lang:en": "Dufferin—Caledon"
       },
       "parent_id": "Q1904"
     },
@@ -24751,7 +24751,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Durham"
+        "lang:en": "Durham"
       },
       "parent_id": "Q1904"
     },
@@ -24775,7 +24775,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Eglinton—Lawrence"
+        "lang:en": "Eglinton—Lawrence"
       },
       "parent_id": "Q1904"
     },
@@ -24799,7 +24799,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Elgin—Middlesex—London"
+        "lang:en": "Elgin—Middlesex—London"
       },
       "parent_id": "Q1904"
     },
@@ -24823,7 +24823,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Essex"
+        "lang:en": "Essex"
       },
       "parent_id": "Q1904"
     },
@@ -24847,7 +24847,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Etobicoke Centre"
+        "lang:en": "Etobicoke Centre"
       },
       "parent_id": "Q1904"
     },
@@ -24871,7 +24871,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Etobicoke North"
+        "lang:en": "Etobicoke North"
       },
       "parent_id": "Q1904"
     },
@@ -24895,7 +24895,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Etobicoke—Lakeshore"
+        "lang:en": "Etobicoke—Lakeshore"
       },
       "parent_id": "Q1904"
     },
@@ -24919,7 +24919,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Guelph"
+        "lang:en": "Guelph"
       },
       "parent_id": "Q1904"
     },
@@ -24943,7 +24943,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Haliburton—Kawartha Lakes—Brock"
+        "lang:en": "Haliburton—Kawartha Lakes—Brock"
       },
       "parent_id": "Q1904"
     },
@@ -24967,7 +24967,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Halton"
+        "lang:en": "Halton"
       },
       "parent_id": "Q1904"
     },
@@ -24991,7 +24991,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Kenora—Rainy River"
+        "lang:en": "Kenora—Rainy River"
       },
       "parent_id": "Q1904"
     },
@@ -25015,7 +25015,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Kitchener Centre"
+        "lang:en": "Kitchener Centre"
       },
       "parent_id": "Q1904"
     },
@@ -25039,7 +25039,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Kitchener—Waterloo"
+        "lang:en": "Kitchener—Waterloo"
       },
       "parent_id": "Q1904"
     },
@@ -25063,7 +25063,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Lambton—Kent—Middlesex"
+        "lang:en": "Lambton—Kent—Middlesex"
       },
       "parent_id": "Q1904"
     },
@@ -25087,7 +25087,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Leeds—Grenville"
+        "lang:en": "Leeds—Grenville"
       },
       "parent_id": "Q1904"
     },
@@ -25111,7 +25111,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Nepean—Carleton"
+        "lang:en": "Nepean—Carleton"
       },
       "parent_id": "Q1904"
     },
@@ -25135,7 +25135,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Niagara Falls"
+        "lang:en": "Niagara Falls"
       },
       "parent_id": "Q1904"
     },
@@ -25159,7 +25159,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Nickel Belt"
+        "lang:en": "Nickel Belt"
       },
       "parent_id": "Q1904"
     },
@@ -25183,7 +25183,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Nipissing"
+        "lang:en": "Nipissing"
       },
       "parent_id": "Q1904"
     },
@@ -25207,7 +25207,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Ottawa Centre"
+        "lang:en": "Ottawa Centre"
       },
       "parent_id": "Q1904"
     },
@@ -25231,7 +25231,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Ottawa West—Nepean"
+        "lang:en": "Ottawa West—Nepean"
       },
       "parent_id": "Q1904"
     },
@@ -25255,7 +25255,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Ottawa—Orléans"
+        "lang:en": "Ottawa—Orléans"
       },
       "parent_id": "Q1904"
     },
@@ -25279,7 +25279,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Parkdale—High Park"
+        "lang:en": "Parkdale—High Park"
       },
       "parent_id": "Q1904"
     },
@@ -25303,7 +25303,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Parry Sound—Muskoka"
+        "lang:en": "Parry Sound—Muskoka"
       },
       "parent_id": "Q1904"
     },
@@ -25327,7 +25327,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Sudbury"
+        "lang:en": "Sudbury"
       },
       "parent_id": "Q1904"
     },
@@ -25351,7 +25351,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Sarnia—Lambton"
+        "lang:en": "Sarnia—Lambton"
       },
       "parent_id": "Q1904"
     },
@@ -25375,7 +25375,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Sault Ste. Marie"
+        "lang:en": "Sault Ste. Marie"
       },
       "parent_id": "Q1904"
     },
@@ -25399,7 +25399,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "St. Paul's"
+        "lang:en": "St. Paul's"
       },
       "parent_id": "Q1904"
     },
@@ -25423,7 +25423,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Stormont—Dundas—South Glengarry"
+        "lang:en": "Stormont—Dundas—South Glengarry"
       },
       "parent_id": "Q1904"
     },
@@ -25447,7 +25447,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Thunder Bay—Superior North"
+        "lang:en": "Thunder Bay—Superior North"
       },
       "parent_id": "Q1904"
     },
@@ -25471,7 +25471,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Thunder Bay—Atikokan"
+        "lang:en": "Thunder Bay—Atikokan"
       },
       "parent_id": "Q1904"
     },
@@ -25495,7 +25495,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Timiskaming—Cochrane"
+        "lang:en": "Timiskaming—Cochrane"
       },
       "parent_id": "Q1904"
     },
@@ -25519,7 +25519,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Toronto Centre"
+        "lang:en": "Toronto Centre"
       },
       "parent_id": "Q1904"
     },
@@ -25543,7 +25543,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Vaughan"
+        "lang:en": "Vaughan"
       },
       "parent_id": "Q1904"
     },
@@ -25567,7 +25567,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Wellington—Halton Hills"
+        "lang:en": "Wellington—Halton Hills"
       },
       "parent_id": "Q1904"
     },
@@ -25591,7 +25591,7 @@
         "lang:fr": "liste des circonscriptions électorales provinciales de l'Ontario"
       },
       "name": {
-        "lang:en_CA": "Willowdale"
+        "lang:en": "Willowdale"
       },
       "parent_id": "Q1904"
     }

--- a/legislative/Q1812866/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1812866/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -12888,8 +12888,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -12913,7 +12913,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Vermilion-Lloydminster"
+        "lang:en": "Vermilion-Lloydminster"
       },
       "parent_id": "Q1951"
     },
@@ -12937,7 +12937,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Whitecourt-Ste. Anne"
+        "lang:en": "Whitecourt-Ste. Anne"
       },
       "parent_id": "Q1951"
     },
@@ -12962,8 +12962,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -12987,7 +12987,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Currie"
+        "lang:en": "Calgary-Currie"
       },
       "parent_id": "Q1951"
     },
@@ -13011,7 +13011,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Airdrie"
+        "lang:en": "Airdrie"
       },
       "parent_id": "Q1951"
     },
@@ -13035,7 +13035,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Athabasca-Sturgeon-Redwater"
+        "lang:en": "Athabasca-Sturgeon-Redwater"
       },
       "parent_id": "Q1951"
     },
@@ -13059,7 +13059,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Banff-Cochrane"
+        "lang:en": "Banff-Cochrane"
       },
       "parent_id": "Q1951"
     },
@@ -13083,7 +13083,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Barrhead-Morinville-Westlock"
+        "lang:en": "Barrhead-Morinville-Westlock"
       },
       "parent_id": "Q1951"
     },
@@ -13107,7 +13107,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Battle River-Wainwright"
+        "lang:en": "Battle River-Wainwright"
       },
       "parent_id": "Q1951"
     },
@@ -13131,7 +13131,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Bonnyville-Cold Lake"
+        "lang:en": "Bonnyville-Cold Lake"
       },
       "parent_id": "Q1951"
     },
@@ -13155,7 +13155,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Acadia"
+        "lang:en": "Calgary-Acadia"
       },
       "parent_id": "Q1951"
     },
@@ -13179,7 +13179,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Bow"
+        "lang:en": "Calgary-Bow"
       },
       "parent_id": "Q1951"
     },
@@ -13203,7 +13203,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Buffalo"
+        "lang:en": "Calgary-Buffalo"
       },
       "parent_id": "Q1951"
     },
@@ -13227,7 +13227,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Cross"
+        "lang:en": "Calgary-Cross"
       },
       "parent_id": "Q1951"
     },
@@ -13251,7 +13251,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-East"
+        "lang:en": "Calgary-East"
       },
       "parent_id": "Q1951"
     },
@@ -13275,7 +13275,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Elbow"
+        "lang:en": "Calgary-Elbow"
       },
       "parent_id": "Q1951"
     },
@@ -13299,7 +13299,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Fish Creek"
+        "lang:en": "Calgary-Fish Creek"
       },
       "parent_id": "Q1951"
     },
@@ -13323,7 +13323,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Foothills"
+        "lang:en": "Calgary-Foothills"
       },
       "parent_id": "Q1951"
     },
@@ -13347,7 +13347,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Fort"
+        "lang:en": "Calgary-Fort"
       },
       "parent_id": "Q1951"
     },
@@ -13371,7 +13371,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Glenmore"
+        "lang:en": "Calgary-Glenmore"
       },
       "parent_id": "Q1951"
     },
@@ -13395,7 +13395,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Greenway"
+        "lang:en": "Calgary-Greenway"
       },
       "parent_id": "Q1951"
     },
@@ -13419,7 +13419,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Hays"
+        "lang:en": "Calgary-Hays"
       },
       "parent_id": "Q1951"
     },
@@ -13443,7 +13443,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Hawkwood"
+        "lang:en": "Calgary-Hawkwood"
       },
       "parent_id": "Q1951"
     },
@@ -13467,7 +13467,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Klein"
+        "lang:en": "Calgary-Klein"
       },
       "parent_id": "Q1951"
     },
@@ -13491,7 +13491,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Lougheed"
+        "lang:en": "Calgary-Lougheed"
       },
       "parent_id": "Q1951"
     },
@@ -13515,7 +13515,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Mackay-Nose Hill"
+        "lang:en": "Calgary-Mackay-Nose Hill"
       },
       "parent_id": "Q1951"
     },
@@ -13539,7 +13539,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-McCall"
+        "lang:en": "Calgary-McCall"
       },
       "parent_id": "Q1951"
     },
@@ -13563,7 +13563,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Mountain View"
+        "lang:en": "Calgary-Mountain View"
       },
       "parent_id": "Q1951"
     },
@@ -13587,7 +13587,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-North West"
+        "lang:en": "Calgary-North West"
       },
       "parent_id": "Q1951"
     },
@@ -13611,7 +13611,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Northern Hills"
+        "lang:en": "Calgary-Northern Hills"
       },
       "parent_id": "Q1951"
     },
@@ -13635,7 +13635,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Shaw"
+        "lang:en": "Calgary-Shaw"
       },
       "parent_id": "Q1951"
     },
@@ -13659,7 +13659,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-Varsity"
+        "lang:en": "Calgary-Varsity"
       },
       "parent_id": "Q1951"
     },
@@ -13683,7 +13683,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-South East"
+        "lang:en": "Calgary-South East"
       },
       "parent_id": "Q1951"
     },
@@ -13707,7 +13707,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Calgary-West"
+        "lang:en": "Calgary-West"
       },
       "parent_id": "Q1951"
     },
@@ -13731,7 +13731,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Cardston-Taber-Warner"
+        "lang:en": "Cardston-Taber-Warner"
       },
       "parent_id": "Q1951"
     },
@@ -13755,7 +13755,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Chestermere-Rocky View"
+        "lang:en": "Chestermere-Rocky View"
       },
       "parent_id": "Q1951"
     },
@@ -13779,7 +13779,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Cypress-Medicine Hat"
+        "lang:en": "Cypress-Medicine Hat"
       },
       "parent_id": "Q1951"
     },
@@ -13803,7 +13803,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Drayton Valley-Devon"
+        "lang:en": "Drayton Valley-Devon"
       },
       "parent_id": "Q1951"
     },
@@ -13827,7 +13827,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Drumheller-Stettler"
+        "lang:en": "Drumheller-Stettler"
       },
       "parent_id": "Q1951"
     },
@@ -13851,7 +13851,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Dunvegan-Central Peace-Notley"
+        "lang:en": "Dunvegan-Central Peace-Notley"
       },
       "parent_id": "Q1951"
     },
@@ -13875,7 +13875,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Beverly-Clareview"
+        "lang:en": "Edmonton-Beverly-Clareview"
       },
       "parent_id": "Q1951"
     },
@@ -13899,7 +13899,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Calder"
+        "lang:en": "Edmonton-Calder"
       },
       "parent_id": "Q1951"
     },
@@ -13923,7 +13923,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Castle Downs"
+        "lang:en": "Edmonton-Castle Downs"
       },
       "parent_id": "Q1951"
     },
@@ -13947,7 +13947,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Centre"
+        "lang:en": "Edmonton-Centre"
       },
       "parent_id": "Q1951"
     },
@@ -13971,7 +13971,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Decore"
+        "lang:en": "Edmonton-Decore"
       },
       "parent_id": "Q1951"
     },
@@ -13995,7 +13995,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Ellerslie"
+        "lang:en": "Edmonton-Ellerslie"
       },
       "parent_id": "Q1951"
     },
@@ -14019,7 +14019,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Glenora"
+        "lang:en": "Edmonton-Glenora"
       },
       "parent_id": "Q1951"
     },
@@ -14043,7 +14043,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Gold Bar"
+        "lang:en": "Edmonton-Gold Bar"
       },
       "parent_id": "Q1951"
     },
@@ -14067,7 +14067,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Highlands-Norwood"
+        "lang:en": "Edmonton-Highlands-Norwood"
       },
       "parent_id": "Q1951"
     },
@@ -14091,7 +14091,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Manning"
+        "lang:en": "Edmonton-Manning"
       },
       "parent_id": "Q1951"
     },
@@ -14115,7 +14115,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-McClung"
+        "lang:en": "Edmonton-McClung"
       },
       "parent_id": "Q1951"
     },
@@ -14139,7 +14139,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Meadowlark"
+        "lang:en": "Edmonton-Meadowlark"
       },
       "parent_id": "Q1951"
     },
@@ -14163,7 +14163,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Mill Creek"
+        "lang:en": "Edmonton-Mill Creek"
       },
       "parent_id": "Q1951"
     },
@@ -14187,7 +14187,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Mill Woods"
+        "lang:en": "Edmonton-Mill Woods"
       },
       "parent_id": "Q1951"
     },
@@ -14211,7 +14211,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Riverview"
+        "lang:en": "Edmonton-Riverview"
       },
       "parent_id": "Q1951"
     },
@@ -14235,7 +14235,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Rutherford"
+        "lang:en": "Edmonton-Rutherford"
       },
       "parent_id": "Q1951"
     },
@@ -14259,7 +14259,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-South West"
+        "lang:en": "Edmonton-South West"
       },
       "parent_id": "Q1951"
     },
@@ -14283,7 +14283,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Strathcona"
+        "lang:en": "Edmonton-Strathcona"
       },
       "parent_id": "Q1951"
     },
@@ -14307,7 +14307,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Edmonton-Whitemud"
+        "lang:en": "Edmonton-Whitemud"
       },
       "parent_id": "Q1951"
     },
@@ -14331,7 +14331,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Fort McMurray-Wood Buffalo"
+        "lang:en": "Fort McMurray-Wood Buffalo"
       },
       "parent_id": "Q1951"
     },
@@ -14355,7 +14355,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Fort McMurray-Conklin"
+        "lang:en": "Fort McMurray-Conklin"
       },
       "parent_id": "Q1951"
     },
@@ -14379,7 +14379,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Fort Saskatchewan-Vegreville"
+        "lang:en": "Fort Saskatchewan-Vegreville"
       },
       "parent_id": "Q1951"
     },
@@ -14403,7 +14403,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Grande Prairie-Smoky"
+        "lang:en": "Grande Prairie-Smoky"
       },
       "parent_id": "Q1951"
     },
@@ -14427,7 +14427,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Grande Prairie-Wapiti"
+        "lang:en": "Grande Prairie-Wapiti"
       },
       "parent_id": "Q1951"
     },
@@ -14451,7 +14451,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Highwood"
+        "lang:en": "Highwood"
       },
       "parent_id": "Q1951"
     },
@@ -14475,7 +14475,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Innisfail-Sylvan Lake"
+        "lang:en": "Innisfail-Sylvan Lake"
       },
       "parent_id": "Q1951"
     },
@@ -14499,7 +14499,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Lac La Biche-St. Paul-Two Hills"
+        "lang:en": "Lac La Biche-St. Paul-Two Hills"
       },
       "parent_id": "Q1951"
     },
@@ -14523,7 +14523,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Lacombe-Ponoka"
+        "lang:en": "Lacombe-Ponoka"
       },
       "parent_id": "Q1951"
     },
@@ -14547,7 +14547,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Leduc-Beaumont"
+        "lang:en": "Leduc-Beaumont"
       },
       "parent_id": "Q1951"
     },
@@ -14571,7 +14571,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Lesser Slave Lake"
+        "lang:en": "Lesser Slave Lake"
       },
       "parent_id": "Q1951"
     },
@@ -14595,7 +14595,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Lethbridge-East"
+        "lang:en": "Lethbridge-East"
       },
       "parent_id": "Q1951"
     },
@@ -14619,7 +14619,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Lethbridge-West"
+        "lang:en": "Lethbridge-West"
       },
       "parent_id": "Q1951"
     },
@@ -14643,7 +14643,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Little Bow"
+        "lang:en": "Little Bow"
       },
       "parent_id": "Q1951"
     },
@@ -14667,7 +14667,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Livingstone-Macleod"
+        "lang:en": "Livingstone-Macleod"
       },
       "parent_id": "Q1951"
     },
@@ -14691,7 +14691,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Medicine Hat"
+        "lang:en": "Medicine Hat"
       },
       "parent_id": "Q1951"
     },
@@ -14715,7 +14715,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Olds-Didsbury-Three Hills"
+        "lang:en": "Olds-Didsbury-Three Hills"
       },
       "parent_id": "Q1951"
     },
@@ -14739,7 +14739,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Peace River"
+        "lang:en": "Peace River"
       },
       "parent_id": "Q1951"
     },
@@ -14763,7 +14763,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Red Deer-North"
+        "lang:en": "Red Deer-North"
       },
       "parent_id": "Q1951"
     },
@@ -14787,7 +14787,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Red Deer-South"
+        "lang:en": "Red Deer-South"
       },
       "parent_id": "Q1951"
     },
@@ -14811,7 +14811,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Rimbey-Rocky Mountain House-Sundre"
+        "lang:en": "Rimbey-Rocky Mountain House-Sundre"
       },
       "parent_id": "Q1951"
     },
@@ -14835,7 +14835,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Sherwood Park"
+        "lang:en": "Sherwood Park"
       },
       "parent_id": "Q1951"
     },
@@ -14859,7 +14859,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Spruce Grove-St. Albert"
+        "lang:en": "Spruce Grove-St. Albert"
       },
       "parent_id": "Q1951"
     },
@@ -14883,7 +14883,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "St. Albert"
+        "lang:en": "St. Albert"
       },
       "parent_id": "Q1951"
     },
@@ -14907,7 +14907,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Stony Plain"
+        "lang:en": "Stony Plain"
       },
       "parent_id": "Q1951"
     },
@@ -14931,7 +14931,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Strathcona-Sherwood Park"
+        "lang:en": "Strathcona-Sherwood Park"
       },
       "parent_id": "Q1951"
     },
@@ -14955,7 +14955,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Strathmore-Brooks"
+        "lang:en": "Strathmore-Brooks"
       },
       "parent_id": "Q1951"
     },
@@ -14979,7 +14979,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "West Yellowhead"
+        "lang:en": "West Yellowhead"
       },
       "parent_id": "Q1951"
     },
@@ -15003,7 +15003,7 @@
         "lang:fr": "Liste des circonscriptions électorales de l'Alberta"
       },
       "name": {
-        "lang:en_CA": "Wetaskiwin-Camrose"
+        "lang:en": "Wetaskiwin-Camrose"
       },
       "parent_id": "Q1951"
     }

--- a/legislative/Q2444341/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2444341/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -112,8 +112,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -137,7 +137,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Toronto"
+        "lang:en": "Toronto"
       },
       "parent_id": "Q1904"
     },
@@ -162,7 +162,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -185,7 +185,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "1 Etobicoke North"
+        "lang:en": "1 Etobicoke North"
       },
       "parent_id": "Q172"
     },
@@ -208,7 +208,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "2 Etobicoke North"
+        "lang:en": "2 Etobicoke North"
       },
       "parent_id": "Q172"
     },
@@ -231,7 +231,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "3 Etobicoke Centre"
+        "lang:en": "3 Etobicoke Centre"
       },
       "parent_id": "Q172"
     },
@@ -254,7 +254,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "4 Etobicoke Centre"
+        "lang:en": "4 Etobicoke Centre"
       },
       "parent_id": "Q172"
     },
@@ -277,7 +277,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "5 Etobicoke-Lakeshore"
+        "lang:en": "5 Etobicoke-Lakeshore"
       },
       "parent_id": "Q172"
     },
@@ -300,7 +300,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "6 Etobicoke-Lakeshore"
+        "lang:en": "6 Etobicoke-Lakeshore"
       },
       "parent_id": "Q172"
     },
@@ -323,7 +323,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "7 York West"
+        "lang:en": "7 York West"
       },
       "parent_id": "Q172"
     },
@@ -346,7 +346,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "8 York West"
+        "lang:en": "8 York West"
       },
       "parent_id": "Q172"
     },
@@ -369,7 +369,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "9 York Centre"
+        "lang:en": "9 York Centre"
       },
       "parent_id": "Q172"
     },
@@ -392,7 +392,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "10 York Centre"
+        "lang:en": "10 York Centre"
       },
       "parent_id": "Q172"
     },
@@ -415,7 +415,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "11 York South-Weston"
+        "lang:en": "11 York South-Weston"
       },
       "parent_id": "Q172"
     },
@@ -438,7 +438,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "12 York South-Weston"
+        "lang:en": "12 York South-Weston"
       },
       "parent_id": "Q172"
     },
@@ -461,7 +461,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "13 Parkdale-High Park"
+        "lang:en": "13 Parkdale-High Park"
       },
       "parent_id": "Q172"
     },
@@ -484,7 +484,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "14 Parkdale-High Park"
+        "lang:en": "14 Parkdale-High Park"
       },
       "parent_id": "Q172"
     },
@@ -507,7 +507,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "15 Eglinton-Lawrence"
+        "lang:en": "15 Eglinton-Lawrence"
       },
       "parent_id": "Q172"
     },
@@ -530,7 +530,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "16 Eglinton-Lawrence"
+        "lang:en": "16 Eglinton-Lawrence"
       },
       "parent_id": "Q172"
     },
@@ -553,7 +553,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "17 Davenport"
+        "lang:en": "17 Davenport"
       },
       "parent_id": "Q172"
     },
@@ -576,7 +576,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "18 Davenport"
+        "lang:en": "18 Davenport"
       },
       "parent_id": "Q172"
     },
@@ -599,7 +599,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "19 Trinity-Spadina"
+        "lang:en": "19 Trinity-Spadina"
       },
       "parent_id": "Q172"
     },
@@ -622,7 +622,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "20 Trinity-Spadina"
+        "lang:en": "20 Trinity-Spadina"
       },
       "parent_id": "Q172"
     },
@@ -645,7 +645,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "21 St. Paul's"
+        "lang:en": "21 St. Paul's"
       },
       "parent_id": "Q172"
     },
@@ -668,7 +668,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "22 St. Paul's"
+        "lang:en": "22 St. Paul's"
       },
       "parent_id": "Q172"
     },
@@ -691,7 +691,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "23 Willowdale"
+        "lang:en": "23 Willowdale"
       },
       "parent_id": "Q172"
     },
@@ -714,7 +714,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "24 Willowdale"
+        "lang:en": "24 Willowdale"
       },
       "parent_id": "Q172"
     },
@@ -737,7 +737,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "25 Don Valley West"
+        "lang:en": "25 Don Valley West"
       },
       "parent_id": "Q172"
     },
@@ -760,7 +760,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "26 Don Valley West"
+        "lang:en": "26 Don Valley West"
       },
       "parent_id": "Q172"
     },
@@ -783,7 +783,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "27 Toronto Centre-Rosedale"
+        "lang:en": "27 Toronto Centre-Rosedale"
       },
       "parent_id": "Q172"
     },
@@ -806,7 +806,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "28 Toronto Centre-Rosedale"
+        "lang:en": "28 Toronto Centre-Rosedale"
       },
       "parent_id": "Q172"
     },
@@ -829,7 +829,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "29 Toronto-Danforth"
+        "lang:en": "29 Toronto-Danforth"
       },
       "parent_id": "Q172"
     },
@@ -852,7 +852,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "30 Toronto-Danforth"
+        "lang:en": "30 Toronto-Danforth"
       },
       "parent_id": "Q172"
     },
@@ -875,7 +875,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "31 Beaches-East York"
+        "lang:en": "31 Beaches-East York"
       },
       "parent_id": "Q172"
     },
@@ -898,7 +898,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "32 Beaches-East York"
+        "lang:en": "32 Beaches-East York"
       },
       "parent_id": "Q172"
     },
@@ -921,7 +921,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "33 Don Valley East"
+        "lang:en": "33 Don Valley East"
       },
       "parent_id": "Q172"
     },
@@ -944,7 +944,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "34 Don Valley East"
+        "lang:en": "34 Don Valley East"
       },
       "parent_id": "Q172"
     },
@@ -967,7 +967,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "35 Scarborough Southwest"
+        "lang:en": "35 Scarborough Southwest"
       },
       "parent_id": "Q172"
     },
@@ -990,7 +990,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "36 Scarborough Southwest"
+        "lang:en": "36 Scarborough Southwest"
       },
       "parent_id": "Q172"
     },
@@ -1013,7 +1013,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "37 Scarborough Centre"
+        "lang:en": "37 Scarborough Centre"
       },
       "parent_id": "Q172"
     },
@@ -1036,7 +1036,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "38 Scarborough Centre"
+        "lang:en": "38 Scarborough Centre"
       },
       "parent_id": "Q172"
     },
@@ -1059,7 +1059,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "39 Scarborough Agincourt"
+        "lang:en": "39 Scarborough Agincourt"
       },
       "parent_id": "Q172"
     },
@@ -1082,7 +1082,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "40 Scarborough Agincourt"
+        "lang:en": "40 Scarborough Agincourt"
       },
       "parent_id": "Q172"
     },
@@ -1105,7 +1105,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "41 Scarborough-Rouge River"
+        "lang:en": "41 Scarborough-Rouge River"
       },
       "parent_id": "Q172"
     },
@@ -1128,7 +1128,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "42 Scarborough-Rouge River"
+        "lang:en": "42 Scarborough-Rouge River"
       },
       "parent_id": "Q172"
     },
@@ -1151,7 +1151,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "43 Scarborough East"
+        "lang:en": "43 Scarborough East"
       },
       "parent_id": "Q172"
     },
@@ -1174,7 +1174,7 @@
         "lang:en": "municipal electoral district of Toronto"
       },
       "name": {
-        "lang:en_CA": "44 Scarborough East"
+        "lang:en": "44 Scarborough East"
       },
       "parent_id": "Q172"
     }

--- a/legislative/Q258843/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q258843/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -58,8 +58,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -82,7 +82,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Mount Pearl North"
+        "lang:en": "Mount Pearl North"
       },
       "parent_id": "Q2003"
     },
@@ -107,8 +107,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -131,7 +131,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Humber - Gros Morne"
+        "lang:en": "Humber - Gros Morne"
       },
       "parent_id": "Q2003"
     },
@@ -154,7 +154,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Corner Brook"
+        "lang:en": "Corner Brook"
       },
       "parent_id": "Q2003"
     },
@@ -177,7 +177,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Topsail - Paradise"
+        "lang:en": "Topsail - Paradise"
       },
       "parent_id": "Q2003"
     },
@@ -200,7 +200,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Mount Pearl - Southlands"
+        "lang:en": "Mount Pearl - Southlands"
       },
       "parent_id": "Q2003"
     },
@@ -223,7 +223,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "St. John's East - Quidi Vidi"
+        "lang:en": "St. John's East - Quidi Vidi"
       },
       "parent_id": "Q2003"
     },
@@ -246,7 +246,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Virginia Waters - Pleasantville"
+        "lang:en": "Virginia Waters - Pleasantville"
       },
       "parent_id": "Q2003"
     },
@@ -269,7 +269,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Waterford Valley"
+        "lang:en": "Waterford Valley"
       },
       "parent_id": "Q2003"
     },
@@ -292,7 +292,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Harbour Grace - Port de Grave"
+        "lang:en": "Harbour Grace - Port de Grave"
       },
       "parent_id": "Q2003"
     },
@@ -315,7 +315,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "St. Barbe - L'anse aux Meadows"
+        "lang:en": "St. Barbe - L'anse aux Meadows"
       },
       "parent_id": "Q2003"
     },
@@ -338,7 +338,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Stephenville - Port Au Port"
+        "lang:en": "Stephenville - Port Au Port"
       },
       "parent_id": "Q2003"
     },
@@ -361,7 +361,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "St. George's - Humber"
+        "lang:en": "St. George's - Humber"
       },
       "parent_id": "Q2003"
     },
@@ -384,7 +384,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Lewisporte - Twillingate"
+        "lang:en": "Lewisporte - Twillingate"
       },
       "parent_id": "Q2003"
     },
@@ -407,7 +407,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Fogo Island - Cape Freels"
+        "lang:en": "Fogo Island - Cape Freels"
       },
       "parent_id": "Q2003"
     },
@@ -430,7 +430,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Burin - Grand Bank"
+        "lang:en": "Burin - Grand Bank"
       },
       "parent_id": "Q2003"
     },
@@ -453,7 +453,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Placentia West - Bellevue"
+        "lang:en": "Placentia West - Bellevue"
       },
       "parent_id": "Q2003"
     },
@@ -476,7 +476,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Bonavista"
+        "lang:en": "Bonavista"
       },
       "parent_id": "Q2003"
     },
@@ -499,7 +499,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Mount Scio"
+        "lang:en": "Mount Scio"
       },
       "parent_id": "Q2003"
     },
@@ -522,7 +522,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Windsor Lake"
+        "lang:en": "Windsor Lake"
       },
       "parent_id": "Q2003"
     },
@@ -545,7 +545,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Baie Verte - Green Bay"
+        "lang:en": "Baie Verte - Green Bay"
       },
       "parent_id": "Q2003"
     },
@@ -568,7 +568,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Humber - Bay of Islands"
+        "lang:en": "Humber - Bay of Islands"
       },
       "parent_id": "Q2003"
     },
@@ -591,7 +591,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Burgeo - La Poile"
+        "lang:en": "Burgeo - La Poile"
       },
       "parent_id": "Q2003"
     },
@@ -614,7 +614,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Cape St. Francis"
+        "lang:en": "Cape St. Francis"
       },
       "parent_id": "Q2003"
     },
@@ -637,7 +637,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Cartwright - L'Anse au Clair"
+        "lang:en": "Cartwright - L'Anse au Clair"
       },
       "parent_id": "Q2003"
     },
@@ -660,7 +660,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Conception Bay East - Bell Island"
+        "lang:en": "Conception Bay East - Bell Island"
       },
       "parent_id": "Q2003"
     },
@@ -683,7 +683,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Conception Bay South"
+        "lang:en": "Conception Bay South"
       },
       "parent_id": "Q2003"
     },
@@ -706,7 +706,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Exploits"
+        "lang:en": "Exploits"
       },
       "parent_id": "Q2003"
     },
@@ -729,7 +729,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Ferryland"
+        "lang:en": "Ferryland"
       },
       "parent_id": "Q2003"
     },
@@ -752,7 +752,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Fortune Bay - Cape La Hune"
+        "lang:en": "Fortune Bay - Cape La Hune"
       },
       "parent_id": "Q2003"
     },
@@ -775,7 +775,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Gander"
+        "lang:en": "Gander"
       },
       "parent_id": "Q2003"
     },
@@ -798,7 +798,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Grand Falls - Windsor - Buchans"
+        "lang:en": "Grand Falls - Windsor - Buchans"
       },
       "parent_id": "Q2003"
     },
@@ -821,7 +821,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Harbour Main"
+        "lang:en": "Harbour Main"
       },
       "parent_id": "Q2003"
     },
@@ -844,7 +844,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Labrador West"
+        "lang:en": "Labrador West"
       },
       "parent_id": "Q2003"
     },
@@ -867,7 +867,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Lake Melville"
+        "lang:en": "Lake Melville"
       },
       "parent_id": "Q2003"
     },
@@ -890,7 +890,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Placentia - St. Mary's"
+        "lang:en": "Placentia - St. Mary's"
       },
       "parent_id": "Q2003"
     },
@@ -913,7 +913,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "St. John's Centre"
+        "lang:en": "St. John's Centre"
       },
       "parent_id": "Q2003"
     },
@@ -936,7 +936,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "St. John's West"
+        "lang:en": "St. John's West"
       },
       "parent_id": "Q2003"
     },
@@ -959,7 +959,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Terra Nova"
+        "lang:en": "Terra Nova"
       },
       "parent_id": "Q2003"
     },
@@ -982,7 +982,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Torngat Mountain"
+        "lang:en": "Torngat Mountain"
       },
       "parent_id": "Q2003"
     },
@@ -1005,7 +1005,7 @@
         "lang:en": "provincial electoral district of Newfoundland and Labrador"
       },
       "name": {
-        "lang:en_CA": "Carbonear - Trinity - Bay de Verde"
+        "lang:en": "Carbonear - Trinity - Bay de Verde"
       },
       "parent_id": "Q2003"
     }

--- a/legislative/Q2867078/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2867078/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -219,8 +219,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -243,7 +243,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Kam Lake"
+        "lang:en": "Kam Lake"
       },
       "parent_id": "Q2007"
     },
@@ -268,8 +268,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -292,7 +292,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Tu Nedhé-Wiilideh"
+        "lang:en": "Tu Nedhé-Wiilideh"
       },
       "parent_id": "Q2007"
     },
@@ -315,7 +315,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Yellowknife North"
+        "lang:en": "Yellowknife North"
       },
       "parent_id": "Q2007"
     },
@@ -338,7 +338,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Deh Cho"
+        "lang:en": "Deh Cho"
       },
       "parent_id": "Q2007"
     },
@@ -361,7 +361,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Yellowknife South"
+        "lang:en": "Yellowknife South"
       },
       "parent_id": "Q2007"
     },
@@ -384,7 +384,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Frame Lake"
+        "lang:en": "Frame Lake"
       },
       "parent_id": "Q2007"
     },
@@ -407,7 +407,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Great Slave"
+        "lang:en": "Great Slave"
       },
       "parent_id": "Q2007"
     },
@@ -430,7 +430,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Hay River South"
+        "lang:en": "Hay River South"
       },
       "parent_id": "Q2007"
     },
@@ -453,7 +453,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Hay River North"
+        "lang:en": "Hay River North"
       },
       "parent_id": "Q2007"
     },
@@ -476,7 +476,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Inuvik Boot Lake"
+        "lang:en": "Inuvik Boot Lake"
       },
       "parent_id": "Q2007"
     },
@@ -499,7 +499,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Inuvik Twin Lakes"
+        "lang:en": "Inuvik Twin Lakes"
       },
       "parent_id": "Q2007"
     },
@@ -522,7 +522,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Mackenzie-Delta"
+        "lang:en": "Mackenzie-Delta"
       },
       "parent_id": "Q2007"
     },
@@ -545,7 +545,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Monfwi"
+        "lang:en": "Monfwi"
       },
       "parent_id": "Q2007"
     },
@@ -568,7 +568,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Nahendeh"
+        "lang:en": "Nahendeh"
       },
       "parent_id": "Q2007"
     },
@@ -591,7 +591,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Nunakput"
+        "lang:en": "Nunakput"
       },
       "parent_id": "Q2007"
     },
@@ -614,7 +614,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Range Lake"
+        "lang:en": "Range Lake"
       },
       "parent_id": "Q2007"
     },
@@ -637,7 +637,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Sahtu"
+        "lang:en": "Sahtu"
       },
       "parent_id": "Q2007"
     },
@@ -660,7 +660,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Thebacha"
+        "lang:en": "Thebacha"
       },
       "parent_id": "Q2007"
     },
@@ -683,7 +683,7 @@
         "lang:en": "territorial electoral district of the Northwest Territories"
       },
       "name": {
-        "lang:en_CA": "Yellowknife Centre"
+        "lang:en": "Yellowknife Centre"
       },
       "parent_id": "Q2007"
     }

--- a/legislative/Q2867082/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2867082/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -204,7 +204,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Aivilik"
+        "lang:en": "Aivilik"
       },
       "parent_id": "Q2023"
     },
@@ -227,7 +227,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Pangnirtung"
+        "lang:en": "Pangnirtung"
       },
       "parent_id": "Q2023"
     },
@@ -251,8 +251,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -275,7 +275,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Aggu"
+        "lang:en": "Aggu"
       },
       "parent_id": "Q2023"
     },
@@ -298,7 +298,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Arviat North-Whale Cove"
+        "lang:en": "Arviat North-Whale Cove"
       },
       "parent_id": "Q2023"
     },
@@ -321,7 +321,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Arviat South"
+        "lang:en": "Arviat South"
       },
       "parent_id": "Q2023"
     },
@@ -344,7 +344,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Iqaluit-Niaqunnguu"
+        "lang:en": "Iqaluit-Niaqunnguu"
       },
       "parent_id": "Q2023"
     },
@@ -367,7 +367,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Iqaluit-Sinaa"
+        "lang:en": "Iqaluit-Sinaa"
       },
       "parent_id": "Q2023"
     },
@@ -390,7 +390,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Netsilik"
+        "lang:en": "Netsilik"
       },
       "parent_id": "Q2023"
     },
@@ -413,7 +413,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Rankin Inlet North-Chesterfield Inlet"
+        "lang:en": "Rankin Inlet North-Chesterfield Inlet"
       },
       "parent_id": "Q2023"
     },
@@ -436,7 +436,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Rankin Inlet South"
+        "lang:en": "Rankin Inlet South"
       },
       "parent_id": "Q2023"
     },
@@ -459,7 +459,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Gjoa Haven"
+        "lang:en": "Gjoa Haven"
       },
       "parent_id": "Q2023"
     },
@@ -482,7 +482,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Iqaluit-Manirajak"
+        "lang:en": "Iqaluit-Manirajak"
       },
       "parent_id": "Q2023"
     },
@@ -505,7 +505,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Iqaluit-Tasiluk"
+        "lang:en": "Iqaluit-Tasiluk"
       },
       "parent_id": "Q2023"
     },
@@ -530,8 +530,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     },
@@ -554,7 +554,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Amittuq"
+        "lang:en": "Amittuq"
       },
       "parent_id": "Q2023"
     },
@@ -577,7 +577,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Baker Lake"
+        "lang:en": "Baker Lake"
       },
       "parent_id": "Q2023"
     },
@@ -600,7 +600,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Cambridge Bay"
+        "lang:en": "Cambridge Bay"
       },
       "parent_id": "Q2023"
     },
@@ -623,7 +623,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Hudson Bay"
+        "lang:en": "Hudson Bay"
       },
       "parent_id": "Q2023"
     },
@@ -646,7 +646,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Kugluktuk"
+        "lang:en": "Kugluktuk"
       },
       "parent_id": "Q2023"
     },
@@ -669,7 +669,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Quttiktuq"
+        "lang:en": "Quttiktuq"
       },
       "parent_id": "Q2023"
     },
@@ -692,7 +692,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "South Baffin"
+        "lang:en": "South Baffin"
       },
       "parent_id": "Q2023"
     },
@@ -715,7 +715,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Tununiq"
+        "lang:en": "Tununiq"
       },
       "parent_id": "Q2023"
     },
@@ -738,7 +738,7 @@
         "lang:en": "territorial electoral district of Nunavut"
       },
       "name": {
-        "lang:en_CA": "Uqqummiut"
+        "lang:en": "Uqqummiut"
       },
       "parent_id": "Q2023"
     }

--- a/legislative/Q2994125/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2994125/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -25,8 +25,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Innes",
-        "lang:fr_CA": "Innes"
+        "lang:en": "Innes",
+        "lang:fr": "Innes"
       },
       "parent_id": "Q1930"
     },
@@ -49,8 +49,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Osgoode",
-        "lang:fr_CA": "Osgoode"
+        "lang:en": "Osgoode",
+        "lang:fr": "Osgoode"
       },
       "parent_id": "Q1930"
     },
@@ -74,8 +74,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -124,7 +124,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Ottawa"
+        "lang:en": "Ottawa"
       },
       "parent_id": "Q1904"
     },
@@ -147,8 +147,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Alta Vista",
-        "lang:fr_CA": "Alta Vista"
+        "lang:en": "Alta Vista",
+        "lang:fr": "Alta Vista"
       },
       "parent_id": "Q1930"
     },
@@ -171,8 +171,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Barrhaven",
-        "lang:fr_CA": "Barrhaven"
+        "lang:en": "Barrhaven",
+        "lang:fr": "Barrhaven"
       },
       "parent_id": "Q1930"
     },
@@ -195,8 +195,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Bay",
-        "lang:fr_CA": "Baie"
+        "lang:en": "Bay",
+        "lang:fr": "Baie"
       },
       "parent_id": "Q1930"
     },
@@ -219,8 +219,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Beacon Hill-Cyrville",
-        "lang:fr_CA": "Beacon Hill-Cyrville"
+        "lang:en": "Beacon Hill-Cyrville",
+        "lang:fr": "Beacon Hill-Cyrville"
       },
       "parent_id": "Q1930"
     },
@@ -243,8 +243,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Capital",
-        "lang:fr_CA": "Capitale"
+        "lang:en": "Capital",
+        "lang:fr": "Capitale"
       },
       "parent_id": "Q1930"
     },
@@ -267,8 +267,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "College",
-        "lang:fr_CA": "Collège"
+        "lang:en": "College",
+        "lang:fr": "Collège"
       },
       "parent_id": "Q1930"
     },
@@ -291,8 +291,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Cumberland",
-        "lang:fr_CA": "Cumberland"
+        "lang:en": "Cumberland",
+        "lang:fr": "Cumberland"
       },
       "parent_id": "Q1930"
     },
@@ -315,8 +315,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Gloucester-South Nepean",
-        "lang:fr_CA": "Gloucester-Nepean-Sud"
+        "lang:en": "Gloucester-South Nepean",
+        "lang:fr": "Gloucester-Nepean-Sud"
       },
       "parent_id": "Q1930"
     },
@@ -339,8 +339,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Gloucester-Southgate",
-        "lang:fr_CA": "Gloucester-Southgate"
+        "lang:en": "Gloucester-Southgate",
+        "lang:fr": "Gloucester-Southgate"
       },
       "parent_id": "Q1930"
     },
@@ -363,8 +363,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Kanata North",
-        "lang:fr_CA": "Kanata-Nord"
+        "lang:en": "Kanata North",
+        "lang:fr": "Kanata-Nord"
       },
       "parent_id": "Q1930"
     },
@@ -387,8 +387,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Kanata South",
-        "lang:fr_CA": "Kanata-Sud"
+        "lang:en": "Kanata South",
+        "lang:fr": "Kanata-Sud"
       },
       "parent_id": "Q1930"
     },
@@ -411,8 +411,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Kitchissippi",
-        "lang:fr_CA": "Kitchissippi"
+        "lang:en": "Kitchissippi",
+        "lang:fr": "Kitchissippi"
       },
       "parent_id": "Q1930"
     },
@@ -435,8 +435,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Knoxdale-Merivale",
-        "lang:fr_CA": "Knoxdale-Merivale"
+        "lang:en": "Knoxdale-Merivale",
+        "lang:fr": "Knoxdale-Merivale"
       },
       "parent_id": "Q1930"
     },
@@ -459,8 +459,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Orléans",
-        "lang:fr_CA": "Orléans"
+        "lang:en": "Orléans",
+        "lang:fr": "Orléans"
       },
       "parent_id": "Q1930"
     },
@@ -483,8 +483,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Rideau-Goulbourn",
-        "lang:fr_CA": "Rideau-Goulbourn"
+        "lang:en": "Rideau-Goulbourn",
+        "lang:fr": "Rideau-Goulbourn"
       },
       "parent_id": "Q1930"
     },
@@ -507,8 +507,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Rideau-Rockcliffe",
-        "lang:fr_CA": "Rideau-Rockcliffe"
+        "lang:en": "Rideau-Rockcliffe",
+        "lang:fr": "Rideau-Rockcliffe"
       },
       "parent_id": "Q1930"
     },
@@ -531,8 +531,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Rideau-Vanier",
-        "lang:fr_CA": "Rideau-Vanier"
+        "lang:en": "Rideau-Vanier",
+        "lang:fr": "Rideau-Vanier"
       },
       "parent_id": "Q1930"
     },
@@ -555,8 +555,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "River",
-        "lang:fr_CA": "Rivière"
+        "lang:en": "River",
+        "lang:fr": "Rivière"
       },
       "parent_id": "Q1930"
     },
@@ -579,8 +579,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Somerset",
-        "lang:fr_CA": "Somerset"
+        "lang:en": "Somerset",
+        "lang:fr": "Somerset"
       },
       "parent_id": "Q1930"
     },
@@ -603,8 +603,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "Stittsville",
-        "lang:fr_CA": "Stittsville"
+        "lang:en": "Stittsville",
+        "lang:fr": "Stittsville"
       },
       "parent_id": "Q1930"
     },
@@ -627,8 +627,8 @@
         "lang:en": "municipal electoral district of Ottawa"
       },
       "name": {
-        "lang:en_CA": "West Carleton – March",
-        "lang:fr_CA": "West Carleton – March"
+        "lang:en": "West Carleton – March",
+        "lang:fr": "West Carleton – March"
       },
       "parent_id": "Q1930"
     }

--- a/legislative/Q2994129/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2994129/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -270,8 +270,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -296,8 +296,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -321,7 +321,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Quebec City"
+        "lang:en": "Quebec City"
       },
       "parent_id": "Q176"
     },
@@ -344,7 +344,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Cap-aux-Diamants"
+        "lang:fr": "Cap-aux-Diamants"
       },
       "parent_id": "Q2145"
     },
@@ -367,7 +367,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Montcalm–Saint-Sacrement"
+        "lang:fr": "Montcalm–Saint-Sacrement"
       },
       "parent_id": "Q2145"
     },
@@ -390,7 +390,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Roch–Saint-Sauveur"
+        "lang:fr": "Saint-Roch–Saint-Sauveur"
       },
       "parent_id": "Q2145"
     },
@@ -413,7 +413,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Limoilou"
+        "lang:fr": "Limoilou"
       },
       "parent_id": "Q2145"
     },
@@ -436,7 +436,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Maizerets-Lairet"
+        "lang:fr": "Maizerets-Lairet"
       },
       "parent_id": "Q2145"
     },
@@ -459,7 +459,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Neufchâtel-Lebourgneuf"
+        "lang:fr": "Neufchâtel-Lebourgneuf"
       },
       "parent_id": "Q2145"
     },
@@ -482,7 +482,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Louis–Sillery"
+        "lang:fr": "Saint-Louis–Sillery"
       },
       "parent_id": "Q2145"
     },
@@ -505,7 +505,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Le Plateau"
+        "lang:fr": "Le Plateau"
       },
       "parent_id": "Q2145"
     },
@@ -528,7 +528,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "La Pointe-de-Sainte-Foy"
+        "lang:fr": "La Pointe-de-Sainte-Foy"
       },
       "parent_id": "Q2145"
     },
@@ -551,7 +551,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Cap-Rouge–Laurentien"
+        "lang:fr": "Cap-Rouge–Laurentien"
       },
       "parent_id": "Q2145"
     },
@@ -574,7 +574,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Saint-Rodrigue"
+        "lang:fr": "Saint-Rodrigue"
       },
       "parent_id": "Q2145"
     },
@@ -597,7 +597,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Louis -XIV"
+        "lang:fr": "Louis -XIV"
       },
       "parent_id": "Q2145"
     },
@@ -620,7 +620,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Les Monts"
+        "lang:fr": "Les Monts"
       },
       "parent_id": "Q2145"
     },
@@ -643,7 +643,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Sainte-Thérèse-de-Lisieux"
+        "lang:fr": "Sainte-Thérèse-de-Lisieux"
       },
       "parent_id": "Q2145"
     },
@@ -666,7 +666,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "La Chute-Montmorency–Seigneurial"
+        "lang:fr": "La Chute-Montmorency–Seigneurial"
       },
       "parent_id": "Q2145"
     },
@@ -689,7 +689,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Robert-Giffard"
+        "lang:fr": "Robert-Giffard"
       },
       "parent_id": "Q2145"
     },
@@ -712,7 +712,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Lac-Saint-Charles–Saint-Émile"
+        "lang:fr": "Lac-Saint-Charles–Saint-Émile"
       },
       "parent_id": "Q2145"
     },
@@ -735,7 +735,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Loretteville-Les Châtels"
+        "lang:fr": "Loretteville-Les Châtels"
       },
       "parent_id": "Q2145"
     },
@@ -758,7 +758,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Val-Bélair"
+        "lang:fr": "Val-Bélair"
       },
       "parent_id": "Q2145"
     },
@@ -781,7 +781,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Vanier-Duberger"
+        "lang:fr": "Vanier-Duberger"
       },
       "parent_id": "Q2145"
     },
@@ -804,7 +804,7 @@
         "lang:en": "Municipal electoral districts of Quebec"
       },
       "name": {
-        "lang:fr_CA": "Les Saules"
+        "lang:fr": "Les Saules"
       },
       "parent_id": "Q2145"
     }

--- a/legislative/Q2994131/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2994131/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -282,8 +282,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -308,8 +308,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -333,7 +333,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Montreal"
+        "lang:en": "Montreal"
       },
       "parent_id": "Q176"
     },
@@ -356,7 +356,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Ahuntsic"
+        "lang:en": "Ahuntsic"
       },
       "parent_id": "Q340"
     },
@@ -379,7 +379,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Bordeaux-Cartierville"
+        "lang:en": "Bordeaux-Cartierville"
       },
       "parent_id": "Q340"
     },
@@ -402,7 +402,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Sulpice"
+        "lang:en": "Saint-Sulpice"
       },
       "parent_id": "Q340"
     },
@@ -425,7 +425,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Sault-au-Récollet"
+        "lang:en": "Sault-au-Récollet"
       },
       "parent_id": "Q340"
     },
@@ -448,7 +448,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Côte-des-Neiges"
+        "lang:en": "Côte-des-Neiges"
       },
       "parent_id": "Q340"
     },
@@ -471,7 +471,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Darlington"
+        "lang:en": "Darlington"
       },
       "parent_id": "Q340"
     },
@@ -494,7 +494,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Loyola"
+        "lang:en": "Loyola"
       },
       "parent_id": "Q340"
     },
@@ -517,7 +517,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Notre-Dame-de-Grâce"
+        "lang:en": "Notre-Dame-de-Grâce"
       },
       "parent_id": "Q340"
     },
@@ -540,7 +540,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Snowdon"
+        "lang:en": "Snowdon"
       },
       "parent_id": "Q340"
     },
@@ -563,7 +563,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Cecil-P.-Newman"
+        "lang:en": "Cecil-P.-Newman"
       },
       "parent_id": "Q340"
     },
@@ -586,7 +586,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Sault-Saint-Louis"
+        "lang:en": "Sault-Saint-Louis"
       },
       "parent_id": "Q340"
     },
@@ -609,7 +609,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "DeLorimier"
+        "lang:en": "DeLorimier"
       },
       "parent_id": "Q340"
     },
@@ -632,7 +632,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Jeanne-Mance"
+        "lang:en": "Jeanne-Mance"
       },
       "parent_id": "Q340"
     },
@@ -655,7 +655,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Mile-End"
+        "lang:en": "Mile-End"
       },
       "parent_id": "Q340"
     },
@@ -678,7 +678,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Henri—Petite-Bourgogne—Pointe-Saint-Charles"
+        "lang:en": "Saint-Henri—Petite-Bourgogne—Pointe-Saint-Charles"
       },
       "parent_id": "Q340"
     },
@@ -701,7 +701,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Paul—Émard"
+        "lang:en": "Saint-Paul—Émard"
       },
       "parent_id": "Q340"
     },
@@ -724,7 +724,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Hochelaga"
+        "lang:en": "Hochelaga"
       },
       "parent_id": "Q340"
     },
@@ -747,7 +747,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Louis-Riel"
+        "lang:en": "Louis-Riel"
       },
       "parent_id": "Q340"
     },
@@ -770,7 +770,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Maisonneuve—Longue-Pointe"
+        "lang:en": "Maisonneuve—Longue-Pointe"
       },
       "parent_id": "Q340"
     },
@@ -793,7 +793,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Tétreaultville"
+        "lang:en": "Tétreaultville"
       },
       "parent_id": "Q340"
     },
@@ -816,7 +816,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Marie-Clarac"
+        "lang:en": "Marie-Clarac"
       },
       "parent_id": "Q340"
     },
@@ -839,7 +839,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Ovide-Clermont"
+        "lang:en": "Ovide-Clermont"
       },
       "parent_id": "Q340"
     },
@@ -862,7 +862,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Bois-de-Liesse"
+        "lang:en": "Bois-de-Liesse"
       },
       "parent_id": "Q340"
     },
@@ -885,7 +885,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Cap-Saint-Jacques"
+        "lang:en": "Cap-Saint-Jacques"
       },
       "parent_id": "Q340"
     },
@@ -908,7 +908,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "La Pointe-aux-Prairies"
+        "lang:en": "La Pointe-aux-Prairies"
       },
       "parent_id": "Q340"
     },
@@ -931,7 +931,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Pointe-aux-Trembles"
+        "lang:en": "Pointe-aux-Trembles"
       },
       "parent_id": "Q340"
     },
@@ -954,7 +954,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Rivière-des-Prairies"
+        "lang:en": "Rivière-des-Prairies"
       },
       "parent_id": "Q340"
     },
@@ -977,7 +977,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Étienne-Desmarteau"
+        "lang:en": "Étienne-Desmarteau"
       },
       "parent_id": "Q340"
     },
@@ -1000,7 +1000,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Marie-Victorin"
+        "lang:en": "Marie-Victorin"
       },
       "parent_id": "Q340"
     },
@@ -1023,7 +1023,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Édouard"
+        "lang:en": "Saint-Édouard"
       },
       "parent_id": "Q340"
     },
@@ -1046,7 +1046,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Vieux-Rosemont"
+        "lang:en": "Vieux-Rosemont"
       },
       "parent_id": "Q340"
     },
@@ -1069,7 +1069,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Côte-de-Liesse"
+        "lang:en": "Côte-de-Liesse"
       },
       "parent_id": "Q340"
     },
@@ -1092,7 +1092,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Norman-McLaren"
+        "lang:en": "Norman-McLaren"
       },
       "parent_id": "Q340"
     },
@@ -1115,7 +1115,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Léonard-Est"
+        "lang:en": "Saint-Léonard-Est"
       },
       "parent_id": "Q340"
     },
@@ -1138,7 +1138,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Léonard-Ouest"
+        "lang:en": "Saint-Léonard-Ouest"
       },
       "parent_id": "Q340"
     },
@@ -1161,7 +1161,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Michel"
+        "lang:en": "Saint-Michel"
       },
       "parent_id": "Q340"
     },
@@ -1184,7 +1184,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Champlain—L'Île-des-Soeurs"
+        "lang:en": "Champlain—L'Île-des-Soeurs"
       },
       "parent_id": "Q340"
     },
@@ -1207,7 +1207,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Desmarchais-Crawford"
+        "lang:en": "Desmarchais-Crawford"
       },
       "parent_id": "Q340"
     },
@@ -1230,7 +1230,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Peter-McGill"
+        "lang:en": "Peter-McGill"
       },
       "parent_id": "Q340"
     },
@@ -1253,7 +1253,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Saint-Jacques"
+        "lang:en": "Saint-Jacques"
       },
       "parent_id": "Q340"
     },
@@ -1276,7 +1276,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Sainte-Marie"
+        "lang:en": "Sainte-Marie"
       },
       "parent_id": "Q340"
     },
@@ -1299,7 +1299,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "François-Perrault"
+        "lang:en": "François-Perrault"
       },
       "parent_id": "Q340"
     },
@@ -1322,7 +1322,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Parc-Extension"
+        "lang:en": "Parc-Extension"
       },
       "parent_id": "Q340"
     },
@@ -1345,7 +1345,7 @@
         "lang:en": "municipal electoral district of Montreal"
       },
       "name": {
-        "lang:en_CA": "Villeray"
+        "lang:en": "Villeray"
       },
       "parent_id": "Q340"
     }

--- a/legislative/Q320273/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q320273/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -11725,8 +11725,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -11749,7 +11749,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Argyle-Barrington"
+        "lang:en": "Argyle-Barrington"
       },
       "parent_id": "Q1952"
     },
@@ -11772,7 +11772,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Cape Breton-Richmond"
+        "lang:en": "Cape Breton-Richmond"
       },
       "parent_id": "Q1952"
     },
@@ -11795,7 +11795,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Clare-Digby"
+        "lang:en": "Clare-Digby"
       },
       "parent_id": "Q1952"
     },
@@ -11818,7 +11818,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Clayton Park West"
+        "lang:en": "Clayton Park West"
       },
       "parent_id": "Q1952"
     },
@@ -11841,7 +11841,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Fairview-Clayton Park"
+        "lang:en": "Fairview-Clayton Park"
       },
       "parent_id": "Q1952"
     },
@@ -11864,7 +11864,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Halifax Armdale"
+        "lang:en": "Halifax Armdale"
       },
       "parent_id": "Q1952"
     },
@@ -11887,7 +11887,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Hammonds Plains-Lucasville"
+        "lang:en": "Hammonds Plains-Lucasville"
       },
       "parent_id": "Q1952"
     },
@@ -11910,7 +11910,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Guysborough-Eastern Shore-Tracadie"
+        "lang:en": "Guysborough-Eastern Shore-Tracadie"
       },
       "parent_id": "Q1952"
     },
@@ -11933,7 +11933,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Northside-Westmount"
+        "lang:en": "Northside-Westmount"
       },
       "parent_id": "Q1952"
     },
@@ -11956,7 +11956,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Preston-Dartmouth"
+        "lang:en": "Preston-Dartmouth"
       },
       "parent_id": "Q1952"
     },
@@ -11979,7 +11979,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Queens-Shelburne"
+        "lang:en": "Queens-Shelburne"
       },
       "parent_id": "Q1952"
     },
@@ -12002,7 +12002,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Sydney River-Mira-Louisbourg"
+        "lang:en": "Sydney River-Mira-Louisbourg"
       },
       "parent_id": "Q1952"
     },
@@ -12025,7 +12025,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Sydney-Whitney Pier"
+        "lang:en": "Sydney-Whitney Pier"
       },
       "parent_id": "Q1952"
     },
@@ -12050,8 +12050,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -12074,7 +12074,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Annapolis"
+        "lang:en": "Annapolis"
       },
       "parent_id": "Q1952"
     },
@@ -12097,7 +12097,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Antigonish"
+        "lang:en": "Antigonish"
       },
       "parent_id": "Q1952"
     },
@@ -12120,7 +12120,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Bedford"
+        "lang:en": "Bedford"
       },
       "parent_id": "Q1952"
     },
@@ -12143,7 +12143,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Cape Breton Centre"
+        "lang:en": "Cape Breton Centre"
       },
       "parent_id": "Q1952"
     },
@@ -12166,7 +12166,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Chester-St. Margaret's"
+        "lang:en": "Chester-St. Margaret's"
       },
       "parent_id": "Q1952"
     },
@@ -12189,7 +12189,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Colchester-Musquodoboit Valley"
+        "lang:en": "Colchester-Musquodoboit Valley"
       },
       "parent_id": "Q1952"
     },
@@ -12212,7 +12212,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Colchester North"
+        "lang:en": "Colchester North"
       },
       "parent_id": "Q1952"
     },
@@ -12235,7 +12235,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Cole Harbour-Eastern Passage"
+        "lang:en": "Cole Harbour-Eastern Passage"
       },
       "parent_id": "Q1952"
     },
@@ -12258,7 +12258,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Cole Harbour-Portland Valley"
+        "lang:en": "Cole Harbour-Portland Valley"
       },
       "parent_id": "Q1952"
     },
@@ -12281,7 +12281,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Cumberland North"
+        "lang:en": "Cumberland North"
       },
       "parent_id": "Q1952"
     },
@@ -12304,7 +12304,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Cumberland South"
+        "lang:en": "Cumberland South"
       },
       "parent_id": "Q1952"
     },
@@ -12327,7 +12327,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Dartmouth East"
+        "lang:en": "Dartmouth East"
       },
       "parent_id": "Q1952"
     },
@@ -12350,7 +12350,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Dartmouth North"
+        "lang:en": "Dartmouth North"
       },
       "parent_id": "Q1952"
     },
@@ -12373,7 +12373,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Dartmouth South"
+        "lang:en": "Dartmouth South"
       },
       "parent_id": "Q1952"
     },
@@ -12396,7 +12396,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Eastern Shore"
+        "lang:en": "Eastern Shore"
       },
       "parent_id": "Q1952"
     },
@@ -12419,7 +12419,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Glace Bay"
+        "lang:en": "Glace Bay"
       },
       "parent_id": "Q1952"
     },
@@ -12442,7 +12442,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Halifax Atlantic"
+        "lang:en": "Halifax Atlantic"
       },
       "parent_id": "Q1952"
     },
@@ -12465,7 +12465,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Halifax Chebucto"
+        "lang:en": "Halifax Chebucto"
       },
       "parent_id": "Q1952"
     },
@@ -12488,7 +12488,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Halifax Citadel-Sable Island"
+        "lang:en": "Halifax Citadel-Sable Island"
       },
       "parent_id": "Q1952"
     },
@@ -12511,7 +12511,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Halifax Needham"
+        "lang:en": "Halifax Needham"
       },
       "parent_id": "Q1952"
     },
@@ -12534,7 +12534,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Hants East"
+        "lang:en": "Hants East"
       },
       "parent_id": "Q1952"
     },
@@ -12557,7 +12557,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Hants West"
+        "lang:en": "Hants West"
       },
       "parent_id": "Q1952"
     },
@@ -12580,7 +12580,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Inverness"
+        "lang:en": "Inverness"
       },
       "parent_id": "Q1952"
     },
@@ -12603,7 +12603,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Kings North"
+        "lang:en": "Kings North"
       },
       "parent_id": "Q1952"
     },
@@ -12626,7 +12626,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Kings South"
+        "lang:en": "Kings South"
       },
       "parent_id": "Q1952"
     },
@@ -12649,7 +12649,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Kings West"
+        "lang:en": "Kings West"
       },
       "parent_id": "Q1952"
     },
@@ -12672,7 +12672,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Lunenburg"
+        "lang:en": "Lunenburg"
       },
       "parent_id": "Q1952"
     },
@@ -12695,7 +12695,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Lunenburg West"
+        "lang:en": "Lunenburg West"
       },
       "parent_id": "Q1952"
     },
@@ -12718,7 +12718,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Pictou Centre"
+        "lang:en": "Pictou Centre"
       },
       "parent_id": "Q1952"
     },
@@ -12741,7 +12741,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Pictou East"
+        "lang:en": "Pictou East"
       },
       "parent_id": "Q1952"
     },
@@ -12764,7 +12764,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Pictou West"
+        "lang:en": "Pictou West"
       },
       "parent_id": "Q1952"
     },
@@ -12787,7 +12787,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Sackville-Beaver Bank"
+        "lang:en": "Sackville-Beaver Bank"
       },
       "parent_id": "Q1952"
     },
@@ -12810,7 +12810,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Sackville-Cobequid"
+        "lang:en": "Sackville-Cobequid"
       },
       "parent_id": "Q1952"
     },
@@ -12833,7 +12833,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Timberlea-Prospect"
+        "lang:en": "Timberlea-Prospect"
       },
       "parent_id": "Q1952"
     },
@@ -12856,7 +12856,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Truro-Bible Hill-Millbrook-Salmon River"
+        "lang:en": "Truro-Bible Hill-Millbrook-Salmon River"
       },
       "parent_id": "Q1952"
     },
@@ -12879,7 +12879,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Victoria-The Lakes"
+        "lang:en": "Victoria-The Lakes"
       },
       "parent_id": "Q1952"
     },
@@ -12902,7 +12902,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Waverley-Fall River-Beaver Bank"
+        "lang:en": "Waverley-Fall River-Beaver Bank"
       },
       "parent_id": "Q1952"
     },
@@ -12925,7 +12925,7 @@
         "lang:en": "provincial electoral district of Nova Scotia"
       },
       "name": {
-        "lang:en_CA": "Yarmouth"
+        "lang:en": "Yarmouth"
       },
       "parent_id": "Q1952"
     }

--- a/legislative/Q383590/Q21157957/popolo-m17n.json
+++ b/legislative/Q383590/Q21157957/popolo-m17n.json
@@ -4044,8 +4044,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Oakville",
-        "lang:fr_CA": "Oakville"
+        "lang:en": "Oakville",
+        "lang:fr": "Oakville"
       },
       "parent_id": "Q1904"
     },
@@ -4069,8 +4069,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -4094,8 +4094,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Ahuntsic-Cartierville",
-        "lang:fr_CA": "Ahuntsic-Cartierville"
+        "lang:en": "Ahuntsic-Cartierville",
+        "lang:fr": "Ahuntsic-Cartierville"
       },
       "parent_id": "Q176"
     },
@@ -4119,8 +4119,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Argenteuil--La Petite-Nation",
-        "lang:fr_CA": "Argenteuil--La Petite-Nation"
+        "lang:en": "Argenteuil--La Petite-Nation",
+        "lang:fr": "Argenteuil--La Petite-Nation"
       },
       "parent_id": "Q176"
     },
@@ -4144,8 +4144,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Avignon--La Mitis--Matane--Matapédia",
-        "lang:fr_CA": "Avignon--La Mitis--Matane--Matapédia"
+        "lang:en": "Avignon--La Mitis--Matane--Matapédia",
+        "lang:fr": "Avignon--La Mitis--Matane--Matapédia"
       },
       "parent_id": "Q176"
     },
@@ -4169,8 +4169,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Banff--Airdrie",
-        "lang:fr_CA": "Banff--Airdrie"
+        "lang:en": "Banff--Airdrie",
+        "lang:fr": "Banff--Airdrie"
       },
       "parent_id": "Q1951"
     },
@@ -4194,8 +4194,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Beloeil--Chambly",
-        "lang:fr_CA": "Beloeil--Chambly"
+        "lang:en": "Beloeil--Chambly",
+        "lang:fr": "Beloeil--Chambly"
       },
       "parent_id": "Q176"
     },
@@ -4219,8 +4219,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Thérèse-De Blainville",
-        "lang:fr_CA": "Thérèse-De Blainville"
+        "lang:en": "Thérèse-De Blainville",
+        "lang:fr": "Thérèse-De Blainville"
       },
       "parent_id": "Q176"
     },
@@ -4244,8 +4244,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Bonavista--Burin--Trinity",
-        "lang:fr_CA": "Bonavista--Burin--Trinity"
+        "lang:en": "Bonavista--Burin--Trinity",
+        "lang:fr": "Bonavista--Burin--Trinity"
       },
       "parent_id": "Q2003"
     },
@@ -4269,8 +4269,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Pierre-Boucher--Les Patriotes--Verchères",
-        "lang:fr_CA": "Pierre-Boucher--Les Patriotes--Verchères"
+        "lang:en": "Pierre-Boucher--Les Patriotes--Verchères",
+        "lang:fr": "Pierre-Boucher--Les Patriotes--Verchères"
       },
       "parent_id": "Q176"
     },
@@ -4294,8 +4294,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brossard--Saint-Lambert",
-        "lang:fr_CA": "Brossard--Saint-Lambert"
+        "lang:en": "Brossard--Saint-Lambert",
+        "lang:fr": "Brossard--Saint-Lambert"
       },
       "parent_id": "Q176"
     },
@@ -4319,8 +4319,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Confederation",
-        "lang:fr_CA": "Calgary Confederation"
+        "lang:en": "Calgary Confederation",
+        "lang:fr": "Calgary Confederation"
       },
       "parent_id": "Q1951"
     },
@@ -4344,8 +4344,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Forest Lawn",
-        "lang:fr_CA": "Calgary Forest Lawn"
+        "lang:en": "Calgary Forest Lawn",
+        "lang:fr": "Calgary Forest Lawn"
       },
       "parent_id": "Q1951"
     },
@@ -4369,8 +4369,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Heritage",
-        "lang:fr_CA": "Calgary Heritage"
+        "lang:en": "Calgary Heritage",
+        "lang:fr": "Calgary Heritage"
       },
       "parent_id": "Q1951"
     },
@@ -4394,8 +4394,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Midnapore",
-        "lang:fr_CA": "Calgary Midnapore"
+        "lang:en": "Calgary Midnapore",
+        "lang:fr": "Calgary Midnapore"
       },
       "parent_id": "Q1951"
     },
@@ -4419,8 +4419,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Rocky Ridge",
-        "lang:fr_CA": "Calgary Rocky Ridge"
+        "lang:en": "Calgary Rocky Ridge",
+        "lang:fr": "Calgary Rocky Ridge"
       },
       "parent_id": "Q1951"
     },
@@ -4444,8 +4444,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Shepard",
-        "lang:fr_CA": "Calgary Shepard"
+        "lang:en": "Calgary Shepard",
+        "lang:fr": "Calgary Shepard"
       },
       "parent_id": "Q1951"
     },
@@ -4469,8 +4469,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Skyview",
-        "lang:fr_CA": "Calgary Skyview"
+        "lang:en": "Calgary Skyview",
+        "lang:fr": "Calgary Skyview"
       },
       "parent_id": "Q1951"
     },
@@ -4494,8 +4494,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Central Okanagan--Similkameen--Nicola",
-        "lang:fr_CA": "Central Okanagan--Similkameen--Nicola"
+        "lang:en": "Central Okanagan--Similkameen--Nicola",
+        "lang:fr": "Central Okanagan--Similkameen--Nicola"
       },
       "parent_id": "Q1974"
     },
@@ -4519,8 +4519,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cloverdale--Langley City",
-        "lang:fr_CA": "Cloverdale--Langley City"
+        "lang:en": "Cloverdale--Langley City",
+        "lang:fr": "Cloverdale--Langley City"
       },
       "parent_id": "Q1974"
     },
@@ -4544,8 +4544,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Aurora--Oak Ridges--Richmond Hill",
-        "lang:fr_CA": "Aurora--Oak Ridges--Richmond Hill"
+        "lang:en": "Aurora--Oak Ridges--Richmond Hill",
+        "lang:fr": "Aurora--Oak Ridges--Richmond Hill"
       },
       "parent_id": "Q1904"
     },
@@ -4569,8 +4569,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Coast of Bays--Central--Notre Dame",
-        "lang:fr_CA": "Coast of Bays--Central--Notre Dame"
+        "lang:en": "Coast of Bays--Central--Notre Dame",
+        "lang:fr": "Coast of Bays--Central--Notre Dame"
       },
       "parent_id": "Q2003"
     },
@@ -4594,8 +4594,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Barrie--Innisfil",
-        "lang:fr_CA": "Barrie--Innisfil"
+        "lang:en": "Barrie--Innisfil",
+        "lang:fr": "Barrie--Innisfil"
       },
       "parent_id": "Q1904"
     },
@@ -4619,8 +4619,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Barrie--Springwater--Oro-Medonte",
-        "lang:fr_CA": "Barrie--Springwater--Oro-Medonte"
+        "lang:en": "Barrie--Springwater--Oro-Medonte",
+        "lang:fr": "Barrie--Springwater--Oro-Medonte"
       },
       "parent_id": "Q1904"
     },
@@ -4644,8 +4644,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Battle River--Crowfoot",
-        "lang:fr_CA": "Battle River--Crowfoot"
+        "lang:en": "Battle River--Crowfoot",
+        "lang:fr": "Battle River--Crowfoot"
       },
       "parent_id": "Q1951"
     },
@@ -4669,8 +4669,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Bay of Quinte",
-        "lang:fr_CA": "Baie de Quinte"
+        "lang:en": "Bay of Quinte",
+        "lang:fr": "Baie de Quinte"
       },
       "parent_id": "Q1904"
     },
@@ -4694,8 +4694,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Coquitlam--Port Coquitlam",
-        "lang:fr_CA": "Coquitlam--Port Coquitlam"
+        "lang:en": "Coquitlam--Port Coquitlam",
+        "lang:fr": "Coquitlam--Port Coquitlam"
       },
       "parent_id": "Q1974"
     },
@@ -4719,8 +4719,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Courtenay--Alberni",
-        "lang:fr_CA": "Courtenay--Alberni"
+        "lang:en": "Courtenay--Alberni",
+        "lang:fr": "Courtenay--Alberni"
       },
       "parent_id": "Q1974"
     },
@@ -4744,8 +4744,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cowichan--Malahat--Langford",
-        "lang:fr_CA": "Cowichan--Malahat--Langford"
+        "lang:en": "Cowichan--Malahat--Langford",
+        "lang:fr": "Cowichan--Malahat--Langford"
       },
       "parent_id": "Q1974"
     },
@@ -4769,8 +4769,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brampton East",
-        "lang:fr_CA": "Brampton-Est"
+        "lang:en": "Brampton East",
+        "lang:fr": "Brampton-Est"
       },
       "parent_id": "Q1904"
     },
@@ -4794,8 +4794,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brampton North",
-        "lang:fr_CA": "Brampton-Nord"
+        "lang:en": "Brampton North",
+        "lang:fr": "Brampton-Nord"
       },
       "parent_id": "Q1904"
     },
@@ -4819,8 +4819,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Burnaby North--Seymour",
-        "lang:fr_CA": "Burnaby-Nord--Seymour"
+        "lang:en": "Burnaby North--Seymour",
+        "lang:fr": "Burnaby-Nord--Seymour"
       },
       "parent_id": "Q1974"
     },
@@ -4844,8 +4844,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Signal Hill",
-        "lang:fr_CA": "Calgary Signal Hill"
+        "lang:en": "Calgary Signal Hill",
+        "lang:fr": "Calgary Signal Hill"
       },
       "parent_id": "Q1951"
     },
@@ -4869,8 +4869,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Chilliwack--Hope",
-        "lang:fr_CA": "Chilliwack--Hope"
+        "lang:en": "Chilliwack--Hope",
+        "lang:fr": "Chilliwack--Hope"
       },
       "parent_id": "Q1974"
     },
@@ -4894,8 +4894,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Churchill--Keewatinook Aski",
-        "lang:fr_CA": "Churchill--Keewatinook Aski"
+        "lang:en": "Churchill--Keewatinook Aski",
+        "lang:fr": "Churchill--Keewatinook Aski"
       },
       "parent_id": "Q1948"
     },
@@ -4919,8 +4919,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Dauphin--Swan River--Neepawa",
-        "lang:fr_CA": "Dauphin--Swan River--Neepawa"
+        "lang:en": "Dauphin--Swan River--Neepawa",
+        "lang:fr": "Dauphin--Swan River--Neepawa"
       },
       "parent_id": "Q1948"
     },
@@ -4944,8 +4944,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Ajax",
-        "lang:fr_CA": "Ajax"
+        "lang:en": "Ajax",
+        "lang:fr": "Ajax"
       },
       "parent_id": "Q1904"
     },
@@ -4969,8 +4969,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Châteauguay--Lacolle",
-        "lang:fr_CA": "Châteauguay--Lacolle"
+        "lang:en": "Châteauguay--Lacolle",
+        "lang:fr": "Châteauguay--Lacolle"
       },
       "parent_id": "Q176"
     },
@@ -4994,8 +4994,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Chatham-Kent--Leamington",
-        "lang:fr_CA": "Chatham-Kent--Leamington"
+        "lang:en": "Chatham-Kent--Leamington",
+        "lang:fr": "Chatham-Kent--Leamington"
       },
       "parent_id": "Q1904"
     },
@@ -5019,8 +5019,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Dorval--Lachine--LaSalle",
-        "lang:fr_CA": "Dorval--Lachine--LaSalle"
+        "lang:en": "Dorval--Lachine--LaSalle",
+        "lang:fr": "Dorval--Lachine--LaSalle"
       },
       "parent_id": "Q176"
     },
@@ -5044,8 +5044,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton Griesbach",
-        "lang:fr_CA": "Edmonton Griesbach"
+        "lang:en": "Edmonton Griesbach",
+        "lang:fr": "Edmonton Griesbach"
       },
       "parent_id": "Q1951"
     },
@@ -5069,8 +5069,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton Manning",
-        "lang:fr_CA": "Edmonton Manning"
+        "lang:en": "Edmonton Manning",
+        "lang:fr": "Edmonton Manning"
       },
       "parent_id": "Q1951"
     },
@@ -5094,8 +5094,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton Riverbend",
-        "lang:fr_CA": "Edmonton Riverbend"
+        "lang:en": "Edmonton Riverbend",
+        "lang:fr": "Edmonton Riverbend"
       },
       "parent_id": "Q1951"
     },
@@ -5119,8 +5119,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton--Wetaskiwin",
-        "lang:fr_CA": "Edmonton--Wetaskiwin"
+        "lang:en": "Edmonton--Wetaskiwin",
+        "lang:fr": "Edmonton--Wetaskiwin"
       },
       "parent_id": "Q1951"
     },
@@ -5144,8 +5144,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brampton South",
-        "lang:fr_CA": "Brampton-Sud"
+        "lang:en": "Brampton South",
+        "lang:fr": "Brampton-Sud"
       },
       "parent_id": "Q1904"
     },
@@ -5169,8 +5169,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Burnaby South",
-        "lang:fr_CA": "Burnaby-Sud"
+        "lang:en": "Burnaby South",
+        "lang:fr": "Burnaby-Sud"
       },
       "parent_id": "Q1974"
     },
@@ -5194,8 +5194,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Whitby",
-        "lang:fr_CA": "Whitby"
+        "lang:en": "Whitby",
+        "lang:fr": "Whitby"
       },
       "parent_id": "Q1904"
     },
@@ -5219,8 +5219,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Milton",
-        "lang:fr_CA": "Milton"
+        "lang:en": "Milton",
+        "lang:fr": "Milton"
       },
       "parent_id": "Q1904"
     },
@@ -5244,8 +5244,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton Mill Woods",
-        "lang:fr_CA": "Edmonton Mill Woods"
+        "lang:en": "Edmonton Mill Woods",
+        "lang:fr": "Edmonton Mill Woods"
       },
       "parent_id": "Q1951"
     },
@@ -5269,8 +5269,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Scarborough North",
-        "lang:fr_CA": "Scarborough-Nord"
+        "lang:en": "Scarborough North",
+        "lang:fr": "Scarborough-Nord"
       },
       "parent_id": "Q1904"
     },
@@ -5294,8 +5294,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mississauga--Erin Mills",
-        "lang:fr_CA": "Mississauga--Erin Mills"
+        "lang:en": "Mississauga--Erin Mills",
+        "lang:fr": "Mississauga--Erin Mills"
       },
       "parent_id": "Q1904"
     },
@@ -5319,8 +5319,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Lanark--Frontenac--Kingston",
-        "lang:fr_CA": "Lanark--Frontenac--Kingston"
+        "lang:en": "Lanark--Frontenac--Kingston",
+        "lang:fr": "Lanark--Frontenac--Kingston"
       },
       "parent_id": "Q1904"
     },
@@ -5344,8 +5344,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vaughan--Woodbridge",
-        "lang:fr_CA": "Vaughan--Woodbridge"
+        "lang:en": "Vaughan--Woodbridge",
+        "lang:fr": "Vaughan--Woodbridge"
       },
       "parent_id": "Q1904"
     },
@@ -5369,8 +5369,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Spadina--Fort York",
-        "lang:fr_CA": "Spadina--Fort York"
+        "lang:en": "Spadina--Fort York",
+        "lang:fr": "Spadina--Fort York"
       },
       "parent_id": "Q1904"
     },
@@ -5394,8 +5394,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "University--Rosedale",
-        "lang:fr_CA": "University--Rosedale"
+        "lang:en": "University--Rosedale",
+        "lang:fr": "University--Rosedale"
       },
       "parent_id": "Q1904"
     },
@@ -5419,8 +5419,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Surrey Centre",
-        "lang:fr_CA": "Surrey-Centre"
+        "lang:en": "Surrey Centre",
+        "lang:fr": "Surrey-Centre"
       },
       "parent_id": "Q1974"
     },
@@ -5444,8 +5444,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Ville-Marie--Le Sud-Ouest--Île-des-Soeurs",
-        "lang:fr_CA": "Ville-Marie--Le Sud-Ouest--Île-des-Surs"
+        "lang:en": "Ville-Marie--Le Sud-Ouest--Île-des-Soeurs",
+        "lang:fr": "Ville-Marie--Le Sud-Ouest--Île-des-Surs"
       },
       "parent_id": "Q176"
     },
@@ -5469,8 +5469,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "King--Vaughan",
-        "lang:fr_CA": "King--Vaughan"
+        "lang:en": "King--Vaughan",
+        "lang:fr": "King--Vaughan"
       },
       "parent_id": "Q1904"
     },
@@ -5494,8 +5494,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Niagara West",
-        "lang:fr_CA": "Niagara-Ouest"
+        "lang:en": "Niagara West",
+        "lang:fr": "Niagara-Ouest"
       },
       "parent_id": "Q1904"
     },
@@ -5519,8 +5519,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "St. Albert--Edmonton",
-        "lang:fr_CA": "St. Albert--Edmonton"
+        "lang:en": "St. Albert--Edmonton",
+        "lang:fr": "St. Albert--Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -5544,8 +5544,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sturgeon River--Parkland",
-        "lang:fr_CA": "Sturgeon River--Parkland"
+        "lang:en": "Sturgeon River--Parkland",
+        "lang:fr": "Sturgeon River--Parkland"
       },
       "parent_id": "Q1951"
     },
@@ -5569,8 +5569,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Northumberland--Peterborough South",
-        "lang:fr_CA": "Northumberland--Peterborough-Sud"
+        "lang:en": "Northumberland--Peterborough South",
+        "lang:fr": "Northumberland--Peterborough-Sud"
       },
       "parent_id": "Q1904"
     },
@@ -5594,8 +5594,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Markham--Stouffville",
-        "lang:fr_CA": "Markham--Stouffville"
+        "lang:en": "Markham--Stouffville",
+        "lang:fr": "Markham--Stouffville"
       },
       "parent_id": "Q1904"
     },
@@ -5619,8 +5619,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Foothills",
-        "lang:fr_CA": "Foothills"
+        "lang:en": "Foothills",
+        "lang:fr": "Foothills"
       },
       "parent_id": "Q1951"
     },
@@ -5644,8 +5644,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Pickering--Uxbridge",
-        "lang:fr_CA": "Pickering--Uxbridge"
+        "lang:en": "Pickering--Uxbridge",
+        "lang:fr": "Pickering--Uxbridge"
       },
       "parent_id": "Q1904"
     },
@@ -5669,8 +5669,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mississauga--Malton",
-        "lang:fr_CA": "Mississauga--Malton"
+        "lang:en": "Mississauga--Malton",
+        "lang:fr": "Mississauga--Malton"
       },
       "parent_id": "Q1904"
     },
@@ -5694,8 +5694,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Montarville",
-        "lang:fr_CA": "Montarville"
+        "lang:en": "Montarville",
+        "lang:fr": "Montarville"
       },
       "parent_id": "Q176"
     },
@@ -5719,8 +5719,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Fort McMurray--Cold Lake",
-        "lang:fr_CA": "Fort McMurray--Cold Lake"
+        "lang:en": "Fort McMurray--Cold Lake",
+        "lang:fr": "Fort McMurray--Cold Lake"
       },
       "parent_id": "Q1951"
     },
@@ -5744,8 +5744,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Markham--Thornhill",
-        "lang:fr_CA": "Markham--Thornhill"
+        "lang:en": "Markham--Thornhill",
+        "lang:fr": "Markham--Thornhill"
       },
       "parent_id": "Q1904"
     },
@@ -5769,8 +5769,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vimy",
-        "lang:fr_CA": "Vimy"
+        "lang:en": "Vimy",
+        "lang:fr": "Vimy"
       },
       "parent_id": "Q176"
     },
@@ -5794,8 +5794,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Flamborough--Glanbrook",
-        "lang:fr_CA": "Flamborough--Glanbrook"
+        "lang:en": "Flamborough--Glanbrook",
+        "lang:fr": "Flamborough--Glanbrook"
       },
       "parent_id": "Q1904"
     },
@@ -5819,8 +5819,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Selkirk--Interlake--Eastman",
-        "lang:fr_CA": "Selkirk--Interlake--Eastman"
+        "lang:en": "Selkirk--Interlake--Eastman",
+        "lang:fr": "Selkirk--Interlake--Eastman"
       },
       "parent_id": "Q1948"
     },
@@ -5844,8 +5844,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kitchener South--Hespeler",
-        "lang:fr_CA": "Kitchener-Sud--Hespeler"
+        "lang:en": "Kitchener South--Hespeler",
+        "lang:fr": "Kitchener-Sud--Hespeler"
       },
       "parent_id": "Q1904"
     },
@@ -5869,8 +5869,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Surrey--Newton",
-        "lang:fr_CA": "Surrey--Newton"
+        "lang:en": "Surrey--Newton",
+        "lang:fr": "Surrey--Newton"
       },
       "parent_id": "Q1974"
     },
@@ -5894,8 +5894,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saint John--Rothesay",
-        "lang:fr_CA": "Saint John--Rothesay"
+        "lang:en": "Saint John--Rothesay",
+        "lang:fr": "Saint John--Rothesay"
       },
       "parent_id": "Q1965"
     },
@@ -5919,8 +5919,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Nanaimo--Ladysmith",
-        "lang:fr_CA": "Nanaimo--Ladysmith"
+        "lang:en": "Nanaimo--Ladysmith",
+        "lang:fr": "Nanaimo--Ladysmith"
       },
       "parent_id": "Q1974"
     },
@@ -5944,8 +5944,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Longueuil--Charles-LeMoyne",
-        "lang:fr_CA": "Longueuil--Charles-Lemoyne"
+        "lang:en": "Longueuil--Charles-LeMoyne",
+        "lang:fr": "Longueuil--Charles-Lemoyne"
       },
       "parent_id": "Q176"
     },
@@ -5969,8 +5969,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Scarborough--Rouge Park",
-        "lang:fr_CA": "Scarborough--Rouge Park"
+        "lang:en": "Scarborough--Rouge Park",
+        "lang:fr": "Scarborough--Rouge Park"
       },
       "parent_id": "Q1904"
     },
@@ -5994,8 +5994,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Hamilton West--Ancaster--Dundas",
-        "lang:fr_CA": "Hamilton-Ouest--Ancaster--Dundas"
+        "lang:en": "Hamilton West--Ancaster--Dundas",
+        "lang:fr": "Hamilton-Ouest--Ancaster--Dundas"
       },
       "parent_id": "Q1904"
     },
@@ -6019,8 +6019,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Hastings--Lennox and Addington",
-        "lang:fr_CA": "Hastings--Lennox and Addington"
+        "lang:en": "Hastings--Lennox and Addington",
+        "lang:fr": "Hastings--Lennox and Addington"
       },
       "parent_id": "Q1904"
     },
@@ -6044,8 +6044,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Pitt Meadows--Maple Ridge",
-        "lang:fr_CA": "Pitt Meadows--Maple Ridge"
+        "lang:en": "Pitt Meadows--Maple Ridge",
+        "lang:fr": "Pitt Meadows--Maple Ridge"
       },
       "parent_id": "Q1974"
     },
@@ -6069,8 +6069,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saskatoon--University",
-        "lang:fr_CA": "Saskatoon--University"
+        "lang:en": "Saskatoon--University",
+        "lang:fr": "Saskatoon--University"
       },
       "parent_id": "Q1989"
     },
@@ -6094,8 +6094,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "LaSalle--Émard--Verdun",
-        "lang:fr_CA": "LaSalle--Émard--Verdun"
+        "lang:en": "LaSalle--Émard--Verdun",
+        "lang:fr": "LaSalle--Émard--Verdun"
       },
       "parent_id": "Q176"
     },
@@ -6119,8 +6119,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Grande Prairie--Mackenzie",
-        "lang:fr_CA": "Grande Prairie--Mackenzie"
+        "lang:en": "Grande Prairie--Mackenzie",
+        "lang:fr": "Grande Prairie--Mackenzie"
       },
       "parent_id": "Q1951"
     },
@@ -6144,8 +6144,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saint Boniface--Saint Vital",
-        "lang:fr_CA": "Saint-Boniface--Saint-Vital"
+        "lang:en": "Saint Boniface--Saint Vital",
+        "lang:fr": "Saint-Boniface--Saint-Vital"
       },
       "parent_id": "Q1948"
     },
@@ -6169,8 +6169,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Carlton Trail--Eagle Creek",
-        "lang:fr_CA": "Sentier Carlton--Eagle Creek"
+        "lang:en": "Carlton Trail--Eagle Creek",
+        "lang:fr": "Sentier Carlton--Eagle Creek"
       },
       "parent_id": "Q1989"
     },
@@ -6194,8 +6194,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Red Deer--Lacombe",
-        "lang:fr_CA": "Red Deer--Lacombe"
+        "lang:en": "Red Deer--Lacombe",
+        "lang:fr": "Red Deer--Lacombe"
       },
       "parent_id": "Q1951"
     },
@@ -6219,8 +6219,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sherwood Park--Fort Saskatchewan",
-        "lang:fr_CA": "Sherwood Park--Fort Saskatchewan"
+        "lang:en": "Sherwood Park--Fort Saskatchewan",
+        "lang:fr": "Sherwood Park--Fort Saskatchewan"
       },
       "parent_id": "Q1951"
     },
@@ -6244,8 +6244,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saskatoon--Grasswood",
-        "lang:fr_CA": "Saskatoon--Grasswood"
+        "lang:en": "Saskatoon--Grasswood",
+        "lang:fr": "Saskatoon--Grasswood"
       },
       "parent_id": "Q1989"
     },
@@ -6269,8 +6269,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Long Range Mountains",
-        "lang:fr_CA": "Long Range Mountains"
+        "lang:en": "Long Range Mountains",
+        "lang:fr": "Long Range Mountains"
       },
       "parent_id": "Q2003"
     },
@@ -6294,8 +6294,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Regina--Lewvan",
-        "lang:fr_CA": "Regina--Lewvan"
+        "lang:en": "Regina--Lewvan",
+        "lang:fr": "Regina--Lewvan"
       },
       "parent_id": "Q1989"
     },
@@ -6319,8 +6319,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Langley--Aldergrove",
-        "lang:fr_CA": "Langley--Aldergrove"
+        "lang:en": "Langley--Aldergrove",
+        "lang:fr": "Langley--Aldergrove"
       },
       "parent_id": "Q1974"
     },
@@ -6344,8 +6344,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Salaberry--Suroît",
-        "lang:fr_CA": "Salaberry--Suroît"
+        "lang:en": "Salaberry--Suroît",
+        "lang:fr": "Salaberry--Suroît"
       },
       "parent_id": "Q176"
     },
@@ -6369,8 +6369,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mission--Matsqui--Fraser Canyon",
-        "lang:fr_CA": "Mission--Matsqui--Fraser Canyon"
+        "lang:en": "Mission--Matsqui--Fraser Canyon",
+        "lang:fr": "Mission--Matsqui--Fraser Canyon"
       },
       "parent_id": "Q1974"
     },
@@ -6394,8 +6394,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Steveston--Richmond East",
-        "lang:fr_CA": "Steveston--Richmond-Est"
+        "lang:en": "Steveston--Richmond East",
+        "lang:fr": "Steveston--Richmond-Est"
       },
       "parent_id": "Q1974"
     },
@@ -6419,8 +6419,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "South Surrey--White Rock",
-        "lang:fr_CA": "Surrey-Sud--White Rock"
+        "lang:en": "South Surrey--White Rock",
+        "lang:fr": "Surrey-Sud--White Rock"
       },
       "parent_id": "Q1974"
     },
@@ -6444,8 +6444,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Red Deer--Mountain View",
-        "lang:fr_CA": "Red Deer--Mountain View"
+        "lang:en": "Red Deer--Mountain View",
+        "lang:fr": "Red Deer--Mountain View"
       },
       "parent_id": "Q1951"
     },
@@ -6469,8 +6469,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mirabel",
-        "lang:fr_CA": "Mirabel"
+        "lang:en": "Mirabel",
+        "lang:fr": "Mirabel"
       },
       "parent_id": "Q176"
     },
@@ -6494,8 +6494,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "South Okanagan--West Kootenay",
-        "lang:fr_CA": "Okanagan-Sud--Kootenay-Ouest"
+        "lang:en": "South Okanagan--West Kootenay",
+        "lang:fr": "Okanagan-Sud--Kootenay-Ouest"
       },
       "parent_id": "Q1974"
     },
@@ -6519,8 +6519,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Miramichi--Grand Lake",
-        "lang:fr_CA": "Miramichi--Grand Lake"
+        "lang:en": "Miramichi--Grand Lake",
+        "lang:fr": "Miramichi--Grand Lake"
       },
       "parent_id": "Q1965"
     },
@@ -6544,8 +6544,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Moose Jaw--Lake Centre--Lanigan",
-        "lang:fr_CA": "Moose Jaw--Lake Centre--Lanigan"
+        "lang:en": "Moose Jaw--Lake Centre--Lanigan",
+        "lang:fr": "Moose Jaw--Lake Centre--Lanigan"
       },
       "parent_id": "Q1989"
     },
@@ -6569,8 +6569,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Notre-Dame-de-Grâce--Westmount",
-        "lang:fr_CA": "Notre-Dame-de-Grâce--Westmount"
+        "lang:en": "Notre-Dame-de-Grâce--Westmount",
+        "lang:fr": "Notre-Dame-de-Grâce--Westmount"
       },
       "parent_id": "Q176"
     },
@@ -6594,8 +6594,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kanata--Carleton",
-        "lang:fr_CA": "Kanata--Carleton"
+        "lang:en": "Kanata--Carleton",
+        "lang:fr": "Kanata--Carleton"
       },
       "parent_id": "Q1904"
     },
@@ -6619,8 +6619,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Oakville North--Burlington",
-        "lang:fr_CA": "Oakville-Nord--Burlington"
+        "lang:en": "Oakville North--Burlington",
+        "lang:fr": "Oakville-Nord--Burlington"
       },
       "parent_id": "Q1904"
     },
@@ -6644,8 +6644,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Peace River--Westlock",
-        "lang:fr_CA": "Peace River--Westlock"
+        "lang:en": "Peace River--Westlock",
+        "lang:fr": "Peace River--Westlock"
       },
       "parent_id": "Q1951"
     },
@@ -6669,8 +6669,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Esquimalt--Saanich--Sooke",
-        "lang:fr_CA": "Esquimalt--Saanich--Sooke"
+        "lang:en": "Esquimalt--Saanich--Sooke",
+        "lang:fr": "Esquimalt--Saanich--Sooke"
       },
       "parent_id": "Q1974"
     },
@@ -6694,8 +6694,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vancouver Granville",
-        "lang:fr_CA": "Vancouver Granville"
+        "lang:en": "Vancouver Granville",
+        "lang:fr": "Vancouver Granville"
       },
       "parent_id": "Q1974"
     },
@@ -6720,8 +6720,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -6746,7 +6746,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -6771,7 +6771,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -6796,8 +6796,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -6822,8 +6822,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -6848,8 +6848,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -6874,8 +6874,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -6900,8 +6900,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -6926,8 +6926,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -6952,8 +6952,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -6978,8 +6978,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -7004,7 +7004,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -7029,8 +7029,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     },
@@ -7054,8 +7054,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Longueuil--Saint-Hubert",
-        "lang:fr_CA": "Longueuil--Saint-Hubert"
+        "lang:en": "Longueuil--Saint-Hubert",
+        "lang:fr": "Longueuil--Saint-Hubert"
       },
       "parent_id": "Q176"
     },
@@ -7079,8 +7079,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Durham",
-        "lang:fr_CA": "Durham"
+        "lang:en": "Durham",
+        "lang:fr": "Durham"
       },
       "parent_id": "Q1904"
     },
@@ -7104,8 +7104,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Terrebonne",
-        "lang:fr_CA": "Terrebonne"
+        "lang:en": "Terrebonne",
+        "lang:fr": "Terrebonne"
       },
       "parent_id": "Q176"
     },
@@ -7129,8 +7129,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Halifax",
-        "lang:fr_CA": "Halifax"
+        "lang:en": "Halifax",
+        "lang:fr": "Halifax"
       },
       "parent_id": "Q1952"
     },
@@ -7154,8 +7154,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Fundy Royal",
-        "lang:fr_CA": "Fundy Royal"
+        "lang:en": "Fundy Royal",
+        "lang:fr": "Fundy Royal"
       },
       "parent_id": "Q1965"
     },
@@ -7179,8 +7179,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "St. Catharines",
-        "lang:fr_CA": "St. Catharines"
+        "lang:en": "St. Catharines",
+        "lang:fr": "St. Catharines"
       },
       "parent_id": "Q1904"
     },
@@ -7204,8 +7204,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Abbotsford",
-        "lang:fr_CA": "Abbotsford"
+        "lang:en": "Abbotsford",
+        "lang:fr": "Abbotsford"
       },
       "parent_id": "Q1974"
     },
@@ -7229,8 +7229,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Abitibi--Baie-James--Nunavik--Eeyou",
-        "lang:fr_CA": "Abitibi--Baie-James--Nunavik--Eeyou"
+        "lang:en": "Abitibi--Baie-James--Nunavik--Eeyou",
+        "lang:fr": "Abitibi--Baie-James--Nunavik--Eeyou"
       },
       "parent_id": "Q176"
     },
@@ -7254,8 +7254,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Abitibi--Témiscamingue",
-        "lang:fr_CA": "Abitibi--Témiscamingue"
+        "lang:en": "Abitibi--Témiscamingue",
+        "lang:fr": "Abitibi--Témiscamingue"
       },
       "parent_id": "Q176"
     },
@@ -7279,8 +7279,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Acadie--Bathurst",
-        "lang:fr_CA": "Acadie--Bathurst"
+        "lang:en": "Acadie--Bathurst",
+        "lang:fr": "Acadie--Bathurst"
       },
       "parent_id": "Q1965"
     },
@@ -7304,8 +7304,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Alfred-Pellan",
-        "lang:fr_CA": "Alfred-Pellan"
+        "lang:en": "Alfred-Pellan",
+        "lang:fr": "Alfred-Pellan"
       },
       "parent_id": "Q176"
     },
@@ -7329,8 +7329,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Algoma--Manitoulin--Kapuskasing",
-        "lang:fr_CA": "Algoma--Manitoulin--Kapuskasing"
+        "lang:en": "Algoma--Manitoulin--Kapuskasing",
+        "lang:fr": "Algoma--Manitoulin--Kapuskasing"
       },
       "parent_id": "Q1904"
     },
@@ -7354,8 +7354,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Avalon",
-        "lang:fr_CA": "Avalon"
+        "lang:en": "Avalon",
+        "lang:fr": "Avalon"
       },
       "parent_id": "Q2003"
     },
@@ -7379,8 +7379,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Bécancour--Nicolet--Saurel",
-        "lang:fr_CA": "Bécancour--Nicolet--Saurel"
+        "lang:en": "Bécancour--Nicolet--Saurel",
+        "lang:fr": "Bécancour--Nicolet--Saurel"
       },
       "parent_id": "Q176"
     },
@@ -7404,8 +7404,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Battlefords--Lloydminster",
-        "lang:fr_CA": "Battlefords--Lloydminster"
+        "lang:en": "Battlefords--Lloydminster",
+        "lang:fr": "Battlefords--Lloydminster"
       },
       "parent_id": "Q1989"
     },
@@ -7429,8 +7429,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Beaches--East York",
-        "lang:fr_CA": "Beaches--East York"
+        "lang:en": "Beaches--East York",
+        "lang:fr": "Beaches--East York"
       },
       "parent_id": "Q1904"
     },
@@ -7454,8 +7454,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Beauce",
-        "lang:fr_CA": "Beauce"
+        "lang:en": "Beauce",
+        "lang:fr": "Beauce"
       },
       "parent_id": "Q176"
     },
@@ -7479,8 +7479,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Beauport--Limoilou",
-        "lang:fr_CA": "Beauport--Limoilou"
+        "lang:en": "Beauport--Limoilou",
+        "lang:fr": "Beauport--Limoilou"
       },
       "parent_id": "Q176"
     },
@@ -7504,8 +7504,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Beauséjour",
-        "lang:fr_CA": "Beauséjour"
+        "lang:en": "Beauséjour",
+        "lang:fr": "Beauséjour"
       },
       "parent_id": "Q1965"
     },
@@ -7529,8 +7529,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Berthier--Maskinongé",
-        "lang:fr_CA": "Berthier--Maskinongé"
+        "lang:en": "Berthier--Maskinongé",
+        "lang:fr": "Berthier--Maskinongé"
       },
       "parent_id": "Q176"
     },
@@ -7554,8 +7554,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Huron--Bruce",
-        "lang:fr_CA": "Huron--Bruce"
+        "lang:en": "Huron--Bruce",
+        "lang:fr": "Huron--Bruce"
       },
       "parent_id": "Q1904"
     },
@@ -7579,8 +7579,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Bourassa",
-        "lang:fr_CA": "Bourassa"
+        "lang:en": "Bourassa",
+        "lang:fr": "Bourassa"
       },
       "parent_id": "Q176"
     },
@@ -7604,8 +7604,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Bow River",
-        "lang:fr_CA": "Bow River"
+        "lang:en": "Bow River",
+        "lang:fr": "Bow River"
       },
       "parent_id": "Q1951"
     },
@@ -7629,8 +7629,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brampton Centre",
-        "lang:fr_CA": "Brampton-Centre"
+        "lang:en": "Brampton Centre",
+        "lang:fr": "Brampton-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -7654,8 +7654,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brampton West",
-        "lang:fr_CA": "Brampton-Ouest"
+        "lang:en": "Brampton West",
+        "lang:fr": "Brampton-Ouest"
       },
       "parent_id": "Q1904"
     },
@@ -7679,8 +7679,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brandon--Souris",
-        "lang:fr_CA": "Brandon--Souris"
+        "lang:en": "Brandon--Souris",
+        "lang:fr": "Brandon--Souris"
       },
       "parent_id": "Q1948"
     },
@@ -7704,8 +7704,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brantford--Brant",
-        "lang:fr_CA": "Brantford--Brant"
+        "lang:en": "Brantford--Brant",
+        "lang:fr": "Brantford--Brant"
       },
       "parent_id": "Q1904"
     },
@@ -7729,8 +7729,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Brome--Missisquoi",
-        "lang:fr_CA": "Brome--Missisquoi"
+        "lang:en": "Brome--Missisquoi",
+        "lang:fr": "Brome--Missisquoi"
       },
       "parent_id": "Q176"
     },
@@ -7754,8 +7754,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Bruce--Grey--Owen Sound",
-        "lang:fr_CA": "Bruce--Grey--Owen Sound"
+        "lang:en": "Bruce--Grey--Owen Sound",
+        "lang:fr": "Bruce--Grey--Owen Sound"
       },
       "parent_id": "Q1904"
     },
@@ -7779,8 +7779,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Centre",
-        "lang:fr_CA": "Calgary-Centre"
+        "lang:en": "Calgary Centre",
+        "lang:fr": "Calgary-Centre"
       },
       "parent_id": "Q1951"
     },
@@ -7804,8 +7804,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Calgary Nose Hill",
-        "lang:fr_CA": "Calgary Nose Hill"
+        "lang:en": "Calgary Nose Hill",
+        "lang:fr": "Calgary Nose Hill"
       },
       "parent_id": "Q1951"
     },
@@ -7829,8 +7829,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cambridge",
-        "lang:fr_CA": "Cambridge"
+        "lang:en": "Cambridge",
+        "lang:fr": "Cambridge"
       },
       "parent_id": "Q1904"
     },
@@ -7854,8 +7854,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cape Breton--Canso",
-        "lang:fr_CA": "Cape Breton--Canso"
+        "lang:en": "Cape Breton--Canso",
+        "lang:fr": "Cape Breton--Canso"
       },
       "parent_id": "Q1952"
     },
@@ -7879,8 +7879,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cardigan",
-        "lang:fr_CA": "Cardigan"
+        "lang:en": "Cardigan",
+        "lang:fr": "Cardigan"
       },
       "parent_id": "Q1979"
     },
@@ -7904,8 +7904,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cariboo--Prince George",
-        "lang:fr_CA": "Cariboo--Prince George"
+        "lang:en": "Cariboo--Prince George",
+        "lang:fr": "Cariboo--Prince George"
       },
       "parent_id": "Q1974"
     },
@@ -7929,8 +7929,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Carleton",
-        "lang:fr_CA": "Carleton"
+        "lang:en": "Carleton",
+        "lang:fr": "Carleton"
       },
       "parent_id": "Q1904"
     },
@@ -7954,8 +7954,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Charleswood--St. James--Assiniboia--Headingley",
-        "lang:fr_CA": "Charleswood--St. James--Assiniboia--Headingley"
+        "lang:en": "Charleswood--St. James--Assiniboia--Headingley",
+        "lang:fr": "Charleswood--St. James--Assiniboia--Headingley"
       },
       "parent_id": "Q1948"
     },
@@ -7979,8 +7979,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Charlottetown",
-        "lang:fr_CA": "Charlottetown"
+        "lang:en": "Charlottetown",
+        "lang:fr": "Charlottetown"
       },
       "parent_id": "Q1979"
     },
@@ -8004,8 +8004,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Chicoutimi--Le Fjord",
-        "lang:fr_CA": "Chicoutimi--Le Fjord"
+        "lang:en": "Chicoutimi--Le Fjord",
+        "lang:fr": "Chicoutimi--Le Fjord"
       },
       "parent_id": "Q176"
     },
@@ -8029,8 +8029,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Compton--Stanstead",
-        "lang:fr_CA": "Compton--Stanstead"
+        "lang:en": "Compton--Stanstead",
+        "lang:fr": "Compton--Stanstead"
       },
       "parent_id": "Q176"
     },
@@ -8054,8 +8054,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cumberland--Colchester",
-        "lang:fr_CA": "Cumberland--Colchester"
+        "lang:en": "Cumberland--Colchester",
+        "lang:fr": "Cumberland--Colchester"
       },
       "parent_id": "Q1952"
     },
@@ -8079,8 +8079,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Cypress Hills--Grasslands",
-        "lang:fr_CA": "Cypress Hills--Grasslands"
+        "lang:en": "Cypress Hills--Grasslands",
+        "lang:fr": "Cypress Hills--Grasslands"
       },
       "parent_id": "Q1989"
     },
@@ -8104,8 +8104,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Dartmouth--Cole Harbour",
-        "lang:fr_CA": "Dartmouth--Cole Harbour"
+        "lang:en": "Dartmouth--Cole Harbour",
+        "lang:fr": "Dartmouth--Cole Harbour"
       },
       "parent_id": "Q1952"
     },
@@ -8129,8 +8129,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Davenport",
-        "lang:fr_CA": "Davenport"
+        "lang:en": "Davenport",
+        "lang:fr": "Davenport"
       },
       "parent_id": "Q1904"
     },
@@ -8154,8 +8154,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Delta",
-        "lang:fr_CA": "Delta"
+        "lang:en": "Delta",
+        "lang:fr": "Delta"
       },
       "parent_id": "Q1974"
     },
@@ -8179,8 +8179,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Desnethé--Missinippi--Churchill River",
-        "lang:fr_CA": "Desnethé--Missinippi--Rivière Churchill"
+        "lang:en": "Desnethé--Missinippi--Churchill River",
+        "lang:fr": "Desnethé--Missinippi--Rivière Churchill"
       },
       "parent_id": "Q1989"
     },
@@ -8204,8 +8204,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Don Valley East",
-        "lang:fr_CA": "Don Valley-Est"
+        "lang:en": "Don Valley East",
+        "lang:fr": "Don Valley-Est"
       },
       "parent_id": "Q1904"
     },
@@ -8229,8 +8229,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Don Valley North",
-        "lang:fr_CA": "Don Valley-Nord"
+        "lang:en": "Don Valley North",
+        "lang:fr": "Don Valley-Nord"
       },
       "parent_id": "Q1904"
     },
@@ -8254,8 +8254,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Don Valley West",
-        "lang:fr_CA": "Don Valley-Ouest"
+        "lang:en": "Don Valley West",
+        "lang:fr": "Don Valley-Ouest"
       },
       "parent_id": "Q1904"
     },
@@ -8279,8 +8279,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Drummond",
-        "lang:fr_CA": "Drummond"
+        "lang:en": "Drummond",
+        "lang:fr": "Drummond"
       },
       "parent_id": "Q176"
     },
@@ -8304,8 +8304,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton Centre",
-        "lang:fr_CA": "Edmonton-Centre"
+        "lang:en": "Edmonton Centre",
+        "lang:fr": "Edmonton-Centre"
       },
       "parent_id": "Q1951"
     },
@@ -8329,8 +8329,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton West",
-        "lang:fr_CA": "Edmonton-Ouest"
+        "lang:en": "Edmonton West",
+        "lang:fr": "Edmonton-Ouest"
       },
       "parent_id": "Q1951"
     },
@@ -8354,8 +8354,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Edmonton Strathcona",
-        "lang:fr_CA": "Edmonton Strathcona"
+        "lang:en": "Edmonton Strathcona",
+        "lang:fr": "Edmonton Strathcona"
       },
       "parent_id": "Q1951"
     },
@@ -8379,8 +8379,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Eglinton--Lawrence",
-        "lang:fr_CA": "Eglinton--Lawrence"
+        "lang:en": "Eglinton--Lawrence",
+        "lang:fr": "Eglinton--Lawrence"
       },
       "parent_id": "Q1904"
     },
@@ -8404,8 +8404,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Egmont",
-        "lang:fr_CA": "Egmont"
+        "lang:en": "Egmont",
+        "lang:fr": "Egmont"
       },
       "parent_id": "Q1979"
     },
@@ -8429,8 +8429,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Elgin--Middlesex--London",
-        "lang:fr_CA": "Elgin--Middlesex--London"
+        "lang:en": "Elgin--Middlesex--London",
+        "lang:fr": "Elgin--Middlesex--London"
       },
       "parent_id": "Q1904"
     },
@@ -8454,8 +8454,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Elmwood--Transcona",
-        "lang:fr_CA": "Elmwood--Transcona"
+        "lang:en": "Elmwood--Transcona",
+        "lang:fr": "Elmwood--Transcona"
       },
       "parent_id": "Q1948"
     },
@@ -8479,8 +8479,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Essex",
-        "lang:fr_CA": "Essex"
+        "lang:en": "Essex",
+        "lang:fr": "Essex"
       },
       "parent_id": "Q1904"
     },
@@ -8504,8 +8504,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Etobicoke Centre",
-        "lang:fr_CA": "Etobicoke-Centre"
+        "lang:en": "Etobicoke Centre",
+        "lang:fr": "Etobicoke-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -8529,8 +8529,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Etobicoke North",
-        "lang:fr_CA": "Etobicoke-Nord"
+        "lang:en": "Etobicoke North",
+        "lang:fr": "Etobicoke-Nord"
       },
       "parent_id": "Q1904"
     },
@@ -8554,8 +8554,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Etobicoke--Lakeshore",
-        "lang:fr_CA": "Etobicoke--Lakeshore"
+        "lang:en": "Etobicoke--Lakeshore",
+        "lang:fr": "Etobicoke--Lakeshore"
       },
       "parent_id": "Q1904"
     },
@@ -8579,8 +8579,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Fleetwood--Port Kells",
-        "lang:fr_CA": "Fleetwood--Port Kells"
+        "lang:en": "Fleetwood--Port Kells",
+        "lang:fr": "Fleetwood--Port Kells"
       },
       "parent_id": "Q1974"
     },
@@ -8604,8 +8604,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Fredericton",
-        "lang:fr_CA": "Fredericton"
+        "lang:en": "Fredericton",
+        "lang:fr": "Fredericton"
       },
       "parent_id": "Q1965"
     },
@@ -8629,8 +8629,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Gaspésie--Les Îles-de-la-Madeleine",
-        "lang:fr_CA": "Gaspésie--Les Îles-de-la-Madeleine"
+        "lang:en": "Gaspésie--Les Îles-de-la-Madeleine",
+        "lang:fr": "Gaspésie--Les Îles-de-la-Madeleine"
       },
       "parent_id": "Q176"
     },
@@ -8654,8 +8654,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Glengarry--Prescott--Russell",
-        "lang:fr_CA": "Glengarry--Prescott--Russell"
+        "lang:en": "Glengarry--Prescott--Russell",
+        "lang:fr": "Glengarry--Prescott--Russell"
       },
       "parent_id": "Q1904"
     },
@@ -8679,8 +8679,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Guelph",
-        "lang:fr_CA": "Guelph"
+        "lang:en": "Guelph",
+        "lang:fr": "Guelph"
       },
       "parent_id": "Q1904"
     },
@@ -8704,8 +8704,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Haliburton--Kawartha Lakes--Brock",
-        "lang:fr_CA": "Haliburton--Kawartha Lakes--Brock"
+        "lang:en": "Haliburton--Kawartha Lakes--Brock",
+        "lang:fr": "Haliburton--Kawartha Lakes--Brock"
       },
       "parent_id": "Q1904"
     },
@@ -8729,8 +8729,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Halifax West",
-        "lang:fr_CA": "Halifax-Ouest"
+        "lang:en": "Halifax West",
+        "lang:fr": "Halifax-Ouest"
       },
       "parent_id": "Q1952"
     },
@@ -8754,8 +8754,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Hamilton Centre",
-        "lang:fr_CA": "Hamilton-Centre"
+        "lang:en": "Hamilton Centre",
+        "lang:fr": "Hamilton-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -8779,8 +8779,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Hamilton East--Stoney Creek",
-        "lang:fr_CA": "Hamilton-Est--Stoney Creek"
+        "lang:en": "Hamilton East--Stoney Creek",
+        "lang:fr": "Hamilton-Est--Stoney Creek"
       },
       "parent_id": "Q1904"
     },
@@ -8804,8 +8804,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Hamilton Mountain",
-        "lang:fr_CA": "Hamilton Mountain"
+        "lang:en": "Hamilton Mountain",
+        "lang:fr": "Hamilton Mountain"
       },
       "parent_id": "Q1904"
     },
@@ -8829,8 +8829,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Hochelaga",
-        "lang:fr_CA": "Hochelaga"
+        "lang:en": "Hochelaga",
+        "lang:fr": "Hochelaga"
       },
       "parent_id": "Q176"
     },
@@ -8854,8 +8854,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Honoré-Mercier",
-        "lang:fr_CA": "Honoré-Mercier"
+        "lang:en": "Honoré-Mercier",
+        "lang:fr": "Honoré-Mercier"
       },
       "parent_id": "Q176"
     },
@@ -8879,8 +8879,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Hull--Aylmer",
-        "lang:fr_CA": "Hull--Aylmer"
+        "lang:en": "Hull--Aylmer",
+        "lang:fr": "Hull--Aylmer"
       },
       "parent_id": "Q176"
     },
@@ -8904,8 +8904,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Joliette",
-        "lang:fr_CA": "Joliette"
+        "lang:en": "Joliette",
+        "lang:fr": "Joliette"
       },
       "parent_id": "Q176"
     },
@@ -8929,8 +8929,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Jonquière",
-        "lang:fr_CA": "Jonquière"
+        "lang:en": "Jonquière",
+        "lang:fr": "Jonquière"
       },
       "parent_id": "Q176"
     },
@@ -8954,8 +8954,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kamloops--Thompson--Cariboo",
-        "lang:fr_CA": "Kamloops--Thompson--Cariboo"
+        "lang:en": "Kamloops--Thompson--Cariboo",
+        "lang:fr": "Kamloops--Thompson--Cariboo"
       },
       "parent_id": "Q1974"
     },
@@ -8979,8 +8979,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kelowna--Lake Country",
-        "lang:fr_CA": "Kelowna--Lake Country"
+        "lang:en": "Kelowna--Lake Country",
+        "lang:fr": "Kelowna--Lake Country"
       },
       "parent_id": "Q1974"
     },
@@ -9004,8 +9004,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kenora",
-        "lang:fr_CA": "Kenora"
+        "lang:en": "Kenora",
+        "lang:fr": "Kenora"
       },
       "parent_id": "Q1904"
     },
@@ -9029,8 +9029,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kildonan--St. Paul",
-        "lang:fr_CA": "Kildonan--St. Paul"
+        "lang:en": "Kildonan--St. Paul",
+        "lang:fr": "Kildonan--St. Paul"
       },
       "parent_id": "Q1948"
     },
@@ -9054,8 +9054,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kingston and the Islands",
-        "lang:fr_CA": "Kingston et les Îles"
+        "lang:en": "Kingston and the Islands",
+        "lang:fr": "Kingston et les Îles"
       },
       "parent_id": "Q1904"
     },
@@ -9079,8 +9079,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kings--Hants",
-        "lang:fr_CA": "Kings--Hants"
+        "lang:en": "Kings--Hants",
+        "lang:fr": "Kings--Hants"
       },
       "parent_id": "Q1952"
     },
@@ -9104,8 +9104,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kitchener Centre",
-        "lang:fr_CA": "Kitchener-Centre"
+        "lang:en": "Kitchener Centre",
+        "lang:fr": "Kitchener-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -9129,8 +9129,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kitchener--Conestoga",
-        "lang:fr_CA": "Kitchener--Conestoga"
+        "lang:en": "Kitchener--Conestoga",
+        "lang:fr": "Kitchener--Conestoga"
       },
       "parent_id": "Q1904"
     },
@@ -9154,8 +9154,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Kootenay--Columbia",
-        "lang:fr_CA": "Kootenay--Columbia"
+        "lang:en": "Kootenay--Columbia",
+        "lang:fr": "Kootenay--Columbia"
       },
       "parent_id": "Q1974"
     },
@@ -9179,8 +9179,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "La Pointe-de-l'Île",
-        "lang:fr_CA": "La Pointe-de-l'Île"
+        "lang:en": "La Pointe-de-l'Île",
+        "lang:fr": "La Pointe-de-l'Île"
       },
       "parent_id": "Q176"
     },
@@ -9204,8 +9204,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Labrador",
-        "lang:fr_CA": "Labrador"
+        "lang:en": "Labrador",
+        "lang:fr": "Labrador"
       },
       "parent_id": "Q2003"
     },
@@ -9229,8 +9229,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Lac-Saint-Jean",
-        "lang:fr_CA": "Lac-Saint-Jean"
+        "lang:en": "Lac-Saint-Jean",
+        "lang:fr": "Lac-Saint-Jean"
       },
       "parent_id": "Q176"
     },
@@ -9254,8 +9254,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Lac-Saint-Louis",
-        "lang:fr_CA": "Lac-Saint-Louis"
+        "lang:en": "Lac-Saint-Louis",
+        "lang:fr": "Lac-Saint-Louis"
       },
       "parent_id": "Q176"
     },
@@ -9279,8 +9279,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Lakeland",
-        "lang:fr_CA": "Lakeland"
+        "lang:en": "Lakeland",
+        "lang:fr": "Lakeland"
       },
       "parent_id": "Q1951"
     },
@@ -9304,8 +9304,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Lambton--Kent--Middlesex",
-        "lang:fr_CA": "Lambton--Kent--Middlesex"
+        "lang:en": "Lambton--Kent--Middlesex",
+        "lang:fr": "Lambton--Kent--Middlesex"
       },
       "parent_id": "Q1904"
     },
@@ -9329,8 +9329,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "La Prairie",
-        "lang:fr_CA": "La Prairie"
+        "lang:en": "La Prairie",
+        "lang:fr": "La Prairie"
       },
       "parent_id": "Q176"
     },
@@ -9354,8 +9354,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Laurentides--Labelle",
-        "lang:fr_CA": "Laurentides--Labelle"
+        "lang:en": "Laurentides--Labelle",
+        "lang:fr": "Laurentides--Labelle"
       },
       "parent_id": "Q176"
     },
@@ -9379,8 +9379,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Laurier--Sainte-Marie",
-        "lang:fr_CA": "Laurier--Sainte-Marie"
+        "lang:en": "Laurier--Sainte-Marie",
+        "lang:fr": "Laurier--Sainte-Marie"
       },
       "parent_id": "Q176"
     },
@@ -9404,8 +9404,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Laval--Les Îles",
-        "lang:fr_CA": "Laval--Les Îles"
+        "lang:en": "Laval--Les Îles",
+        "lang:fr": "Laval--Les Îles"
       },
       "parent_id": "Q176"
     },
@@ -9429,8 +9429,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Lethbridge",
-        "lang:fr_CA": "Lethbridge"
+        "lang:en": "Lethbridge",
+        "lang:fr": "Lethbridge"
       },
       "parent_id": "Q1951"
     },
@@ -9454,8 +9454,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "London North Centre",
-        "lang:fr_CA": "London-Centre-Nord"
+        "lang:en": "London North Centre",
+        "lang:fr": "London-Centre-Nord"
       },
       "parent_id": "Q1904"
     },
@@ -9479,8 +9479,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "London West",
-        "lang:fr_CA": "London-Ouest"
+        "lang:en": "London West",
+        "lang:fr": "London-Ouest"
       },
       "parent_id": "Q1904"
     },
@@ -9504,8 +9504,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "London--Fanshawe",
-        "lang:fr_CA": "London--Fanshawe"
+        "lang:en": "London--Fanshawe",
+        "lang:fr": "London--Fanshawe"
       },
       "parent_id": "Q1904"
     },
@@ -9529,8 +9529,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Lévis--Lotbinière",
-        "lang:fr_CA": "Lévis--Lotbinière"
+        "lang:en": "Lévis--Lotbinière",
+        "lang:fr": "Lévis--Lotbinière"
       },
       "parent_id": "Q176"
     },
@@ -9554,8 +9554,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Louis-Hébert",
-        "lang:fr_CA": "Louis-Hébert"
+        "lang:en": "Louis-Hébert",
+        "lang:fr": "Louis-Hébert"
       },
       "parent_id": "Q176"
     },
@@ -9579,8 +9579,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Louis-Saint-Laurent",
-        "lang:fr_CA": "Louis-Saint-Laurent"
+        "lang:en": "Louis-Saint-Laurent",
+        "lang:fr": "Louis-Saint-Laurent"
       },
       "parent_id": "Q176"
     },
@@ -9604,8 +9604,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Bellechasse--Les Etchemins--Lévis",
-        "lang:fr_CA": "Bellechasse--Les Etchemins--Lévis"
+        "lang:en": "Bellechasse--Les Etchemins--Lévis",
+        "lang:fr": "Bellechasse--Les Etchemins--Lévis"
       },
       "parent_id": "Q176"
     },
@@ -9629,8 +9629,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Madawaska--Restigouche",
-        "lang:fr_CA": "Madawaska--Restigouche"
+        "lang:en": "Madawaska--Restigouche",
+        "lang:fr": "Madawaska--Restigouche"
       },
       "parent_id": "Q1965"
     },
@@ -9654,8 +9654,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Manicouagan",
-        "lang:fr_CA": "Manicouagan"
+        "lang:en": "Manicouagan",
+        "lang:fr": "Manicouagan"
       },
       "parent_id": "Q176"
     },
@@ -9679,8 +9679,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Marc-Aurèle-Fortin",
-        "lang:fr_CA": "Marc-Aurèle-Fortin"
+        "lang:en": "Marc-Aurèle-Fortin",
+        "lang:fr": "Marc-Aurèle-Fortin"
       },
       "parent_id": "Q176"
     },
@@ -9704,8 +9704,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Markham--Unionville",
-        "lang:fr_CA": "Markham--Unionville"
+        "lang:en": "Markham--Unionville",
+        "lang:fr": "Markham--Unionville"
       },
       "parent_id": "Q1904"
     },
@@ -9729,8 +9729,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mississauga East--Cooksville",
-        "lang:fr_CA": "Mississauga-Est--Cooksville"
+        "lang:en": "Mississauga East--Cooksville",
+        "lang:fr": "Mississauga-Est--Cooksville"
       },
       "parent_id": "Q1904"
     },
@@ -9754,8 +9754,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mississauga--Lakeshore",
-        "lang:fr_CA": "Mississauga--Lakeshore"
+        "lang:en": "Mississauga--Lakeshore",
+        "lang:fr": "Mississauga--Lakeshore"
       },
       "parent_id": "Q1904"
     },
@@ -9779,8 +9779,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mississauga--Streetsville",
-        "lang:fr_CA": "Mississauga--Streetsville"
+        "lang:en": "Mississauga--Streetsville",
+        "lang:fr": "Mississauga--Streetsville"
       },
       "parent_id": "Q1904"
     },
@@ -9804,8 +9804,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Moncton--Riverview--Dieppe",
-        "lang:fr_CA": "Moncton--Riverview--Dieppe"
+        "lang:en": "Moncton--Riverview--Dieppe",
+        "lang:fr": "Moncton--Riverview--Dieppe"
       },
       "parent_id": "Q1965"
     },
@@ -9829,8 +9829,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mount Royal",
-        "lang:fr_CA": "Mont-Royal"
+        "lang:en": "Mount Royal",
+        "lang:fr": "Mont-Royal"
       },
       "parent_id": "Q176"
     },
@@ -9854,8 +9854,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Montcalm",
-        "lang:fr_CA": "Montcalm"
+        "lang:en": "Montcalm",
+        "lang:fr": "Montcalm"
       },
       "parent_id": "Q176"
     },
@@ -9879,8 +9879,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Montmagny--L'Islet--Kamouraska--Rivière-du-Loup",
-        "lang:fr_CA": "Montmagny--L'Islet--Kamouraska--Rivière-du-Loup"
+        "lang:en": "Montmagny--L'Islet--Kamouraska--Rivière-du-Loup",
+        "lang:fr": "Montmagny--L'Islet--Kamouraska--Rivière-du-Loup"
       },
       "parent_id": "Q176"
     },
@@ -9904,8 +9904,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mégantic--L'Érable",
-        "lang:fr_CA": "Mégantic--L'Érable"
+        "lang:en": "Mégantic--L'Érable",
+        "lang:fr": "Mégantic--L'Érable"
       },
       "parent_id": "Q176"
     },
@@ -9929,8 +9929,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Nepean",
-        "lang:fr_CA": "Nepean"
+        "lang:en": "Nepean",
+        "lang:fr": "Nepean"
       },
       "parent_id": "Q1904"
     },
@@ -9954,8 +9954,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Newmarket--Aurora",
-        "lang:fr_CA": "Newmarket--Aurora"
+        "lang:en": "Newmarket--Aurora",
+        "lang:fr": "Newmarket--Aurora"
       },
       "parent_id": "Q1904"
     },
@@ -9979,8 +9979,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Niagara Centre",
-        "lang:fr_CA": "Niagara-Centre"
+        "lang:en": "Niagara Centre",
+        "lang:fr": "Niagara-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -10004,8 +10004,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Niagara Falls",
-        "lang:fr_CA": "Niagara Falls"
+        "lang:en": "Niagara Falls",
+        "lang:fr": "Niagara Falls"
       },
       "parent_id": "Q1904"
     },
@@ -10029,8 +10029,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Nickel Belt",
-        "lang:fr_CA": "Nickel Belt"
+        "lang:en": "Nickel Belt",
+        "lang:fr": "Nickel Belt"
       },
       "parent_id": "Q1904"
     },
@@ -10054,8 +10054,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Nipissing--Timiskaming",
-        "lang:fr_CA": "Nipissing--Timiskaming"
+        "lang:en": "Nipissing--Timiskaming",
+        "lang:fr": "Nipissing--Timiskaming"
       },
       "parent_id": "Q1904"
     },
@@ -10079,8 +10079,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "North Island--Powell River",
-        "lang:fr_CA": "North Island--Powell River"
+        "lang:en": "North Island--Powell River",
+        "lang:fr": "North Island--Powell River"
       },
       "parent_id": "Q1974"
     },
@@ -10104,8 +10104,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "North Vancouver",
-        "lang:fr_CA": "North Vancouver"
+        "lang:en": "North Vancouver",
+        "lang:fr": "North Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -10129,8 +10129,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "New Brunswick Southwest",
-        "lang:fr_CA": "Nouveau-Brunswick-Sud-Ouest"
+        "lang:en": "New Brunswick Southwest",
+        "lang:fr": "Nouveau-Brunswick-Sud-Ouest"
       },
       "parent_id": "Q1965"
     },
@@ -10154,8 +10154,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Central Nova",
-        "lang:fr_CA": "Nova-Centre"
+        "lang:en": "Central Nova",
+        "lang:fr": "Nova-Centre"
       },
       "parent_id": "Q1952"
     },
@@ -10179,8 +10179,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "West Nova",
-        "lang:fr_CA": "Nova-Ouest"
+        "lang:en": "West Nova",
+        "lang:fr": "Nova-Ouest"
       },
       "parent_id": "Q1952"
     },
@@ -10204,8 +10204,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Oshawa",
-        "lang:fr_CA": "Oshawa"
+        "lang:en": "Oshawa",
+        "lang:fr": "Oshawa"
       },
       "parent_id": "Q1904"
     },
@@ -10229,8 +10229,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Ottawa Centre",
-        "lang:fr_CA": "Ottawa-Centre"
+        "lang:en": "Ottawa Centre",
+        "lang:fr": "Ottawa-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -10254,8 +10254,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Ottawa West--Nepean",
-        "lang:fr_CA": "Ottawa-Ouest--Nepean"
+        "lang:en": "Ottawa West--Nepean",
+        "lang:fr": "Ottawa-Ouest--Nepean"
       },
       "parent_id": "Q1904"
     },
@@ -10279,8 +10279,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Ottawa South",
-        "lang:fr_CA": "Ottawa-Sud"
+        "lang:en": "Ottawa South",
+        "lang:fr": "Ottawa-Sud"
       },
       "parent_id": "Q1904"
     },
@@ -10304,8 +10304,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Orléans",
-        "lang:fr_CA": "Orléans"
+        "lang:en": "Orléans",
+        "lang:fr": "Orléans"
       },
       "parent_id": "Q1904"
     },
@@ -10329,8 +10329,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Ottawa--Vanier",
-        "lang:fr_CA": "Ottawa--Vanier"
+        "lang:en": "Ottawa--Vanier",
+        "lang:fr": "Ottawa--Vanier"
       },
       "parent_id": "Q1904"
     },
@@ -10354,8 +10354,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Outremont",
-        "lang:fr_CA": "Outremont"
+        "lang:en": "Outremont",
+        "lang:fr": "Outremont"
       },
       "parent_id": "Q176"
     },
@@ -10379,8 +10379,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Oxford",
-        "lang:fr_CA": "Oxford"
+        "lang:en": "Oxford",
+        "lang:fr": "Oxford"
       },
       "parent_id": "Q1904"
     },
@@ -10404,8 +10404,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Papineau",
-        "lang:fr_CA": "Papineau"
+        "lang:en": "Papineau",
+        "lang:fr": "Papineau"
       },
       "parent_id": "Q176"
     },
@@ -10429,8 +10429,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Parkdale--High Park",
-        "lang:fr_CA": "Parkdale--High Park"
+        "lang:en": "Parkdale--High Park",
+        "lang:fr": "Parkdale--High Park"
       },
       "parent_id": "Q1904"
     },
@@ -10454,8 +10454,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Parry Sound--Muskoka",
-        "lang:fr_CA": "Parry Sound--Muskoka"
+        "lang:en": "Parry Sound--Muskoka",
+        "lang:fr": "Parry Sound--Muskoka"
       },
       "parent_id": "Q1904"
     },
@@ -10479,8 +10479,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Perth--Wellington",
-        "lang:fr_CA": "Perth--Wellington"
+        "lang:en": "Perth--Wellington",
+        "lang:fr": "Perth--Wellington"
       },
       "parent_id": "Q1904"
     },
@@ -10504,8 +10504,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Peterborough--Kawartha",
-        "lang:fr_CA": "Peterborough--Kawartha"
+        "lang:en": "Peterborough--Kawartha",
+        "lang:fr": "Peterborough--Kawartha"
       },
       "parent_id": "Q1904"
     },
@@ -10529,8 +10529,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Pontiac",
-        "lang:fr_CA": "Pontiac"
+        "lang:en": "Pontiac",
+        "lang:fr": "Pontiac"
       },
       "parent_id": "Q176"
     },
@@ -10554,8 +10554,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Port Moody--Coquitlam",
-        "lang:fr_CA": "Port Moody--Coquitlam"
+        "lang:en": "Port Moody--Coquitlam",
+        "lang:fr": "Port Moody--Coquitlam"
       },
       "parent_id": "Q1974"
     },
@@ -10579,8 +10579,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Portage--Lisgar",
-        "lang:fr_CA": "Portage--Lisgar"
+        "lang:en": "Portage--Lisgar",
+        "lang:fr": "Portage--Lisgar"
       },
       "parent_id": "Q1948"
     },
@@ -10604,8 +10604,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Portneuf--Jacques-Cartier",
-        "lang:fr_CA": "Portneuf--Jacques-Cartier"
+        "lang:en": "Portneuf--Jacques-Cartier",
+        "lang:fr": "Portneuf--Jacques-Cartier"
       },
       "parent_id": "Q176"
     },
@@ -10629,8 +10629,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Prince Albert",
-        "lang:fr_CA": "Prince Albert"
+        "lang:en": "Prince Albert",
+        "lang:fr": "Prince Albert"
       },
       "parent_id": "Q1989"
     },
@@ -10654,8 +10654,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Prince George--Peace River--Northern Rockies",
-        "lang:fr_CA": "Prince George--Peace River--Northern Rockies"
+        "lang:en": "Prince George--Peace River--Northern Rockies",
+        "lang:fr": "Prince George--Peace River--Northern Rockies"
       },
       "parent_id": "Q1974"
     },
@@ -10679,8 +10679,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Provencher",
-        "lang:fr_CA": "Provencher"
+        "lang:en": "Provencher",
+        "lang:fr": "Provencher"
       },
       "parent_id": "Q1948"
     },
@@ -10704,8 +10704,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Québec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Québec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q176"
     },
@@ -10729,8 +10729,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Regina--Qu'Appelle",
-        "lang:fr_CA": "Regina--Qu'Appelle"
+        "lang:en": "Regina--Qu'Appelle",
+        "lang:fr": "Regina--Qu'Appelle"
       },
       "parent_id": "Q1989"
     },
@@ -10754,8 +10754,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Regina--Wascana",
-        "lang:fr_CA": "Regina--Wascana"
+        "lang:en": "Regina--Wascana",
+        "lang:fr": "Regina--Wascana"
       },
       "parent_id": "Q1989"
     },
@@ -10779,8 +10779,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Renfrew--Nipissing--Pembroke",
-        "lang:fr_CA": "Renfrew--Nipissing--Pembroke"
+        "lang:en": "Renfrew--Nipissing--Pembroke",
+        "lang:fr": "Renfrew--Nipissing--Pembroke"
       },
       "parent_id": "Q1904"
     },
@@ -10804,8 +10804,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Repentigny",
-        "lang:fr_CA": "Repentigny"
+        "lang:en": "Repentigny",
+        "lang:fr": "Repentigny"
       },
       "parent_id": "Q176"
     },
@@ -10829,8 +10829,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Richmond Centre",
-        "lang:fr_CA": "Richmond-Centre"
+        "lang:en": "Richmond Centre",
+        "lang:fr": "Richmond-Centre"
       },
       "parent_id": "Q1974"
     },
@@ -10854,8 +10854,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Richmond Hill",
-        "lang:fr_CA": "Richmond Hill"
+        "lang:en": "Richmond Hill",
+        "lang:fr": "Richmond Hill"
       },
       "parent_id": "Q1904"
     },
@@ -10879,8 +10879,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Richmond--Arthabaska",
-        "lang:fr_CA": "Richmond--Arthabaska"
+        "lang:en": "Richmond--Arthabaska",
+        "lang:fr": "Richmond--Arthabaska"
       },
       "parent_id": "Q176"
     },
@@ -10904,8 +10904,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Rimouski-Neigette--Témiscouata--Les Basques",
-        "lang:fr_CA": "Rimouski-Neigette--Témiscouata--Les Basques"
+        "lang:en": "Rimouski-Neigette--Témiscouata--Les Basques",
+        "lang:fr": "Rimouski-Neigette--Témiscouata--Les Basques"
       },
       "parent_id": "Q176"
     },
@@ -10929,8 +10929,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Rivière-des-Mille-Îles",
-        "lang:fr_CA": "Rivière-des-Mille-Îles"
+        "lang:en": "Rivière-des-Mille-Îles",
+        "lang:fr": "Rivière-des-Mille-Îles"
       },
       "parent_id": "Q176"
     },
@@ -10954,8 +10954,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saanich--Gulf Islands",
-        "lang:fr_CA": "Saanich--Gulf Islands"
+        "lang:en": "Saanich--Gulf Islands",
+        "lang:fr": "Saanich--Gulf Islands"
       },
       "parent_id": "Q1974"
     },
@@ -10979,8 +10979,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sackville--Preston--Chezzetcook",
-        "lang:fr_CA": "Sackville--Preston--Chezzetcook"
+        "lang:en": "Sackville--Preston--Chezzetcook",
+        "lang:fr": "Sackville--Preston--Chezzetcook"
       },
       "parent_id": "Q1952"
     },
@@ -11004,8 +11004,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saint-Hyacinthe--Bagot",
-        "lang:fr_CA": "Saint-Hyacinthe--Bagot"
+        "lang:en": "Saint-Hyacinthe--Bagot",
+        "lang:fr": "Saint-Hyacinthe--Bagot"
       },
       "parent_id": "Q176"
     },
@@ -11029,8 +11029,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saint-Jean",
-        "lang:fr_CA": "Saint-Jean"
+        "lang:en": "Saint-Jean",
+        "lang:fr": "Saint-Jean"
       },
       "parent_id": "Q176"
     },
@@ -11054,8 +11054,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saint-Laurent",
-        "lang:fr_CA": "Saint-Laurent"
+        "lang:en": "Saint-Laurent",
+        "lang:fr": "Saint-Laurent"
       },
       "parent_id": "Q176"
     },
@@ -11079,8 +11079,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saint-Léonard--Saint-Michel",
-        "lang:fr_CA": "Saint-Léonard--Saint-Michel"
+        "lang:en": "Saint-Léonard--Saint-Michel",
+        "lang:fr": "Saint-Léonard--Saint-Michel"
       },
       "parent_id": "Q176"
     },
@@ -11104,8 +11104,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saint-Maurice--Champlain",
-        "lang:fr_CA": "Saint-Maurice--Champlain"
+        "lang:en": "Saint-Maurice--Champlain",
+        "lang:fr": "Saint-Maurice--Champlain"
       },
       "parent_id": "Q176"
     },
@@ -11129,8 +11129,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sarnia--Lambton",
-        "lang:fr_CA": "Sarnia--Lambton"
+        "lang:en": "Sarnia--Lambton",
+        "lang:fr": "Sarnia--Lambton"
       },
       "parent_id": "Q1904"
     },
@@ -11154,8 +11154,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Saskatoon West",
-        "lang:fr_CA": "Saskatoon-Ouest"
+        "lang:en": "Saskatoon West",
+        "lang:fr": "Saskatoon-Ouest"
       },
       "parent_id": "Q1989"
     },
@@ -11179,8 +11179,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sault Ste. Marie",
-        "lang:fr_CA": "Sault Ste. Marie"
+        "lang:en": "Sault Ste. Marie",
+        "lang:fr": "Sault Ste. Marie"
       },
       "parent_id": "Q1904"
     },
@@ -11204,8 +11204,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Scarborough Centre",
-        "lang:fr_CA": "Scarborough-Centre"
+        "lang:en": "Scarborough Centre",
+        "lang:fr": "Scarborough-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -11229,8 +11229,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Scarborough Southwest",
-        "lang:fr_CA": "Scarborough-Sud-Ouest"
+        "lang:en": "Scarborough Southwest",
+        "lang:fr": "Scarborough-Sud-Ouest"
       },
       "parent_id": "Q1904"
     },
@@ -11254,8 +11254,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Scarborough--Guildwood",
-        "lang:fr_CA": "Scarborough--Guildwood"
+        "lang:en": "Scarborough--Guildwood",
+        "lang:fr": "Scarborough--Guildwood"
       },
       "parent_id": "Q1904"
     },
@@ -11279,8 +11279,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Scarborough--Agincourt",
-        "lang:fr_CA": "Scarborough--Agincourt"
+        "lang:en": "Scarborough--Agincourt",
+        "lang:fr": "Scarborough--Agincourt"
       },
       "parent_id": "Q1904"
     },
@@ -11304,8 +11304,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Shefford",
-        "lang:fr_CA": "Shefford"
+        "lang:en": "Shefford",
+        "lang:fr": "Shefford"
       },
       "parent_id": "Q176"
     },
@@ -11329,8 +11329,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sherbrooke",
-        "lang:fr_CA": "Sherbrooke"
+        "lang:en": "Sherbrooke",
+        "lang:fr": "Sherbrooke"
       },
       "parent_id": "Q176"
     },
@@ -11354,8 +11354,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Simcoe North",
-        "lang:fr_CA": "Simcoe-Nord"
+        "lang:en": "Simcoe North",
+        "lang:fr": "Simcoe-Nord"
       },
       "parent_id": "Q1904"
     },
@@ -11379,8 +11379,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Simcoe--Grey",
-        "lang:fr_CA": "Simcoe--Grey"
+        "lang:en": "Simcoe--Grey",
+        "lang:fr": "Simcoe--Grey"
       },
       "parent_id": "Q1904"
     },
@@ -11404,8 +11404,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Skeena--Bulkley Valley",
-        "lang:fr_CA": "Skeena--Bulkley Valley"
+        "lang:en": "Skeena--Bulkley Valley",
+        "lang:fr": "Skeena--Bulkley Valley"
       },
       "parent_id": "Q1974"
     },
@@ -11429,8 +11429,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Souris--Moose Mountain",
-        "lang:fr_CA": "Souris--Moose Mountain"
+        "lang:en": "Souris--Moose Mountain",
+        "lang:fr": "Souris--Moose Mountain"
       },
       "parent_id": "Q1989"
     },
@@ -11454,8 +11454,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "South Shore--St. Margarets",
-        "lang:fr_CA": "South Shore--St. Margarets"
+        "lang:en": "South Shore--St. Margarets",
+        "lang:fr": "South Shore--St. Margarets"
       },
       "parent_id": "Q1952"
     },
@@ -11479,8 +11479,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "St. John's East",
-        "lang:fr_CA": "St. John's-Est"
+        "lang:en": "St. John's East",
+        "lang:fr": "St. John's-Est"
       },
       "parent_id": "Q2003"
     },
@@ -11504,8 +11504,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "St. John's South--Mount Pearl",
-        "lang:fr_CA": "St. John's-Sud--Mount Pearl"
+        "lang:en": "St. John's South--Mount Pearl",
+        "lang:fr": "St. John's-Sud--Mount Pearl"
       },
       "parent_id": "Q2003"
     },
@@ -11529,8 +11529,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Toronto--St. Paul's",
-        "lang:fr_CA": "Toronto--St. Paul's"
+        "lang:en": "Toronto--St. Paul's",
+        "lang:fr": "Toronto--St. Paul's"
       },
       "parent_id": "Q1904"
     },
@@ -11554,8 +11554,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Stormont--Dundas--South Glengarry",
-        "lang:fr_CA": "Stormont--Dundas--South Glengarry"
+        "lang:en": "Stormont--Dundas--South Glengarry",
+        "lang:fr": "Stormont--Dundas--South Glengarry"
       },
       "parent_id": "Q1904"
     },
@@ -11579,8 +11579,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sudbury",
-        "lang:fr_CA": "Sudbury"
+        "lang:en": "Sudbury",
+        "lang:fr": "Sudbury"
       },
       "parent_id": "Q1904"
     },
@@ -11604,8 +11604,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Sydney--Victoria",
-        "lang:fr_CA": "Sydney--Victoria"
+        "lang:en": "Sydney--Victoria",
+        "lang:fr": "Sydney--Victoria"
       },
       "parent_id": "Q1952"
     },
@@ -11629,8 +11629,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q2007"
     },
@@ -11654,8 +11654,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Thornhill",
-        "lang:fr_CA": "Thornhill"
+        "lang:en": "Thornhill",
+        "lang:fr": "Thornhill"
       },
       "parent_id": "Q1904"
     },
@@ -11679,8 +11679,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Thunder Bay--Superior North",
-        "lang:fr_CA": "Thunder Bay--Supérieur-Nord"
+        "lang:en": "Thunder Bay--Superior North",
+        "lang:fr": "Thunder Bay--Supérieur-Nord"
       },
       "parent_id": "Q1904"
     },
@@ -11704,8 +11704,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Thunder Bay--Rainy River",
-        "lang:fr_CA": "Thunder Bay--Rainy River"
+        "lang:en": "Thunder Bay--Rainy River",
+        "lang:fr": "Thunder Bay--Rainy River"
       },
       "parent_id": "Q1904"
     },
@@ -11729,8 +11729,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Timmins--James Bay",
-        "lang:fr_CA": "Timmins--Baie James"
+        "lang:en": "Timmins--James Bay",
+        "lang:fr": "Timmins--Baie James"
       },
       "parent_id": "Q1904"
     },
@@ -11754,8 +11754,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Toronto--Danforth",
-        "lang:fr_CA": "Toronto--Danforth"
+        "lang:en": "Toronto--Danforth",
+        "lang:fr": "Toronto--Danforth"
       },
       "parent_id": "Q1904"
     },
@@ -11779,8 +11779,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Trois-Rivières",
-        "lang:fr_CA": "Trois-Rivières"
+        "lang:en": "Trois-Rivières",
+        "lang:fr": "Trois-Rivières"
       },
       "parent_id": "Q176"
     },
@@ -11804,8 +11804,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vancouver Centre",
-        "lang:fr_CA": "Vancouver-Centre"
+        "lang:en": "Vancouver Centre",
+        "lang:fr": "Vancouver-Centre"
       },
       "parent_id": "Q1974"
     },
@@ -11829,8 +11829,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vancouver South",
-        "lang:fr_CA": "Vancouver-Sud"
+        "lang:en": "Vancouver South",
+        "lang:fr": "Vancouver-Sud"
       },
       "parent_id": "Q1974"
     },
@@ -11854,8 +11854,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vancouver Quadra",
-        "lang:fr_CA": "Vancouver Quadra"
+        "lang:en": "Vancouver Quadra",
+        "lang:fr": "Vancouver Quadra"
       },
       "parent_id": "Q1974"
     },
@@ -11879,8 +11879,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vancouver Kingsway",
-        "lang:fr_CA": "Vancouver Kingsway"
+        "lang:en": "Vancouver Kingsway",
+        "lang:fr": "Vancouver Kingsway"
       },
       "parent_id": "Q1974"
     },
@@ -11904,8 +11904,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vaudreuil--Soulanges",
-        "lang:fr_CA": "Vaudreuil--Soulanges"
+        "lang:en": "Vaudreuil--Soulanges",
+        "lang:fr": "Vaudreuil--Soulanges"
       },
       "parent_id": "Q176"
     },
@@ -11929,8 +11929,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Victoria",
-        "lang:fr_CA": "Victoria"
+        "lang:en": "Victoria",
+        "lang:fr": "Victoria"
       },
       "parent_id": "Q1974"
     },
@@ -11954,8 +11954,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Waterloo",
-        "lang:fr_CA": "Waterloo"
+        "lang:en": "Waterloo",
+        "lang:fr": "Waterloo"
       },
       "parent_id": "Q1904"
     },
@@ -11979,8 +11979,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Wellington--Halton Hills",
-        "lang:fr_CA": "Wellington--Halton Hills"
+        "lang:en": "Wellington--Halton Hills",
+        "lang:fr": "Wellington--Halton Hills"
       },
       "parent_id": "Q1904"
     },
@@ -12004,8 +12004,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "West Vancouver--Sunshine Coast--Sea to Sky Country",
-        "lang:fr_CA": "West Vancouver--Sunshine Coast--Sea to Sky Country"
+        "lang:en": "West Vancouver--Sunshine Coast--Sea to Sky Country",
+        "lang:fr": "West Vancouver--Sunshine Coast--Sea to Sky Country"
       },
       "parent_id": "Q1974"
     },
@@ -12029,8 +12029,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Willowdale",
-        "lang:fr_CA": "Willowdale"
+        "lang:en": "Willowdale",
+        "lang:fr": "Willowdale"
       },
       "parent_id": "Q1904"
     },
@@ -12054,8 +12054,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Windsor West",
-        "lang:fr_CA": "Windsor-Ouest"
+        "lang:en": "Windsor West",
+        "lang:fr": "Windsor-Ouest"
       },
       "parent_id": "Q1904"
     },
@@ -12079,8 +12079,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Windsor--Tecumseh",
-        "lang:fr_CA": "Windsor--Tecumseh"
+        "lang:en": "Windsor--Tecumseh",
+        "lang:fr": "Windsor--Tecumseh"
       },
       "parent_id": "Q1904"
     },
@@ -12104,8 +12104,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Winnipeg Centre",
-        "lang:fr_CA": "Winnipeg-Centre"
+        "lang:en": "Winnipeg Centre",
+        "lang:fr": "Winnipeg-Centre"
       },
       "parent_id": "Q1948"
     },
@@ -12129,8 +12129,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Winnipeg South Centre",
-        "lang:fr_CA": "Winnipeg-Centre-Sud"
+        "lang:en": "Winnipeg South Centre",
+        "lang:fr": "Winnipeg-Centre-Sud"
       },
       "parent_id": "Q1948"
     },
@@ -12154,8 +12154,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Winnipeg North",
-        "lang:fr_CA": "Winnipeg-Nord"
+        "lang:en": "Winnipeg North",
+        "lang:fr": "Winnipeg-Nord"
       },
       "parent_id": "Q1948"
     },
@@ -12179,8 +12179,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Winnipeg South",
-        "lang:fr_CA": "Winnipeg-Sud"
+        "lang:en": "Winnipeg South",
+        "lang:fr": "Winnipeg-Sud"
       },
       "parent_id": "Q1948"
     },
@@ -12204,8 +12204,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Yellowhead",
-        "lang:fr_CA": "Yellowhead"
+        "lang:en": "Yellowhead",
+        "lang:fr": "Yellowhead"
       },
       "parent_id": "Q1951"
     },
@@ -12229,8 +12229,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "York Centre",
-        "lang:fr_CA": "York-Centre"
+        "lang:en": "York Centre",
+        "lang:fr": "York-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -12254,8 +12254,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Humber River--Black Creek",
-        "lang:fr_CA": "Humber River--Black Creek"
+        "lang:en": "Humber River--Black Creek",
+        "lang:fr": "Humber River--Black Creek"
       },
       "parent_id": "Q1904"
     },
@@ -12279,8 +12279,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "York South--Weston",
-        "lang:fr_CA": "York-Sud--Weston"
+        "lang:en": "York South--Weston",
+        "lang:fr": "York-Sud--Weston"
       },
       "parent_id": "Q1904"
     },
@@ -12304,8 +12304,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Yorkton--Melville",
-        "lang:fr_CA": "Yorkton--Melville"
+        "lang:en": "Yorkton--Melville",
+        "lang:fr": "Yorkton--Melville"
       },
       "parent_id": "Q1989"
     },
@@ -12329,8 +12329,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "York--Simcoe",
-        "lang:fr_CA": "York--Simcoe"
+        "lang:en": "York--Simcoe",
+        "lang:fr": "York--Simcoe"
       },
       "parent_id": "Q1904"
     },
@@ -12354,8 +12354,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Yukon",
-        "lang:fr_CA": "Yukon"
+        "lang:en": "Yukon",
+        "lang:fr": "Yukon"
       },
       "parent_id": "Q2009"
     },
@@ -12379,8 +12379,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Rivière-du-Nord",
-        "lang:fr_CA": "Rivière-du-Nord"
+        "lang:en": "Rivière-du-Nord",
+        "lang:fr": "Rivière-du-Nord"
       },
       "parent_id": "Q176"
     },
@@ -12404,8 +12404,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Charlesbourg--Haute-Saint-Charles",
-        "lang:fr_CA": "Charlesbourg--Haute-Saint-Charles"
+        "lang:en": "Charlesbourg--Haute-Saint-Charles",
+        "lang:fr": "Charlesbourg--Haute-Saint-Charles"
       },
       "parent_id": "Q176"
     },
@@ -12429,8 +12429,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "North Okanagan--Shuswap",
-        "lang:fr_CA": "North Okanagan--Shuswap"
+        "lang:en": "North Okanagan--Shuswap",
+        "lang:fr": "North Okanagan--Shuswap"
       },
       "parent_id": "Q1974"
     },
@@ -12454,8 +12454,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Malpeque",
-        "lang:fr_CA": "Malpeque"
+        "lang:en": "Malpeque",
+        "lang:fr": "Malpeque"
       },
       "parent_id": "Q1979"
     },
@@ -12479,8 +12479,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Beauport--Côte-de-Beaupré--Île dOrléans--Charlevoix",
-        "lang:fr_CA": "Beauport--Côte-de-Beaupré--Île d'Orléans--Charlevoix"
+        "lang:en": "Beauport--Côte-de-Beaupré--Île dOrléans--Charlevoix",
+        "lang:fr": "Beauport--Côte-de-Beaupré--Île d'Orléans--Charlevoix"
       },
       "parent_id": "Q176"
     },
@@ -12504,8 +12504,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Haldimand--Norfolk",
-        "lang:fr_CA": "Haldimand--Norfolk"
+        "lang:en": "Haldimand--Norfolk",
+        "lang:fr": "Haldimand--Norfolk"
       },
       "parent_id": "Q1904"
     },
@@ -12529,8 +12529,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Leeds--Grenville--Thousand Islands and Rideau Lakes",
-        "lang:fr_CA": "Leeds--Grenville--Thousand Islands et Rideau Lakes"
+        "lang:en": "Leeds--Grenville--Thousand Islands and Rideau Lakes",
+        "lang:fr": "Leeds--Grenville--Thousand Islands et Rideau Lakes"
       },
       "parent_id": "Q1904"
     },
@@ -12554,8 +12554,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q2023"
     },
@@ -12579,8 +12579,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Pierrefonds--Dollard",
-        "lang:fr_CA": "Pierrefonds--Dollard"
+        "lang:en": "Pierrefonds--Dollard",
+        "lang:fr": "Pierrefonds--Dollard"
       },
       "parent_id": "Q176"
     },
@@ -12604,8 +12604,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Dufferin--Caledon",
-        "lang:fr_CA": "Dufferin--Caledon"
+        "lang:en": "Dufferin--Caledon",
+        "lang:fr": "Dufferin--Caledon"
       },
       "parent_id": "Q1904"
     },
@@ -12629,8 +12629,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Tobique--Mactaquac",
-        "lang:fr_CA": "Tobique--Mactaquac"
+        "lang:en": "Tobique--Mactaquac",
+        "lang:fr": "Tobique--Mactaquac"
       },
       "parent_id": "Q1965"
     },
@@ -12654,8 +12654,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "New Westminster--Burnaby",
-        "lang:fr_CA": "New Westminster--Burnaby"
+        "lang:en": "New Westminster--Burnaby",
+        "lang:fr": "New Westminster--Burnaby"
       },
       "parent_id": "Q1974"
     },
@@ -12679,8 +12679,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Gatineau",
-        "lang:fr_CA": "Gatineau"
+        "lang:en": "Gatineau",
+        "lang:fr": "Gatineau"
       },
       "parent_id": "Q176"
     },
@@ -12704,8 +12704,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Rosemont--La Petite-Patrie",
-        "lang:fr_CA": "Rosemont--La Petite-Patrie"
+        "lang:en": "Rosemont--La Petite-Patrie",
+        "lang:fr": "Rosemont--La Petite-Patrie"
       },
       "parent_id": "Q176"
     },
@@ -12729,8 +12729,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Medicine Hat--Cardston--Warner",
-        "lang:fr_CA": "Medicine Hat--Cardston--Warner"
+        "lang:en": "Medicine Hat--Cardston--Warner",
+        "lang:fr": "Medicine Hat--Cardston--Warner"
       },
       "parent_id": "Q1951"
     },
@@ -12754,8 +12754,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Burlington",
-        "lang:fr_CA": "Burlington"
+        "lang:en": "Burlington",
+        "lang:fr": "Burlington"
       },
       "parent_id": "Q1904"
     },
@@ -12779,8 +12779,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Toronto Centre",
-        "lang:fr_CA": "Toronto-Centre"
+        "lang:en": "Toronto Centre",
+        "lang:fr": "Toronto-Centre"
       },
       "parent_id": "Q1904"
     },
@@ -12804,8 +12804,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Vancouver East",
-        "lang:fr_CA": "Vancouver-Est"
+        "lang:en": "Vancouver East",
+        "lang:fr": "Vancouver-Est"
       },
       "parent_id": "Q1974"
     },
@@ -12829,8 +12829,8 @@
         "lang:fr": "circonscription électorale fédérale canadienne"
       },
       "name": {
-        "lang:en_CA": "Mississauga Centre",
-        "lang:fr_CA": "Mississauga-Centre"
+        "lang:en": "Mississauga Centre",
+        "lang:fr": "Mississauga-Centre"
       },
       "parent_id": "Q1904"
     }

--- a/legislative/Q4145705/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q4145705/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -78,8 +78,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -104,8 +104,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -129,7 +129,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Calgary"
+        "lang:en": "Calgary"
       },
       "parent_id": "Q1951"
     },
@@ -152,7 +152,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 1 (Calgary)"
+        "lang:en": "Ward 1 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -175,7 +175,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 2 (Calgary)"
+        "lang:en": "Ward 2 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -198,7 +198,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 3 (Calgary)"
+        "lang:en": "Ward 3 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -221,7 +221,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 4 (Calgary)"
+        "lang:en": "Ward 4 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -244,7 +244,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 5 (Calgary)"
+        "lang:en": "Ward 5 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -267,7 +267,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 6 (Calgary)"
+        "lang:en": "Ward 6 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -290,7 +290,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 7 (Calgary)"
+        "lang:en": "Ward 7 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -313,7 +313,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 8 (Calgary)"
+        "lang:en": "Ward 8 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -336,7 +336,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 9 (Calgary)"
+        "lang:en": "Ward 9 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -359,7 +359,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 10 (Calgary)"
+        "lang:en": "Ward 10 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -382,7 +382,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 11 (Calgary)"
+        "lang:en": "Ward 11 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -405,7 +405,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 12 (Calgary)"
+        "lang:en": "Ward 12 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -428,7 +428,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 13 (Calgary)"
+        "lang:en": "Ward 13 (Calgary)"
       },
       "parent_id": "Q36312"
     },
@@ -451,7 +451,7 @@
         "lang:en": "municipal electoral district of Calgary"
       },
       "name": {
-        "lang:en_CA": "Ward 14 (Calgary)"
+        "lang:en": "Ward 14 (Calgary)"
       },
       "parent_id": "Q36312"
     }

--- a/legislative/Q47489643/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q47489643/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -77,7 +77,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q1974"
     },
@@ -100,7 +100,7 @@
         "lang:en": "municipal electoral district of Vancouver"
       },
       "name": {
-        "lang:en_CA": "Vancouver"
+        "lang:en": "Vancouver"
       },
       "parent_id": "Q24639"
     }

--- a/legislative/Q47489645/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q47489645/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,7 +52,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -76,7 +76,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Winnipeg"
+        "lang:en": "Winnipeg"
       },
       "parent_id": "Q1948"
     },
@@ -99,7 +99,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Old Kildonan"
+        "lang:en": "Old Kildonan"
       },
       "parent_id": "Q2135"
     },
@@ -122,7 +122,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Mynarski"
+        "lang:en": "Mynarski"
       },
       "parent_id": "Q2135"
     },
@@ -145,7 +145,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Point Douglas"
+        "lang:en": "Point Douglas"
       },
       "parent_id": "Q2135"
     },
@@ -168,7 +168,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Daniel McIntyre"
+        "lang:en": "Daniel McIntyre"
       },
       "parent_id": "Q2135"
     },
@@ -191,7 +191,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "St. James - Brooklands - Weston"
+        "lang:en": "St. James - Brooklands - Weston"
       },
       "parent_id": "Q2135"
     },
@@ -214,7 +214,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "St. Charles"
+        "lang:en": "St. Charles"
       },
       "parent_id": "Q2135"
     },
@@ -237,7 +237,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Charleswood - Tuxedo - Whyte Ridge"
+        "lang:en": "Charleswood - Tuxedo - Whyte Ridge"
       },
       "parent_id": "Q2135"
     },
@@ -260,7 +260,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "River Heights - Fort Garry"
+        "lang:en": "River Heights - Fort Garry"
       },
       "parent_id": "Q2135"
     },
@@ -283,7 +283,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Fort Rouge - East Fort Garry"
+        "lang:en": "Fort Rouge - East Fort Garry"
       },
       "parent_id": "Q2135"
     },
@@ -306,7 +306,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "South Winnipeg - St Norbert"
+        "lang:en": "South Winnipeg - St Norbert"
       },
       "parent_id": "Q2135"
     },
@@ -329,7 +329,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "St. Vital"
+        "lang:en": "St. Vital"
       },
       "parent_id": "Q2135"
     },
@@ -352,7 +352,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "St. Boniface"
+        "lang:en": "St. Boniface"
       },
       "parent_id": "Q2135"
     },
@@ -375,7 +375,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Transcona"
+        "lang:en": "Transcona"
       },
       "parent_id": "Q2135"
     },
@@ -398,7 +398,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "Elmwood - East Kildonan"
+        "lang:en": "Elmwood - East Kildonan"
       },
       "parent_id": "Q2135"
     },
@@ -421,7 +421,7 @@
         "lang:en": "municipal electoral district of Winnipeg"
       },
       "name": {
-        "lang:en_CA": "North Kildonan"
+        "lang:en": "North Kildonan"
       },
       "parent_id": "Q2135"
     }

--- a/legislative/Q5339025/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q5339025/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -52,8 +52,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -77,7 +77,7 @@
         "lang:fr": "ville"
       },
       "name": {
-        "lang:en_CA": "Edmonton"
+        "lang:en": "Edmonton"
       },
       "parent_id": "Q1951"
     },
@@ -100,7 +100,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 12"
+        "lang:en": "WARD 12"
       },
       "parent_id": "Q2096"
     },
@@ -123,7 +123,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 01"
+        "lang:en": "WARD 01"
       },
       "parent_id": "Q2096"
     },
@@ -146,7 +146,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 02"
+        "lang:en": "WARD 02"
       },
       "parent_id": "Q2096"
     },
@@ -169,7 +169,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 03"
+        "lang:en": "WARD 03"
       },
       "parent_id": "Q2096"
     },
@@ -192,7 +192,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 04"
+        "lang:en": "WARD 04"
       },
       "parent_id": "Q2096"
     },
@@ -215,7 +215,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 05"
+        "lang:en": "WARD 05"
       },
       "parent_id": "Q2096"
     },
@@ -238,7 +238,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 06"
+        "lang:en": "WARD 06"
       },
       "parent_id": "Q2096"
     },
@@ -261,7 +261,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 07"
+        "lang:en": "WARD 07"
       },
       "parent_id": "Q2096"
     },
@@ -284,7 +284,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 08"
+        "lang:en": "WARD 08"
       },
       "parent_id": "Q2096"
     },
@@ -307,7 +307,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 09"
+        "lang:en": "WARD 09"
       },
       "parent_id": "Q2096"
     },
@@ -330,7 +330,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 10"
+        "lang:en": "WARD 10"
       },
       "parent_id": "Q2096"
     },
@@ -353,7 +353,7 @@
         "lang:en": "municipal electoral district of Edmonton"
       },
       "name": {
-        "lang:en_CA": "WARD 11"
+        "lang:en": "WARD 11"
       },
       "parent_id": "Q2096"
     }

--- a/legislative/Q825815/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q825815/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -169,8 +169,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -195,8 +195,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -219,7 +219,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Alberton-Roseville"
+        "lang:en": "Alberton-Roseville"
       },
       "parent_id": "Q1979"
     },
@@ -242,7 +242,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Belfast-Murray River"
+        "lang:en": "Belfast-Murray River"
       },
       "parent_id": "Q1979"
     },
@@ -265,7 +265,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Borden-Kinkora"
+        "lang:en": "Borden-Kinkora"
       },
       "parent_id": "Q1979"
     },
@@ -288,7 +288,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Charlottetown-Brighton"
+        "lang:en": "Charlottetown-Brighton"
       },
       "parent_id": "Q1979"
     },
@@ -311,7 +311,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Charlottetown-Parkdale"
+        "lang:en": "Charlottetown-Parkdale"
       },
       "parent_id": "Q1979"
     },
@@ -334,7 +334,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Charlottetown-Lewis Point"
+        "lang:en": "Charlottetown-Lewis Point"
       },
       "parent_id": "Q1979"
     },
@@ -357,7 +357,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Charlottetown-Sherwood"
+        "lang:en": "Charlottetown-Sherwood"
       },
       "parent_id": "Q1979"
     },
@@ -380,7 +380,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Charlottetown-Victoria Park"
+        "lang:en": "Charlottetown-Victoria Park"
       },
       "parent_id": "Q1979"
     },
@@ -403,7 +403,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Cornwall-Meadowbank"
+        "lang:en": "Cornwall-Meadowbank"
       },
       "parent_id": "Q1979"
     },
@@ -426,7 +426,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Evangeline-Miscouche"
+        "lang:en": "Evangeline-Miscouche"
       },
       "parent_id": "Q1979"
     },
@@ -449,7 +449,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Georgetown-St. Peters"
+        "lang:en": "Georgetown-St. Peters"
       },
       "parent_id": "Q1979"
     },
@@ -472,7 +472,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Kellys Cross-Cumberland"
+        "lang:en": "Kellys Cross-Cumberland"
       },
       "parent_id": "Q1979"
     },
@@ -495,7 +495,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Kensington-Malpeque"
+        "lang:en": "Kensington-Malpeque"
       },
       "parent_id": "Q1979"
     },
@@ -518,7 +518,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Montague-Kilmuir"
+        "lang:en": "Montague-Kilmuir"
       },
       "parent_id": "Q1979"
     },
@@ -541,7 +541,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Morell-Mermaid"
+        "lang:en": "Morell-Mermaid"
       },
       "parent_id": "Q1979"
     },
@@ -564,7 +564,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "O'Leary-Inverness"
+        "lang:en": "O'Leary-Inverness"
       },
       "parent_id": "Q1979"
     },
@@ -587,7 +587,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Rustico-Emerald"
+        "lang:en": "Rustico-Emerald"
       },
       "parent_id": "Q1979"
     },
@@ -610,7 +610,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Souris-Elmira"
+        "lang:en": "Souris-Elmira"
       },
       "parent_id": "Q1979"
     },
@@ -633,7 +633,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Stratford-Kinlock"
+        "lang:en": "Stratford-Kinlock"
       },
       "parent_id": "Q1979"
     },
@@ -656,7 +656,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Summerside-St. Eleanors"
+        "lang:en": "Summerside-St. Eleanors"
       },
       "parent_id": "Q1979"
     },
@@ -679,7 +679,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Summerside-Wilmot"
+        "lang:en": "Summerside-Wilmot"
       },
       "parent_id": "Q1979"
     },
@@ -702,7 +702,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Tignish-Palmer Road"
+        "lang:en": "Tignish-Palmer Road"
       },
       "parent_id": "Q1979"
     },
@@ -725,7 +725,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Tracadie-Hillsborough Park"
+        "lang:en": "Tracadie-Hillsborough Park"
       },
       "parent_id": "Q1979"
     },
@@ -748,7 +748,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Tyne Valley-Linkletter"
+        "lang:en": "Tyne Valley-Linkletter"
       },
       "parent_id": "Q1979"
     },
@@ -771,7 +771,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "Vernon River-Stratford"
+        "lang:en": "Vernon River-Stratford"
       },
       "parent_id": "Q1979"
     },
@@ -794,7 +794,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "West Royalty-Springvale"
+        "lang:en": "West Royalty-Springvale"
       },
       "parent_id": "Q1979"
     },
@@ -817,7 +817,7 @@
         "lang:en": "provincial electoral district of Prince Edward Island"
       },
       "name": {
-        "lang:en_CA": "York-Oyster Bed"
+        "lang:en": "York-Oyster Bed"
       },
       "parent_id": "Q1979"
     }

--- a/legislative/Q841180/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q841180/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -13475,8 +13475,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -13501,8 +13501,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Quebec",
-        "lang:fr_CA": "Québec"
+        "lang:en": "Quebec",
+        "lang:fr": "Québec"
       },
       "parent_id": "Q16"
     },
@@ -13527,7 +13527,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Ontario"
+        "lang:en": "Ontario"
       },
       "parent_id": "Q16"
     },
@@ -13552,7 +13552,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Manitoba"
+        "lang:en": "Manitoba"
       },
       "parent_id": "Q16"
     },
@@ -13577,8 +13577,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Alberta",
-        "lang:fr_CA": "Alberta"
+        "lang:en": "Alberta",
+        "lang:fr": "Alberta"
       },
       "parent_id": "Q16"
     },
@@ -13603,8 +13603,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nova Scotia",
-        "lang:fr_CA": "Nouvelle-Écosse"
+        "lang:en": "Nova Scotia",
+        "lang:fr": "Nouvelle-Écosse"
       },
       "parent_id": "Q16"
     },
@@ -13629,8 +13629,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "New Brunswick",
-        "lang:fr_CA": "Nouveau-Brunswick"
+        "lang:en": "New Brunswick",
+        "lang:fr": "Nouveau-Brunswick"
       },
       "parent_id": "Q16"
     },
@@ -13655,8 +13655,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "British Columbia",
-        "lang:fr_CA": "Colombie-Britannique"
+        "lang:en": "British Columbia",
+        "lang:fr": "Colombie-Britannique"
       },
       "parent_id": "Q16"
     },
@@ -13681,8 +13681,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Prince Edward Island",
-        "lang:fr_CA": "Île-du-Prince-Édouard"
+        "lang:en": "Prince Edward Island",
+        "lang:fr": "Île-du-Prince-Édouard"
       },
       "parent_id": "Q16"
     },
@@ -13707,8 +13707,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Saskatchewan",
-        "lang:fr_CA": "Saskatchewan"
+        "lang:en": "Saskatchewan",
+        "lang:fr": "Saskatchewan"
       },
       "parent_id": "Q16"
     },
@@ -13733,8 +13733,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Newfoundland and Labrador",
-        "lang:fr_CA": "Terre-Neuve et Labrador"
+        "lang:en": "Newfoundland and Labrador",
+        "lang:fr": "Terre-Neuve et Labrador"
       },
       "parent_id": "Q16"
     },
@@ -13759,8 +13759,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Northwest Territories",
-        "lang:fr_CA": "Territoires du Nord-Ouest"
+        "lang:en": "Northwest Territories",
+        "lang:fr": "Territoires du Nord-Ouest"
       },
       "parent_id": "Q16"
     },
@@ -13785,7 +13785,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -13810,8 +13810,8 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Nunavut",
-        "lang:fr_CA": "Nunavut"
+        "lang:en": "Nunavut",
+        "lang:fr": "Nunavut"
       },
       "parent_id": "Q16"
     }

--- a/legislative/Q908022/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q908022/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -1374,8 +1374,8 @@
         "lang:fr": "pays"
       },
       "name": {
-        "lang:en_CA": "Canada",
-        "lang:fr_CA": "Canada"
+        "lang:en": "Canada",
+        "lang:fr": "Canada"
       },
       "parent_id": null
     },
@@ -1398,7 +1398,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Copperbelt North"
+        "lang:en": "Copperbelt North"
       },
       "parent_id": "Q2009"
     },
@@ -1421,7 +1421,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Copperbelt South"
+        "lang:en": "Copperbelt South"
       },
       "parent_id": "Q2009"
     },
@@ -1444,7 +1444,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Mountainview"
+        "lang:en": "Mountainview"
       },
       "parent_id": "Q2009"
     },
@@ -1467,7 +1467,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Takhini Kopper King"
+        "lang:en": "Takhini Kopper King"
       },
       "parent_id": "Q2009"
     },
@@ -1490,7 +1490,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Mount Lorne - Southern Lakes"
+        "lang:en": "Mount Lorne - Southern Lakes"
       },
       "parent_id": "Q2009"
     },
@@ -1515,7 +1515,7 @@
         "lang:fr": "provinces et territoires du Canada"
       },
       "name": {
-        "lang:en_CA": "Yukon"
+        "lang:en": "Yukon"
       },
       "parent_id": "Q16"
     },
@@ -1538,7 +1538,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Klondike"
+        "lang:en": "Klondike"
       },
       "parent_id": "Q2009"
     },
@@ -1561,7 +1561,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Kluane"
+        "lang:en": "Kluane"
       },
       "parent_id": "Q2009"
     },
@@ -1584,7 +1584,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Lake Laberge"
+        "lang:en": "Lake Laberge"
       },
       "parent_id": "Q2009"
     },
@@ -1607,7 +1607,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Mayo Tatchun"
+        "lang:en": "Mayo Tatchun"
       },
       "parent_id": "Q2009"
     },
@@ -1630,7 +1630,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Pelly Nisutlin"
+        "lang:en": "Pelly Nisutlin"
       },
       "parent_id": "Q2009"
     },
@@ -1653,7 +1653,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Porter Creek Centre"
+        "lang:en": "Porter Creek Centre"
       },
       "parent_id": "Q2009"
     },
@@ -1676,7 +1676,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Porter Creek North"
+        "lang:en": "Porter Creek North"
       },
       "parent_id": "Q2009"
     },
@@ -1699,7 +1699,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Porter Creek South"
+        "lang:en": "Porter Creek South"
       },
       "parent_id": "Q2009"
     },
@@ -1722,7 +1722,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Riverdale South"
+        "lang:en": "Riverdale South"
       },
       "parent_id": "Q2009"
     },
@@ -1745,7 +1745,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Riverdale North"
+        "lang:en": "Riverdale North"
       },
       "parent_id": "Q2009"
     },
@@ -1768,7 +1768,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Vuntut Gwitchin"
+        "lang:en": "Vuntut Gwitchin"
       },
       "parent_id": "Q2009"
     },
@@ -1791,7 +1791,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Whitehorse Centre"
+        "lang:en": "Whitehorse Centre"
       },
       "parent_id": "Q2009"
     },
@@ -1814,7 +1814,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Whitehorse West"
+        "lang:en": "Whitehorse West"
       },
       "parent_id": "Q2009"
     },
@@ -1837,7 +1837,7 @@
         "lang:en": "territorial electoral district of Yukon"
       },
       "name": {
-        "lang:en_CA": "Watson Lake"
+        "lang:en": "Watson Lake"
       },
       "parent_id": "Q2009"
     }


### PR DESCRIPTION
In #25 I updated `config.json` to use Wikidata language codes, but forgot about `boundaries/index.json`, which has a language-to-name-column mapping. This PR finishes off the code migration work.

I've grepped for `en_CA` and `fr_CA` in the resulting branch, and both strings are now nowhere to be found, as intended.