### PR TITLE
Clean build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/everypolitician/commons-builder.git
-  revision: 2465e18f00c6aaa07c89934fb0c02572ef0d9318
+  revision: 936a12eddd2fc0eda3d910bde60f605d34960c26
   specs:
     commons-builder (0.1.0)
       commons-integrity

--- a/build_output.txt
+++ b/build_output.txt
@@ -1,6 +1,7 @@
 WARNING: Position member of Vaughan City Council (Q56099571) not in boundary associated_wikidata_positions
 WARNING: Position member of Markham City Council (Q56099529) not in boundary associated_wikidata_positions
 WARNING: Position member of Surrey City Council (Q56099617) not in boundary associated_wikidata_positions
+WARNING: the district Shawinigan (Q18642499) wasn't found in the boundary data for position Member of the Senate of Canada (Q18524027)
 WARNING: Position Mayor of Laval (Q56097740) not in boundary associated_wikidata_positions
 WARNING: Position Mayor of Vaughan (Q56099574) not in boundary associated_wikidata_positions
 WARNING: Position maire de Saint-Jean (Q28382706) not in boundary associated_wikidata_positions

--- a/executive/Q5419831/current/query-results.json
+++ b/executive/Q5419831/current/query-results.json
@@ -778,17 +778,17 @@
       },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q138345"
+        "value" : "http://www.wikidata.org/entity/Q21035865"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Liberal Party of Canada"
+        "value" : "Senate Liberal Caucus"
       },
       "party_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Parti libéral du Canada"
+        "value" : "caucus des sénateurs libéraux"
       }
     }, {
       "statement" : {
@@ -866,17 +866,17 @@
       },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21035865"
+        "value" : "http://www.wikidata.org/entity/Q138345"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Senate Liberal Caucus"
+        "value" : "Liberal Party of Canada"
       },
       "party_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "caucus des sénateurs libéraux"
+        "value" : "Parti libéral du Canada"
       }
     }, {
       "statement" : {

--- a/executive/Q5589283/current/popolo-m17n.json
+++ b/executive/Q5589283/current/popolo-m17n.json
@@ -1,9 +1,55 @@
 {
   "persons": [
-
+    {
+      "name": {
+        "lang:en": "Doug Ford Jr.",
+        "lang:fr": "Doug Ford Jr."
+      },
+      "id": "Q5300478",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5300478"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/FordNationDougFord"
+        }
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:en": "Government of Ontario",
+        "lang:fr": "gouvernement de l'Ontario"
+      },
+      "id": "Q5589283",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5589283"
+        }
+      ],
+      "area_id": "Q1904"
+    },
+    {
+      "name": {
+        "lang:en": "Progressive Conservative Party of Ontario",
+        "lang:fr": "Parti progressiste-conservateur de l'Ontario"
+      },
+      "id": "Q826977",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q826977"
+        }
+      ]
+    }
   ],
   "areas": [
     {
@@ -58,6 +104,23 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5300478-e412768b-4428-1be2-a607-384ade23fa64",
+      "person_id": "Q5300478",
+      "on_behalf_of_id": "Q826977",
+      "organization_id": "Q5589283",
+      "area_id": "Q1904",
+      "start_date": "2018-06-29",
+      "role_superclass_code": "Q2505921",
+      "role_superclass": {
+        "lang:en": "premier",
+        "lang:fr": "premier ministre du Canada"
+      },
+      "role_code": "Q2560704",
+      "role": {
+        "lang:en": "Premier of Ontario",
+        "lang:fr": "Premier ministre de l'Ontario"
+      }
+    }
   ]
 }

--- a/executive/Q5589283/current/query-results.json
+++ b/executive/Q5589283/current/query-results.json
@@ -3,6 +3,108 @@
     "vars" : [ "statement", "item", "name_en", "name_fr", "party", "party_name_en", "party_name_fr", "district", "district_name_en", "district_name_fr", "role", "role_en", "role_fr", "start", "end", "facebook", "role_superclass", "role_superclass_en", "role_superclass_fr", "org", "org_en", "org_fr", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5300478-e412768b-4428-1be2-a607-384ade23fa64"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5300478"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Doug Ford Jr."
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Doug Ford Jr."
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q826977"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Party of Ontario"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti progressiste-conservateur de l'Ontario"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ontario"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ontario"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2560704"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Premier of Ontario"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Premier ministre de l'Ontario"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-06-29T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "FordNationDougFord"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2505921"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "premier"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "premier ministre du Canada"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5589283"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Government of Ontario"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "gouvernement de l'Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      }
+    } ]
   }
 }

--- a/legislative/Q1323479/Q29561388/popolo-m17n.json
+++ b/legislative/Q1323479/Q29561388/popolo-m17n.json
@@ -130,6 +130,22 @@
     },
     {
       "name": {
+        "lang:en": "John Martin",
+        "lang:fr": "John Martin"
+      },
+      "id": "Q16244253",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16244253"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Mike Morris",
         "lang:fr": "Mike Morris"
       },
@@ -686,6 +702,22 @@
     },
     {
       "name": {
+        "lang:en": "Christy Clark",
+        "lang:fr": "Christy Clark"
+      },
+      "id": "Q460064",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q460064"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Adrian Dix",
         "lang:fr": "Adrian Dix"
       },
@@ -1085,6 +1117,25 @@
     },
     {
       "name": {
+        "lang:en": "Leonard Krog",
+        "lang:fr": "Leonard Krog"
+      },
+      "id": "Q6525470",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6525470"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/leonardkrogmlananaimo"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Linda Reid",
         "lang:fr": "Linda Reid"
       },
@@ -1293,6 +1344,22 @@
     },
     {
       "name": {
+        "lang:en": "Richard Lee",
+        "lang:fr": "Richard Lee"
+      },
+      "id": "Q7327305",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7327305"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Scott Fraser",
         "lang:fr": "Scott Fraser"
       },
@@ -1390,6 +1457,20 @@
       "seat_counts": {
         "Q19004821": "87"
       }
+    },
+    {
+      "name": {
+        "lang:en": "British Columbia New Democratic Party",
+        "lang:fr": "Nouveau Parti démocratique de la Colombie-Britannique"
+      },
+      "id": "Q919052",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q919052"
+        }
+      ]
     }
   ],
   "areas": [
@@ -3592,6 +3673,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q16244253-d10c2701-4d1f-00f1-f290-6682f6b82b85",
+      "person_id": "Q16244253",
+      "organization_id": "Q1323479",
+      "area_id": "Q5099089",
+      "start_date": "2013-01-01",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19004821",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of British Columbia",
+        "lang:fr": "membre de l'Assemblée législative de la Colombie-Britannique"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q16244342-07745E30-AC6E-42B0-B4D1-B07D21C2187C",
       "person_id": "Q16244342",
       "organization_id": "Q1323479",
@@ -4169,6 +4267,24 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q460064-998BA52E-D914-4004-848A-BE6D9A348809",
+      "person_id": "Q460064",
+      "organization_id": "Q1323479",
+      "area_id": "Q7989671",
+      "start_date": "2013-07-10",
+      "end_date": "2017-08-04",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19004821",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of British Columbia",
+        "lang:fr": "membre de l'Assemblée législative de la Colombie-Britannique"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q4684985-FF8FA14B-A036-4B30-97F9-61AD5E23585A",
       "person_id": "Q4684985",
       "organization_id": "Q1323479",
@@ -4601,6 +4717,24 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q6525470-1c97b4dd-4256-6d54-514c-00069782db7a",
+      "person_id": "Q6525470",
+      "on_behalf_of_id": "Q919052",
+      "organization_id": "Q1323479",
+      "area_id": "Q10857025",
+      "start_date": "2017-06-22",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19004821",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of British Columbia",
+        "lang:fr": "membre de l'Assemblée législative de la Colombie-Britannique"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q6551917-2F18FA30-DFD4-4BC3-94B2-7183BBBDB7D8",
       "person_id": "Q6551917",
       "organization_id": "Q1323479",
@@ -4813,6 +4947,23 @@
       "person_id": "Q7323220",
       "organization_id": "Q1323479",
       "area_id": "Q28233141",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19004821",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of British Columbia",
+        "lang:fr": "membre de l'Assemblée législative de la Colombie-Britannique"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7327305-b01d1443-4b53-3c44-3524-84609fe59a3a",
+      "person_id": "Q7327305",
+      "organization_id": "Q1323479",
+      "area_id": "Q4999593",
+      "start_date": "2001-05-16",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q1323479/Q29561388/query-results.json
+++ b/legislative/Q1323479/Q29561388/query-results.json
@@ -737,6 +737,90 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5099089"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Chilliwack"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16244253-d10c2701-4d1f-00f1-f290-6682f6b82b85"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19004821"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Colombie-Britannique"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of British Columbia"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16244253"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "John Martin"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1323479"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de la Colombie-Britannique"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of British Columbia"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1974"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Martin"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-01-01T00:00:00Z"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7244010"
       },
       "district_name_en" : {
@@ -3566,6 +3650,100 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7989671"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Westside-Kelowna"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q460064-998BA52E-D914-4004-848A-BE6D9A348809"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19004821"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Colombie-Britannique"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of British Columbia"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q460064"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Christy Clark"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1323479"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de la Colombie-Britannique"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of British Columbia"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1974"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Christy Clark"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Westside-Kelowna"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-07-10T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-08-04T00:00:00Z"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7914101"
       },
       "district_name_en" : {
@@ -5758,6 +5936,113 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q10857025"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nanaimo"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6525470-1c97b4dd-4256-6d54-514c-00069782db7a"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19004821"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Colombie-Britannique"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of British Columbia"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6525470"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Leonard Krog"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1323479"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de la Colombie-Britannique"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of British Columbia"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1974"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Leonard Krog"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nanaimo"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-22T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "leonardkrogmlananaimo"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q919052"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique de la Colombie-Britannique"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "British Columbia New Democratic Party"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q28233150"
       },
       "district_name_en" : {
@@ -5930,7 +6215,7 @@
       },
       "statement" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q6780534-F7FB4F90-32CD-4271-9888-86DD622BB300"
+        "value" : "http://www.wikidata.org/entity/statement/Q6780534-B222EF7A-6E1F-4D9B-BE30-9E55CC9C4FC7"
       },
       "role_superclass" : {
         "type" : "uri",
@@ -6009,7 +6294,7 @@
       },
       "statement" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q6780534-B222EF7A-6E1F-4D9B-BE30-9E55CC9C4FC7"
+        "value" : "http://www.wikidata.org/entity/statement/Q6780534-F7FB4F90-32CD-4271-9888-86DD622BB300"
       },
       "role_superclass" : {
         "type" : "uri",
@@ -6890,6 +7175,95 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Rich Coleman"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4999593"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Burnaby North"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7327305-b01d1443-4b53-3c44-3524-84609fe59a3a"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19004821"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Colombie-Britannique"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of British Columbia"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7327305"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Richard Lee"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1323479"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de la Colombie-Britannique"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of British Columbia"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1974"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Lee"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Burnaby-Nord"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2001-05-16T00:00:00Z"
       }
     }, {
       "district" : {

--- a/legislative/Q1323479/Q29561388/query-used.rq
+++ b/legislative/Q1323479/Q29561388/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q29561388 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q29561388 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q29561388 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q29561388 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q1492249/Q16246364/popolo-m17n.json
+++ b/legislative/Q1492249/Q16246364/popolo-m17n.json
@@ -386,6 +386,22 @@
     },
     {
       "name": {
+        "lang:en": "Marc H. Plante",
+        "lang:fr": "Marc H. Plante"
+      },
+      "id": "Q16864576",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16864576"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Yves St-Denis",
         "lang:fr": "Yves St-Denis"
       },
@@ -478,6 +494,41 @@
       ],
       "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Jean-Paul Diamond",
+        "lang:fr": "Jean-Paul Diamond"
+      },
+      "id": "Q2379503",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2379503"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Mireille Jean",
+        "lang:fr": "Mireille Jean"
+      },
+      "id": "Q24053442",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q24053442"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/Mireille-Jean-1728674760702848"
+        }
       ]
     },
     {
@@ -754,6 +805,38 @@
     },
     {
       "name": {
+        "lang:en": "Francine Charbonneau",
+        "lang:fr": "Francine Charbonneau"
+      },
+      "id": "Q3081197",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3081197"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "François Gendron",
+        "lang:fr": "François Gendron"
+      },
+      "id": "Q3084718",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3084718"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "François Legault",
         "lang:fr": "François Legault"
       },
@@ -778,6 +861,22 @@
         {
           "scheme": "wikidata",
           "identifier": "Q3085498"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Françoise David",
+        "lang:fr": "Françoise David"
+      },
+      "id": "Q3086459",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3086459"
         }
       ],
       "links": [
@@ -882,6 +981,22 @@
     },
     {
       "name": {
+        "lang:en": "Jacques Daoust",
+        "lang:fr": "Jacques Daoust"
+      },
+      "id": "Q3158630",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3158630"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Jean-François Lisée",
         "lang:fr": "Jean-François Lisée"
       },
@@ -954,6 +1069,38 @@
         {
           "scheme": "wikidata",
           "identifier": "Q3194088"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Laurent Lessard",
+        "lang:fr": "Laurent Lessard"
+      },
+      "id": "Q3219349",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3219349"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Lise Thériault",
+        "lang:fr": "Lise Thériault"
+      },
+      "id": "Q3242528",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3242528"
         }
       ],
       "links": [
@@ -1186,6 +1333,25 @@
     },
     {
       "name": {
+        "lang:en": "Philippe Couillard",
+        "lang:fr": "Philippe Couillard"
+      },
+      "id": "Q3379654",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3379654"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/phcouillard"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Pierre-Michel Auger",
         "lang:fr": "Pierre-Michel Auger"
       },
@@ -1210,6 +1376,22 @@
         {
           "scheme": "wikidata",
           "identifier": "Q3383756"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Pierre Moreau",
+        "lang:fr": "Pierre Moreau"
+      },
+      "id": "Q3386345",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3386345"
         }
       ],
       "links": [
@@ -1487,6 +1669,22 @@
       "links": [
 
       ]
+    },
+    {
+      "name": {
+        "lang:en": "Sam Hamad",
+        "lang:fr": "Sam Hamad"
+      },
+      "id": "Q921062",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q921062"
+        }
+      ],
+      "links": [
+
+      ]
     }
   ],
   "organizations": [
@@ -1507,6 +1705,20 @@
       "seat_counts": {
         "Q3305338": "125"
       }
+    },
+    {
+      "name": {
+        "lang:en": "Parti Québécois",
+        "lang:fr": "Parti québécois"
+      },
+      "id": "Q950356",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q950356"
+        }
+      ]
     }
   ],
   "areas": [
@@ -4953,6 +5165,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q16864576-474d72eb-4d48-076d-8f1b-685e2580d99d",
+      "person_id": "Q16864576",
+      "organization_id": "Q1492249",
+      "area_id": "Q3297286",
+      "start_date": "2014-04-07",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q17000245-D4F31EA6-5751-43A9-A7B8-E4B3D7E5DF7E",
       "person_id": "Q17000245",
       "organization_id": "Q1492249",
@@ -5049,6 +5278,42 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q2379503-A1016122-7AED-47AA-887F-8DD9BD4693FB",
+      "person_id": "Q2379503",
+      "organization_id": "Q1492249",
+      "area_id": "Q3297286",
+      "start_date": "2008-12-08",
+      "end_date": "2014-04-07",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q24053442-88f79ff6-4553-863a-48db-c9c31da9c60f",
+      "person_id": "Q24053442",
+      "on_behalf_of_id": "Q950356",
+      "organization_id": "Q1492249",
+      "area_id": "Q2963419",
+      "start_date": "2016-04-11",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q2415818-208F55E4-0005-4323-8D54-18BD40688D6B",
       "person_id": "Q2415818",
       "organization_id": "Q1492249",
@@ -5101,6 +5366,22 @@
       "person_id": "Q2826998",
       "organization_id": "Q1492249",
       "area_id": "Q3515928",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2830317-564A9447-5D7B-4272-9CF1-179864D6B03A",
+      "person_id": "Q2830317",
+      "organization_id": "Q1492249",
+      "area_id": "Q3472258",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -5210,6 +5491,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q2965998-2FF3C932-0F1B-4DE1-A913-410D252EF6F3",
+      "person_id": "Q2965998",
+      "organization_id": "Q1492249",
+      "area_id": "Q2822230",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q2965998-4C48D66E-0229-4F3F-874B-7468C10652AD",
       "person_id": "Q2965998",
       "organization_id": "Q1492249",
@@ -5276,12 +5573,45 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3035523-F7D9C8B3-563D-40E0-9ED4-3E214E775FD4",
+      "person_id": "Q3035523",
+      "organization_id": "Q1492249",
+      "area_id": "Q2894824",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3035523-FD94A299-845B-4080-B081-0B73381217D3",
       "person_id": "Q3035523",
       "organization_id": "Q1492249",
       "area_id": "Q2894824",
       "start_date": "2003-04-14",
       "end_date": "2007-03-26",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3035523-afc41085-4ae8-7c30-445b-9a7803022c63",
+      "person_id": "Q3035523",
+      "organization_id": "Q1492249",
+      "area_id": "Q2894824",
+      "start_date": "2008-12-08",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -5326,6 +5656,40 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3081197-8F221F13-4F3A-4FE7-81B3-4A8A9F8F5489",
+      "person_id": "Q3081197",
+      "organization_id": "Q1492249",
+      "area_id": "Q3314264",
+      "start_date": "2008-12-08",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3084718-5A96202E-426C-454D-AEC8-CE039889CA6B",
+      "person_id": "Q3084718",
+      "organization_id": "Q1492249",
+      "area_id": "Q2821647",
+      "start_date": "1976-11-15",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3085147-61C51508-6A8E-4359-B3D1-06A4B8509882",
       "person_id": "Q3085147",
       "organization_id": "Q1492249",
@@ -5346,6 +5710,24 @@
       "person_id": "Q3085498",
       "organization_id": "Q1492249",
       "area_id": "Q3294760",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3086459-10A92CD0-40EA-4E91-BAFC-35E622742968",
+      "person_id": "Q3086459",
+      "organization_id": "Q1492249",
+      "area_id": "Q3111624",
+      "start_date": "2012-09-04",
+      "end_date": "2017-01-19",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -5454,6 +5836,24 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3158630-2C77F399-12B6-4381-B1AE-A259F2484CEB",
+      "person_id": "Q3158630",
+      "organization_id": "Q1492249",
+      "area_id": "Q3555824",
+      "start_date": "2014-04-07",
+      "end_date": "2016-08-19",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3165748-2B763B74-8E63-4320-9C83-363F62CBBBC9",
       "person_id": "Q3165748",
       "organization_id": "Q1492249",
@@ -5502,6 +5902,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3193323-6328BD78-984F-4BCF-BAE4-110A1021797E",
+      "person_id": "Q3193323",
+      "organization_id": "Q1492249",
+      "area_id": "Q3431469",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3193323-E10B40E9-C28D-41D9-BE6B-5DC76D595E4F",
       "person_id": "Q3193323",
       "organization_id": "Q1492249",
@@ -5519,11 +5935,77 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3194088-1D33AFB6-7C2F-485A-8772-0457077274FB",
+      "person_id": "Q3194088",
+      "organization_id": "Q1492249",
+      "area_id": "Q3344589",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3194088-2B01B6CC-7D8F-4E0C-9D05-A9E45AFBE47C",
       "person_id": "Q3194088",
       "organization_id": "Q1492249",
       "area_id": "Q3344589",
       "start_date": "2008-12-08",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3219349-49cc4ed0-4c46-e730-4398-ac9446644ac9",
+      "person_id": "Q3219349",
+      "organization_id": "Q1492249",
+      "area_id": "Q3259964",
+      "start_date": "2012-09-04",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3219349-E79E87F6-599E-4B5F-B883-2E8AB23096E2",
+      "person_id": "Q3219349",
+      "organization_id": "Q1492249",
+      "area_id": "Q3259964",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3242528-F430026F-DAE4-4E72-A27D-12726ECEF782",
+      "person_id": "Q3242528",
+      "organization_id": "Q1492249",
+      "area_id": "Q2850263",
+      "start_date": "2012-09-04",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -5762,6 +6244,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3379654-FB8C4431-FE29-4AAE-B2CE-1C45AB1F1D2F",
+      "person_id": "Q3379654",
+      "organization_id": "Q1492249",
+      "area_id": "Q2381824",
+      "start_date": "2014-04-07",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3383393-114A634E-DE21-4543-92F4-0E863F3725E7",
       "person_id": "Q3383393",
       "organization_id": "Q1492249",
@@ -5782,6 +6281,23 @@
       "person_id": "Q3383756",
       "organization_id": "Q1492249",
       "area_id": "Q3321617",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3386345-270C6A51-0F40-419E-8AD9-22D809397A53",
+      "person_id": "Q3386345",
+      "organization_id": "Q1492249",
+      "area_id": "Q2971888",
+      "start_date": "2008-12-08",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -5859,6 +6375,38 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3436093-5F9E5DB6-0EDF-46B6-833C-012040F854CD",
+      "person_id": "Q3436093",
+      "organization_id": "Q1492249",
+      "area_id": "Q261059",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3436093-96F55DB8-DA3A-45E7-95A0-C54515E57FD4",
+      "person_id": "Q3436093",
+      "organization_id": "Q1492249",
+      "area_id": "Q261059",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3436093-FCAE51FD-AFA0-4AE2-9E39-F0C2983BB629",
       "person_id": "Q3436093",
       "organization_id": "Q1492249",
@@ -5913,6 +6461,22 @@
       "organization_id": "Q1492249",
       "area_id": "Q3099274",
       "start_date": "2007-03-26",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3502236-886193D9-4D94-420D-8C51-CFEA41A315C5",
+      "person_id": "Q3502236",
+      "organization_id": "Q1492249",
+      "area_id": "Q3099274",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -6023,6 +6587,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q518024-9F3752D1-9B1A-4F8F-9CEE-80E346157AF2",
+      "person_id": "Q518024",
+      "organization_id": "Q1492249",
+      "area_id": "Q3214651",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q518024-BC81A3BA-6C6F-4F76-B461-520B3ED93C8E",
       "person_id": "Q518024",
       "organization_id": "Q1492249",
@@ -6060,6 +6640,23 @@
       "person_id": "Q728648",
       "organization_id": "Q1492249",
       "area_id": "Q3098859",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305338",
+      "role": {
+        "lang:en": "Member of the National Assembly of Quebec",
+        "lang:fr": "député de l'Assemblée nationale du Québec"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q921062-2C020B94-E34A-4A42-887F-C216AC329414",
+      "person_id": "Q921062",
+      "organization_id": "Q1492249",
+      "area_id": "Q3260600",
+      "start_date": "2003-04-14",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q1492249/Q16246364/query-results.json
+++ b/legislative/Q1492249/Q16246364/query-results.json
@@ -4,20 +4,6 @@
   },
   "results" : {
     "bindings" : [ {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3211644"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "La Pinière"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "La Pinière"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15965478-7CEF619D-64AA-4FCD-87D3-456801B2FFFC"
@@ -86,22 +72,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3306380"
+        "value" : "http://www.wikidata.org/entity/Q3211644"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Mercier"
+        "value" : "La Pinière"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Mercier"
-      },
+        "value" : "La Pinière"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q1607747-1C256D45-15BD-4C19-9585-D5C06B2D6D1F"
@@ -171,26 +157,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3306380"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mercier"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mercier"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2008-12-08T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3514032"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Taillon"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Taillon"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16188600-42CF9603-AADE-4727-8582-06D695FE5C64"
@@ -259,22 +245,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3010893"
+        "value" : "http://www.wikidata.org/entity/Q3514032"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "D'Arcy-McGee"
+        "value" : "Taillon"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "D'Arcy-McGee"
-      },
+        "value" : "Taillon"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16205644-49D6DF75-4E9D-4F66-A89C-9A754FEDC447"
@@ -343,22 +329,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3434356"
+        "value" : "http://www.wikidata.org/entity/Q3010893"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Robert-Baldwin"
+        "value" : "D'Arcy-McGee"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Robert-Baldwin"
-      },
+        "value" : "D'Arcy-McGee"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16212596-82F1EB5E-B653-4935-A293-F80595798D6B"
@@ -428,26 +414,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3434356"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert-Baldwin"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Robert-Baldwin"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2014-04-07T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3464415"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sainte-Rose"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Sainte-Rose"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16232138-1241021A-92DB-4F62-A532-11DA9AFAD35B"
@@ -516,22 +502,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3358665"
+        "value" : "http://www.wikidata.org/entity/Q3464415"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Outremont"
+        "value" : "Sainte-Rose"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Outremont"
-      },
+        "value" : "Sainte-Rose"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16243873-2B502CF9-0E09-48A8-9897-467BD8BACE3D"
@@ -601,26 +587,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3358665"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Outremont"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Outremont"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2014-04-07T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3397735"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pontiac"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Pontiac"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16243956-E9D4B148-09C2-4901-BB33-44B11E57ED12"
@@ -689,22 +675,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3462965"
+        "value" : "http://www.wikidata.org/entity/Q3397735"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Maurice"
+        "value" : "Pontiac"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint-Maurice"
-      },
+        "value" : "Pontiac"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16243994-9A1E7C1A-232E-4B66-BECB-1DA263CC4BFC"
@@ -773,22 +759,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3539917"
+        "value" : "http://www.wikidata.org/entity/Q3462965"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Trois-Rivières"
+        "value" : "Saint-Maurice"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Trois-Rivières"
-      },
+        "value" : "Saint-Maurice"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244005-7D9D9CCC-A2DB-469C-84E4-0891FA844838"
@@ -857,22 +843,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3556797"
+        "value" : "http://www.wikidata.org/entity/Q3539917"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Viau"
+        "value" : "Trois-Rivières"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Viau"
-      },
+        "value" : "Trois-Rivières"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244040-28AEEFB7-C062-46DA-9B2C-AA7537BB131F"
@@ -942,26 +928,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3556797"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Viau"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Viau"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2013-12-09T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2910794"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Borduas"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Borduas"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244101-528EF56F-D21F-4C82-B7FD-BB09F1436DB9"
@@ -1030,22 +1016,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3006259"
+        "value" : "http://www.wikidata.org/entity/Q2910794"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Crémazie"
+        "value" : "Borduas"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Crémazie"
-      },
+        "value" : "Borduas"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244327-D55BD8AA-2858-43A6-8CA4-DE9B5360B8D3"
@@ -1114,22 +1100,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3219748"
+        "value" : "http://www.wikidata.org/entity/Q3006259"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Laval-des-Rapides"
+        "value" : "Crémazie"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Laval-des-Rapides"
-      },
+        "value" : "Crémazie"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244447-F3479B0A-162D-4887-BAB1-FEED3C201F3E"
@@ -1198,22 +1184,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q600540"
+        "value" : "http://www.wikidata.org/entity/Q3219748"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Iberville"
+        "value" : "Laval-des-Rapides"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Iberville"
-      },
+        "value" : "Laval-des-Rapides"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244543-411B2502-6C1E-4E98-A5BC-1B67B9AC8488"
@@ -1282,22 +1268,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2960791"
+        "value" : "http://www.wikidata.org/entity/Q600540"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Charlevoix–Côte-de-Beaupré"
+        "value" : "Iberville"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Charlevoix–Côte-de-Beaupré"
-      },
+        "value" : "Iberville"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244573-9C698C9F-63A0-44D8-A518-3F35B42FF8E1"
@@ -1366,22 +1352,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3462431"
+        "value" : "http://www.wikidata.org/entity/Q2960791"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Hyacinthe"
+        "value" : "Charlevoix–Côte-de-Beaupré"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint-Hyacinthe"
-      },
+        "value" : "Charlevoix–Côte-de-Beaupré"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244616-DA175697-3885-4C15-86CA-4FC262D9D2C5"
@@ -1450,22 +1436,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3117289"
+        "value" : "http://www.wikidata.org/entity/Q3462431"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Groulx"
+        "value" : "Saint-Hyacinthe"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Groulx"
-      },
+        "value" : "Saint-Hyacinthe"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16540298-C7B2C5DB-7380-41E3-AA80-C8D9C592E8CD"
@@ -1534,22 +1520,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2821645"
+        "value" : "http://www.wikidata.org/entity/Q3117289"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Abitibi-Est"
+        "value" : "Groulx"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Abitibi-Est"
-      },
+        "value" : "Groulx"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16727603-2ACC00C5-C547-41F0-B2DE-0A090BD0BD6B"
@@ -1618,22 +1604,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3337918"
+        "value" : "http://www.wikidata.org/entity/Q2821645"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Nelligan"
+        "value" : "Abitibi-Est"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Nelligan"
-      },
+        "value" : "Abitibi-Est"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16728132-14062D56-1BDC-4AFE-864B-2123AC9FDD22"
@@ -1703,26 +1689,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3337918"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nelligan"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nelligan"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2014-04-07T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3462187"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Saint-François"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saint-François"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16729638-6A282413-5611-4286-A7CC-7233F2A0E928"
@@ -1791,22 +1777,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3183003"
+        "value" : "http://www.wikidata.org/entity/Q3462187"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Johnson"
+        "value" : "Saint-François"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Johnson"
-      },
+        "value" : "Saint-François"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16731204-FB582AC2-A134-43A6-B980-0B62E1DDBBA6"
@@ -1875,22 +1861,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q788732"
+        "value" : "http://www.wikidata.org/entity/Q3183003"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Vaudreuil"
+        "value" : "Johnson"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Vaudreuil"
-      },
+        "value" : "Johnson"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16733340-45C5BDE6-A83B-4690-B782-089C4443F1FE"
@@ -1959,22 +1945,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3481912"
+        "value" : "http://www.wikidata.org/entity/Q788732"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Sherbrooke"
+        "value" : "Vaudreuil"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Sherbrooke"
-      },
+        "value" : "Vaudreuil"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16864531-93699AB2-092C-45AE-815D-3F4DCC9E7475"
@@ -2043,22 +2029,111 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2860941"
+        "value" : "http://www.wikidata.org/entity/Q3481912"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Argenteuil"
+        "value" : "Sherbrooke"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Argenteuil"
+        "value" : "Sherbrooke"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16864576-474d72eb-4d48-076d-8f1b-685e2580d99d"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16864576"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marc H. Plante"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Marc H. Plante"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3297286"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maskinongé"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Maskinongé"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-04-07T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q17000245-D4F31EA6-5751-43A9-A7B8-E4B3D7E5DF7E"
@@ -2127,22 +2202,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3431420"
+        "value" : "http://www.wikidata.org/entity/Q2860941"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Richelieu"
+        "value" : "Argenteuil"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Richelieu"
-      },
+        "value" : "Argenteuil"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19605003-CBDC39A5-A4F1-49AF-B4AC-B14277F29A20"
@@ -2211,22 +2286,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3292298"
+        "value" : "http://www.wikidata.org/entity/Q3431420"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Marie-Victorin"
+        "value" : "Richelieu"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Marie-Victorin"
-      },
+        "value" : "Richelieu"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q20666410-577AE179-D0ED-410A-90D1-78666973F6D4"
@@ -2295,22 +2370,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3425708"
+        "value" : "http://www.wikidata.org/entity/Q3292298"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "René-Lévesque"
+        "value" : "Marie-Victorin"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "René-Lévesque"
-      },
+        "value" : "Marie-Victorin"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q21451564-801BD386-1DD9-42DA-ACB9-5E2B3A6E0BE9"
@@ -2379,22 +2454,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3063783"
+        "value" : "http://www.wikidata.org/entity/Q3425708"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Fabre"
+        "value" : "René-Lévesque"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fabre"
-      },
+        "value" : "René-Lévesque"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q21512056-8083522A-0D67-4C16-9FB1-FC651E57578E"
@@ -2463,22 +2538,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2893119"
+        "value" : "http://www.wikidata.org/entity/Q3063783"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Beauce-Sud"
+        "value" : "Fabre"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Beauce-Sud"
-      },
+        "value" : "Fabre"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q22277229-5086039E-9172-4FF7-90A9-45A36D1D00E9"
@@ -2547,22 +2622,223 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3491636"
+        "value" : "http://www.wikidata.org/entity/Q2893119"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Soulanges"
+        "value" : "Beauce-Sud"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Soulanges"
+        "value" : "Beauce-Sud"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2379503-A1016122-7AED-47AA-887F-8DD9BD4693FB"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2379503"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jean-Paul Diamond"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jean-Paul Diamond"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3297286"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maskinongé"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Maskinongé"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-12-08T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-04-07T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q24053442-88f79ff6-4553-863a-48db-c9c31da9c60f"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q24053442"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mireille Jean"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mireille Jean"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2963419"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chicoutimi"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Chicoutimi"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-04-11T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q950356"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti québécois"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Parti Québécois"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "Mireille-Jean-1728674760702848"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2415818-208F55E4-0005-4323-8D54-18BD40688D6B"
@@ -2631,22 +2907,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3555824"
+        "value" : "http://www.wikidata.org/entity/Q3491636"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Verdun"
+        "value" : "Soulanges"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Verdun"
-      },
+        "value" : "Soulanges"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q27969074-4675E307-7FE8-48DF-94E5-E151BFC536D6"
@@ -2715,22 +2991,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3462678"
+        "value" : "http://www.wikidata.org/entity/Q3555824"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Jérôme"
+        "value" : "Verdun"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint-Jérôme"
-      },
+        "value" : "Verdun"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q27975624-8BD27653-E1F9-4FD9-A4B9-87394F43D373"
@@ -2799,22 +3075,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3515928"
+        "value" : "http://www.wikidata.org/entity/Q3462678"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Taschereau"
+        "value" : "Saint-Jérôme"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Taschereau"
-      },
+        "value" : "Saint-Jérôme"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2826998-0B7D51BA-204A-4E23-AAC3-F6FE8FC4AE4C"
@@ -2883,8 +3159,91 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3515928"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Taschereau"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Taschereau"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2830317-564A9447-5D7B-4272-9CF1-179864D6B03A"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2830317"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alain Therrien"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alain Therrien"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3472258"
@@ -2898,7 +3257,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Sanguinet"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2830317-E41F7EA1-1D23-4373-8081-BA3AD24F3831"
@@ -2968,26 +3328,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3472258"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sanguinet"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sanguinet"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2012-09-04T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3362911"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Papineau"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Papineau"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2833749-D4F4EC8C-8DD6-4831-8B21-99F25C2B316E"
@@ -3056,22 +3416,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3166585"
+        "value" : "http://www.wikidata.org/entity/Q3362911"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Jean-Lesage"
+        "value" : "Papineau"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Jean-Lesage"
-      },
+        "value" : "Papineau"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2847668-AE685F4A-3C22-47ED-9070-5976497CD8DB"
@@ -3140,22 +3500,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2893118"
+        "value" : "http://www.wikidata.org/entity/Q3166585"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Beauce-Nord"
+        "value" : "Jean-Lesage"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Beauce-Nord"
-      },
+        "value" : "Jean-Lesage"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2848664-8F1D1971-F37C-4E30-9907-670439CCD401"
@@ -3224,22 +3584,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3024863"
+        "value" : "http://www.wikidata.org/entity/Q2893118"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Deux-Montagnes"
+        "value" : "Beauce-Nord"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Deux-Montagnes"
-      },
+        "value" : "Beauce-Nord"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2896382-E58F9E95-BA8F-41E9-8628-316C46B06E73"
@@ -3308,22 +3668,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3138924"
+        "value" : "http://www.wikidata.org/entity/Q3024863"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Hochelaga-Maisonneuve"
+        "value" : "Deux-Montagnes"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Hochelaga-Maisonneuve"
-      },
+        "value" : "Deux-Montagnes"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2939910-340739B1-CDFC-4F87-808B-9CAB5F5FCD79"
@@ -3392,8 +3752,91 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3138924"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hochelaga-Maisonneuve"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Hochelaga-Maisonneuve"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2965998-2FF3C932-0F1B-4DE1-A913-410D252EF6F3"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2965998"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Christine St-Pierre"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Christine St-Pierre"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2822230"
@@ -3407,7 +3850,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Acadie"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2965998-4C48D66E-0229-4F3F-874B-7468C10652AD"
@@ -3477,26 +3921,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2822230"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Acadie"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Acadie"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2007-03-26T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2899431"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bertrand"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Bertrand"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2977224-AB5BFF82-2D5E-458D-8763-0B32ABF516B5"
@@ -3565,22 +4009,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3462578"
+        "value" : "http://www.wikidata.org/entity/Q2899431"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Jean"
+        "value" : "Bertrand"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint-Jean"
-      },
+        "value" : "Bertrand"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3017281-740019C8-D097-474F-BE56-0EB4C40C2FF7"
@@ -3649,22 +4093,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3462395"
+        "value" : "http://www.wikidata.org/entity/Q3462578"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Henri–Sainte-Anne"
+        "value" : "Saint-Jean"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint-Henri–Sainte-Anne"
-      },
+        "value" : "Saint-Jean"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3034943-99b48ca2-4715-2fdd-570f-58d8d9f403e5"
@@ -3734,12 +4178,95 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3462395"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Saint-Henri–Sainte-Anne"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saint-Henri–Sainte-Anne"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2015-11-09T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3035523-F7D9C8B3-563D-40E0-9ED4-3E214E775FD4"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3035523"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dominique Vien"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dominique Vien"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2894824"
@@ -3753,7 +4280,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Bellechasse"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3035523-FD94A299-845B-4080-B081-0B73381217D3"
@@ -3823,6 +4351,20 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2894824"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bellechasse"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bellechasse"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -3834,20 +4376,95 @@
         "value" : "2007-03-26T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3035523-afc41085-4ae8-7c30-445b-9a7803022c63"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3035523"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dominique Vien"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dominique Vien"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3341152"
+        "value" : "http://www.wikidata.org/entity/Q2894824"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Nicolet-Bécancour"
+        "value" : "Bellechasse"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Nicolet-Bécancour"
+        "value" : "Bellechasse"
       },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-12-08T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3036064-9B5F608D-285A-480D-A507-508D1EC8F3D1"
@@ -3916,22 +4533,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3175932"
+        "value" : "http://www.wikidata.org/entity/Q3341152"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Jeanne-Mance–Viger"
+        "value" : "Nicolet-Bécancour"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Jeanne-Mance–Viger"
-      },
+        "value" : "Nicolet-Bécancour"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3072205-D1120BCE-E87D-42F5-90FC-B18EEB20FB65"
@@ -4000,22 +4617,200 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3202478"
+        "value" : "http://www.wikidata.org/entity/Q3175932"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "L'Assomption"
+        "value" : "Jeanne-Mance–Viger"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "L'Assomption"
+        "value" : "Jeanne-Mance–Viger"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3081197-8F221F13-4F3A-4FE7-81B3-4A8A9F8F5489"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3081197"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Francine Charbonneau"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Francine Charbonneau"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3314264"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mille-Îles"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mille-Îles"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-12-08T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3084718-5A96202E-426C-454D-AEC8-CE039889CA6B"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3084718"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "François Gendron"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "François Gendron"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2821647"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Abitibi-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Abitibi-Ouest"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1976-11-15T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3085147-61C51508-6A8E-4359-B3D1-06A4B8509882"
@@ -4084,22 +4879,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3294760"
+        "value" : "http://www.wikidata.org/entity/Q3202478"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Marquette"
+        "value" : "L'Assomption"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Marquette"
-      },
+        "value" : "L'Assomption"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3085498-42E9C68E-696F-4307-A79B-815D1A09A967"
@@ -4168,22 +4963,116 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3157893"
+        "value" : "http://www.wikidata.org/entity/Q3294760"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Jacques-Cartier"
+        "value" : "Marquette"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Jacques-Cartier"
+        "value" : "Marquette"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3086459-10A92CD0-40EA-4E91-BAFC-35E622742968"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3086459"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Françoise David"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Françoise David"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3111624"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gouin"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gouin"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-09-04T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-01-19T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3101084-A3240DA4-A638-41E8-94F4-4B6A430D8F92"
@@ -4252,22 +5141,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3593522"
+        "value" : "http://www.wikidata.org/entity/Q3157893"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Îles-de-la-Madeleine"
+        "value" : "Jacques-Cartier"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Îles-de-la-Madeleine"
-      },
+        "value" : "Jacques-Cartier"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3104104-EDB5A4FB-0101-41DB-8AD0-00AB9052771E"
@@ -4336,22 +5225,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3219660"
+        "value" : "http://www.wikidata.org/entity/Q3593522"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Laurier-Dorion"
+        "value" : "Îles-de-la-Madeleine"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Laurier-Dorion"
-      },
+        "value" : "Îles-de-la-Madeleine"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3104353-7EEEE3EB-1A9F-484E-9586-F4E853897F92"
@@ -4420,22 +5309,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3332790"
+        "value" : "http://www.wikidata.org/entity/Q3219660"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Mégantic"
+        "value" : "Laurier-Dorion"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Mégantic"
-      },
+        "value" : "Laurier-Dorion"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3104870-B03B7277-127C-4E37-8720-5E3AFB049945"
@@ -4504,22 +5393,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2893182"
+        "value" : "http://www.wikidata.org/entity/Q3332790"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Beauharnois"
+        "value" : "Mégantic"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Beauharnois"
-      },
+        "value" : "Mégantic"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3121940-296CF63C-5E72-4F3C-A3FD-355CC3B6999F"
@@ -4588,22 +5477,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3567542"
+        "value" : "http://www.wikidata.org/entity/Q2893182"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Westmount–Saint-Louis"
+        "value" : "Beauharnois"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Westmount–Saint-Louis"
-      },
+        "value" : "Beauharnois"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3158487-A9751089-B36B-4DA2-8C14-8BFD54EC4AAA"
@@ -4672,22 +5561,116 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q9648145"
+        "value" : "http://www.wikidata.org/entity/Q3567542"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Rosemont"
+        "value" : "Westmount–Saint-Louis"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Rosemont"
+        "value" : "Westmount–Saint-Louis"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3158630-2C77F399-12B6-4381-B1AE-A259F2484CEB"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3158630"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jacques Daoust"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jacques Daoust"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3555824"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Verdun"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Verdun"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-04-07T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-08-19T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3165748-2B763B74-8E63-4320-9C83-363F62CBBBC9"
@@ -4756,22 +5739,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3462722"
+        "value" : "http://www.wikidata.org/entity/Q9648145"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Laurent"
+        "value" : "Rosemont"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint-Laurent"
-      },
+        "value" : "Rosemont"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3167384-683860A6-9826-4074-ABBE-02811567A7CF"
@@ -4840,22 +5823,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3219830"
+        "value" : "http://www.wikidata.org/entity/Q3462722"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Laviolette"
+        "value" : "Saint-Laurent"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Laviolette"
-      },
+        "value" : "Saint-Laurent"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3189174-3711DBC2-9340-447D-9033-285749EC489E"
@@ -4924,8 +5907,91 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3219830"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Laviolette"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Laviolette"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3193323-6328BD78-984F-4BCF-BAE4-110A1021797E"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3193323"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karine Vallières"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Karine Vallières"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3431469"
@@ -4939,7 +6005,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Richmond"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3193323-E10B40E9-C28D-41D9-BE6B-5DC76D595E4F"
@@ -5009,12 +6076,95 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3431469"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richmond"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Richmond"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2012-09-04T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3194088-1D33AFB6-7C2F-485A-8772-0457077274FB"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3194088"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kathleen Weil"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kathleen Weil"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3344589"
@@ -5028,7 +6178,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Notre-Dame-de-Grâce"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3194088-2B01B6CC-7D8F-4E0C-9D05-A9E45AFBE47C"
@@ -5098,26 +6249,288 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3344589"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Notre-Dame-de-Grâce"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Notre-Dame-de-Grâce"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2008-12-08T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3219349-E79E87F6-599E-4B5F-B883-2E8AB23096E2"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3219349"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Laurent Lessard"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Laurent Lessard"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3041436"
+        "value" : "http://www.wikidata.org/entity/Q3259964"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Duplessis"
+        "value" : "Lotbinière-Frontenac"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Duplessis"
+        "value" : "Lotbinière-Frontenac"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3219349-49cc4ed0-4c46-e730-4398-ac9446644ac9"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3219349"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Laurent Lessard"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Laurent Lessard"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3259964"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lotbinière-Frontenac"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lotbinière-Frontenac"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-09-04T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3242528-F430026F-DAE4-4E72-A27D-12726ECEF782"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3242528"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lise Thériault"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lise Thériault"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2850263"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anjou–Louis-Riel"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Anjou–Louis-Riel"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-09-04T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3259663-F9ADF1C2-E13F-4FA5-BB65-80FF01D4B20E"
@@ -5186,22 +6599,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2922329"
+        "value" : "http://www.wikidata.org/entity/Q3041436"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Bourget"
+        "value" : "Duplessis"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Bourget"
-      },
+        "value" : "Duplessis"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3280630-AB22FE8C-C898-4FA2-90A6-3233419AAF51"
@@ -5270,22 +6683,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3464370"
+        "value" : "http://www.wikidata.org/entity/Q2922329"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Sainte-Marie–Saint-Jacques"
+        "value" : "Bourget"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Sainte-Marie–Saint-Jacques"
-      },
+        "value" : "Bourget"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3286462-423091C0-3776-4C67-A35D-C6E62EB12194"
@@ -5355,26 +6768,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3464370"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sainte-Marie–Saint-Jacques"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sainte-Marie–Saint-Jacques"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2014-04-07T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2957545"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Chapleau"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Chapleau"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3287884-C2DDC212-6B23-4883-B8AF-A9C10ADB5A07"
@@ -5443,22 +6856,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2967723"
+        "value" : "http://www.wikidata.org/entity/Q2957545"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Chutes-de-la-Chaudière"
+        "value" : "Chapleau"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Chutes-de-la-Chaudière"
-      },
+        "value" : "Chapleau"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3288328-6D9A0A0D-2539-4985-B238-4BCFF25C838F"
@@ -5527,22 +6940,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3206243"
+        "value" : "http://www.wikidata.org/entity/Q2967723"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "LaFontaine"
+        "value" : "Chutes-de-la-Chaudière"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "LaFontaine"
-      },
+        "value" : "Chutes-de-la-Chaudière"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3288424-7E70DD6B-F168-41B5-B4C5-E4AD173FB355"
@@ -5611,22 +7024,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3553117"
+        "value" : "http://www.wikidata.org/entity/Q3206243"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Vachon"
+        "value" : "LaFontaine"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Vachon"
-      },
+        "value" : "LaFontaine"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3295823-ADF8A574-0104-41C2-8884-CD63BFE6D911"
@@ -5696,26 +7109,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3553117"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Vachon"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Vachon"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2010-07-05T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3143016"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Hull"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Hull"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3296332-F22862CA-FD67-4352-B7FA-77E29AD91F53"
@@ -5784,22 +7197,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3518684"
+        "value" : "http://www.wikidata.org/entity/Q3143016"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Terrebonne"
+        "value" : "Hull"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Terrebonne"
-      },
+        "value" : "Hull"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3298889-2B209FFA-F8FB-493A-A8D7-3F713C3BF33B"
@@ -5868,22 +7281,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3399332"
+        "value" : "http://www.wikidata.org/entity/Q3518684"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Portneuf"
+        "value" : "Terrebonne"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Portneuf"
-      },
+        "value" : "Terrebonne"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3310318-2D44DF41-7C37-49A3-938C-7349E8F53B8D"
@@ -5952,22 +7365,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3217775"
+        "value" : "http://www.wikidata.org/entity/Q3399332"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Laporte"
+        "value" : "Portneuf"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Laporte"
-      },
+        "value" : "Portneuf"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3341090-2773A779-55FB-497B-A3D9-266F95816DB3"
@@ -6036,22 +7449,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3010622"
+        "value" : "http://www.wikidata.org/entity/Q3217775"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Côte-du-Sud"
+        "value" : "Laporte"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Côte-du-Sud"
-      },
+        "value" : "Laporte"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3343510-8EDB0BF6-7C3E-4BCA-89D1-31EBC9EA83EF"
@@ -6120,22 +7533,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3298209"
+        "value" : "http://www.wikidata.org/entity/Q3010622"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Matane-Matapédia"
+        "value" : "Côte-du-Sud"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Matane-Matapédia"
-      },
+        "value" : "Côte-du-Sud"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3367320-D9481FD6-4D97-4FF5-931B-48E75AF639AC"
@@ -6204,22 +7617,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3554586"
+        "value" : "http://www.wikidata.org/entity/Q3298209"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Vanier-Les Rivières"
+        "value" : "Matane-Matapédia"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Vanier-Les Rivières"
-      },
+        "value" : "Matane-Matapédia"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3369531-523E8B8A-DE51-4128-BD25-A4F6397F96FC"
@@ -6288,22 +7701,115 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2955903"
+        "value" : "http://www.wikidata.org/entity/Q3554586"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Champlain"
+        "value" : "Vanier-Les Rivières"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Champlain"
+        "value" : "Vanier-Les Rivières"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3379654-FB8C4431-FE29-4AAE-B2CE-1C45AB1F1D2F"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3379654"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Philippe Couillard"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Philippe Couillard"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2381824"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Roberval"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Roberval"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-04-07T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "phcouillard"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3383393-114A634E-DE21-4543-92F4-0E863F3725E7"
@@ -6372,22 +7878,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3321617"
+        "value" : "http://www.wikidata.org/entity/Q2955903"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Mont-Royal"
+        "value" : "Champlain"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Mont-Royal"
-      },
+        "value" : "Champlain"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3383756-51CD4BE0-C48D-4D18-A37F-C5E920308ACE"
@@ -6456,22 +7962,111 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2925997"
+        "value" : "http://www.wikidata.org/entity/Q3321617"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Brome-Missisquoi"
+        "value" : "Mont-Royal"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Brome-Missisquoi"
+        "value" : "Mont-Royal"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3386345-270C6A51-0F40-419E-8AD9-22D809397A53"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3386345"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pierre Moreau"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pierre Moreau"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2971888"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Châteauguay"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Châteauguay"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-12-08T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3386510-23379AE5-70D6-4EFD-9EF4-03520FC3B342"
@@ -6541,26 +8136,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2925997"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brome-Missisquoi"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brome-Missisquoi"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "1980-11-17T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3355914"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Orford"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Orford"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3386771-CEE28AE3-DDF5-4DEB-AF0E-46B333D81E30"
@@ -6629,22 +8224,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3211885"
+        "value" : "http://www.wikidata.org/entity/Q3355914"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "La Prairie"
+        "value" : "Orford"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "La Prairie"
-      },
+        "value" : "Orford"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3431041-00536D54-1436-4CB0-9473-E4C2DBFBB16D"
@@ -6713,22 +8308,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q726528"
+        "value" : "http://www.wikidata.org/entity/Q3211885"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Bourassa-Sauvé"
+        "value" : "La Prairie"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Bourassa-Sauvé"
-      },
+        "value" : "La Prairie"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3433264-267E9B30-7764-4121-B046-F7285CD11B35"
@@ -6797,8 +8392,91 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q726528"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bourassa-Sauvé"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bourassa-Sauvé"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3436093-5F9E5DB6-0EDF-46B6-833C-012040F854CD"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3436093"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert Poëti"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Robert Poeti"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q261059"
@@ -6812,7 +8490,92 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Marguerite-Bourgeoys"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3436093-96F55DB8-DA3A-45E7-95A0-C54515E57FD4"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3436093"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert Poëti"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Robert Poeti"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q261059"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marguerite-Bourgeoys"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Marguerite-Bourgeoys"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3436093-FCAE51FD-AFA0-4AE2-9E39-F0C2983BB629"
@@ -6882,26 +8645,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q261059"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marguerite-Bourgeoys"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Marguerite-Bourgeoys"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2012-09-04T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3040650"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dubuc"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Dubuc"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3479542-A2CB8B1E-59D4-4813-B593-BA070870FBDF"
@@ -6970,22 +8733,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2382048"
+        "value" : "http://www.wikidata.org/entity/Q3040650"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Huntingdon"
+        "value" : "Dubuc"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Huntingdon"
-      },
+        "value" : "Dubuc"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3501598-C0B3E73E-977E-47F6-9661-6C75E363F0C9"
@@ -7054,8 +8817,91 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2382048"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Huntingdon"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Huntingdon"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3502236-886193D9-4D94-420D-8C51-CFEA41A315C5"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3502236"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stéphanie Vallée"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stéphanie Vallée"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3099274"
@@ -7069,7 +8915,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Gatineau"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3502236-850578B6-92D1-4683-ABDB-326864C9A960"
@@ -7139,26 +8986,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3099274"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gatineau"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gatineau"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2007-03-26T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3183626"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jonquière"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Jonquière"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3507009-A5289B10-4B8A-4943-A9CC-4C464C109503"
@@ -7228,26 +9075,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3183626"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jonquière"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jonquière"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2007-03-26T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3170034"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jean-Talon"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Jean-Talon"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3510271-899D3F0A-D03F-418E-ACA2-2D26FADEC9DB"
@@ -7316,22 +9163,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3040122"
+        "value" : "http://www.wikidata.org/entity/Q3170034"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Drummond–Bois-Francs"
+        "value" : "Jean-Talon"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Drummond–Bois-Francs"
-      },
+        "value" : "Jean-Talon"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3510315-6DCC1A2C-89AD-4195-90B1-2AFE36762BC3"
@@ -7400,22 +9247,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3183136"
+        "value" : "http://www.wikidata.org/entity/Q3040122"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Joliette"
+        "value" : "Drummond–Bois-Francs"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Joliette"
-      },
+        "value" : "Drummond–Bois-Francs"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3564320-6F145D27-D2DB-451B-8064-A6EE0571B412"
@@ -7485,26 +9332,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3183136"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joliette"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Joliette"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2008-12-08T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2961704"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Chauveau"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Chauveau"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3564393-FA992B27-669A-416B-A372-7C971E6EB23A"
@@ -7573,22 +9420,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3260600"
+        "value" : "http://www.wikidata.org/entity/Q2961704"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Louis-Hébert"
+        "value" : "Chauveau"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Louis-Hébert"
-      },
+        "value" : "Chauveau"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q41545405-7D1C81F3-A72B-448B-BE4F-B175DA10DF78"
@@ -7657,8 +9504,91 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3260600"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Louis-Hébert"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Louis-Hébert"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q518024-9F3752D1-9B1A-4F8F-9CEE-80E346157AF2"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q518024"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alexandre Cloutier"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alexandre Cloutier"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3214651"
@@ -7672,7 +9602,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Lac-Saint-Jean"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q518024-BC81A3BA-6C6F-4F76-B461-520B3ED93C8E"
@@ -7742,26 +9673,26 @@
         "type" : "literal",
         "value" : "125"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3214651"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lac-Saint-Jean"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lac-Saint-Jean"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2007-03-26T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3111624"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Gouin"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Gouin"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q664086-BFE37CD3-B2EF-4F11-A6B7-4138AE8CB38B"
@@ -7830,22 +9761,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3098859"
+        "value" : "http://www.wikidata.org/entity/Q3111624"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Gaspé"
+        "value" : "Gouin"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Gaspé"
-      },
+        "value" : "Gouin"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q728648-89871005-DB79-483C-96BB-5475F8B58820"
@@ -7914,6 +9845,109 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3098859"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gaspé"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gaspé"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q921062-2C020B94-E34A-4A42-887F-C216AC329414"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305338"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée nationale du Québec"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the National Assembly of Quebec"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q921062"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sam Hamad"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sam Hamad"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1492249"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée nationale du Québec"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly of Quebec"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "125"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3260600"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Louis-Hébert"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Louis-Hébert"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-04-14T00:00:00Z"
       }
     } ]
   }

--- a/legislative/Q1492249/Q16246364/query-used.rq
+++ b/legislative/Q1492249/Q16246364/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q16246364 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q16246364 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q16246364 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q16246364 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q1516914/Q18220962/query-results.json
+++ b/legislative/Q1516914/Q18220962/query-results.json
@@ -4,15 +4,6 @@
   },
   "results" : {
     "bindings" : [ {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3195267"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Kent South"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18149585-F671B8A7-8B34-476D-BC64-B9334821CEC2"
@@ -82,21 +73,21 @@
         "type" : "literal",
         "value" : "Benoît Bourque"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3195267"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Kent-Sud"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q281399"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "New Maryland-Sunbury West"
-      },
+        "value" : "Kent South"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18149828-2AED2E7D-1921-46A3-81C7-61AF4E667CFB"
@@ -166,21 +157,21 @@
         "type" : "literal",
         "value" : "Jeff Carr"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q281399"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "New Maryland—Sunbury-Ouest"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3113468"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Grand Falls-Drummond-Saint-André"
-      },
+        "value" : "New Maryland-Sunbury West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18149930-3E993B9D-BBD0-4D43-8DF8-1D68CBB3DC37"
@@ -250,21 +241,21 @@
         "type" : "literal",
         "value" : "Chuck Chiasson"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3113468"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Grand-Sault—Drummond—Saint-André"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16983208"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Hampton"
-      },
+        "value" : "Grand Falls-Drummond-Saint-André"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18150265-09215A68-B531-4800-B560-FD792A650F49"
@@ -333,17 +324,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Gary Crossman"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3341339"
+        "value" : "http://www.wikidata.org/entity/Q16983208"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Nigadoo-Chaleur"
-      },
+        "value" : "Hampton"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18164931-BA9EB33B-CF31-4E0F-8962-A2962CA3467E"
@@ -413,21 +404,21 @@
         "type" : "literal",
         "value" : "Daniel Guitard"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3341339"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Nigadoo-Chaleur"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2879404"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Miramichi Bay-Neguac"
-      },
+        "value" : "Nigadoo-Chaleur"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18164963-67D2BF3F-17D2-49D0-A371-938F7723BE59"
@@ -497,21 +488,21 @@
         "type" : "literal",
         "value" : "Lisa Harris"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2879404"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Baie-de-Miramichi—Neguac"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16955881"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Carleton-Victoria"
-      },
+        "value" : "Miramichi Bay-Neguac"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18164964-AA38F2B6-CCEF-49DF-BD2E-34258DE9241C"
@@ -580,17 +571,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Andrew Harvey"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5499248"
+        "value" : "http://www.wikidata.org/entity/Q16955881"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fredericton North"
-      },
+        "value" : "Carleton-Victoria"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18165005-0C3B81CC-16A7-4614-99D6-A3A1C7B3821E"
@@ -659,17 +650,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Stephen Horsman"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2830904"
+        "value" : "http://www.wikidata.org/entity/Q5499248"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Albert"
-      },
+        "value" : "Fredericton North"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18165066-AFE5B6EB-B3B9-4466-B4B0-5FDBD9A0FFF3"
@@ -739,21 +730,21 @@
         "type" : "literal",
         "value" : "Brian Keirstead"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2830904"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Albert (circonscription provinciale)"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3275450"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Madawaska-les-Lacs"
-      },
+        "value" : "Albert"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18165811-C723EF24-CCA7-4CEB-985B-86192EE65289"
@@ -823,21 +814,21 @@
         "type" : "literal",
         "value" : "Francine Landry"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3275450"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Madawaska-les-Lacs"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17090780"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moncton East"
-      },
+        "value" : "Madawaska-les-Lacs"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18165829-A2D4D48F-9F89-4E82-8A1F-96675048851E"
@@ -906,17 +897,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Monique LeBlanc"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7316116"
+        "value" : "http://www.wikidata.org/entity/Q17090780"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Restigouche West"
-      },
+        "value" : "Moncton East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18167937-D8C818A0-1CD2-4C73-8EC5-924B79BEBDEE"
@@ -985,17 +976,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Gilles LePage"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16989122"
+        "value" : "http://www.wikidata.org/entity/Q7316116"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Kings Centre"
-      },
+        "value" : "Restigouche West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18167984-E793D68B-1E14-41D7-86A4-F516BCBDFBF0"
@@ -1064,17 +1055,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Bill Oliver"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q47462432"
+        "value" : "http://www.wikidata.org/entity/Q16989122"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moncton South"
-      },
+        "value" : "Kings Centre"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18168015-EF1747A3-BA87-4268-B753-EF20E7AF652E"
@@ -1143,17 +1134,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Cathy Rogers"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3216887"
+        "value" : "http://www.wikidata.org/entity/Q47462432"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lamèque-Shippagan-Miscou"
-      },
+        "value" : "Moncton South"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18168022-11D36254-A3D8-41B2-A081-481860551EA0"
@@ -1223,21 +1214,21 @@
         "type" : "literal",
         "value" : "Wilfred Roussel"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3216887"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Lamèque-Shippagan-Miscou"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3536142"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Tracadie-Sheila"
-      },
+        "value" : "Lamèque-Shippagan-Miscou"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18168023-D7C1738D-005F-4ED4-87B3-E8DC9FE1A7B8"
@@ -1307,21 +1298,21 @@
         "type" : "literal",
         "value" : "Serge Rousselle"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3536142"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Tracadie-Sheila"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q47462543"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moncton Northwest"
-      },
+        "value" : "Tracadie-Sheila"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18168079-35D5942A-D630-4F74-A0D3-DF081618888B"
@@ -1390,17 +1381,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Ernie Steeves"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16256540"
+        "value" : "http://www.wikidata.org/entity/Q47462543"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Carleton"
-      },
+        "value" : "Moncton Northwest"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q22277736-C3E58E8D-648B-4747-BFC6-69CEB4D07BC3"
@@ -1464,17 +1455,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "49"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3515350"
+        "value" : "http://www.wikidata.org/entity/Q16256540"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Tantramar"
-      },
+        "value" : "Carleton"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2898195-3CCE36F4-A0A2-43D4-8F97-B7F5EE24CA9A"
@@ -1544,21 +1535,21 @@
         "type" : "literal",
         "value" : "Bernard LeBlanc"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3515350"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Tantramar"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3439665"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Rogersville-Kouchibouguac"
-      },
+        "value" : "Tantramar"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2899609-A3815C83-49C6-475C-8D04-C04F7D670EDB"
@@ -1628,21 +1619,21 @@
         "type" : "literal",
         "value" : "Bertrand LeBlanc"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3439665"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Rogersville-Kouchibouguac"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17090633"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Miramichi"
-      },
+        "value" : "Rogersville-Kouchibouguac"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2903215-AC41AAA2-79A4-4B24-AAF9-8CDCBA7A599D"
@@ -1711,17 +1702,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Bill Fraser"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q964313"
+        "value" : "http://www.wikidata.org/entity/Q17090633"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Quispamsis"
-      },
+        "value" : "Miramichi"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2905723-00EB37EB-795E-41A8-BBEE-6055B5D8BA5F"
@@ -1791,21 +1782,21 @@
         "type" : "literal",
         "value" : "Blaine Higgs"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q964313"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Quispamsis"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17093013"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Shediac Bay-Dieppe"
-      },
+        "value" : "Quispamsis"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2924893-038CF323-EF1A-49A1-9B29-9E9284337AE6"
@@ -1874,17 +1865,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Brian Gallant"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16950560"
+        "value" : "http://www.wikidata.org/entity/Q17093013"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Bathurst West-Beresford"
-      },
+        "value" : "Shediac Bay-Dieppe"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2924935-2147D556-3D1D-46BC-89AC-18BFA67E92FE"
@@ -1953,17 +1944,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Brian Kenny"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16981385"
+        "value" : "http://www.wikidata.org/entity/Q16950560"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fredericton West-Hanwell"
-      },
+        "value" : "Bathurst West-Beresford"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2924947-188D4988-4A5B-4EDB-9B13-A569B9370271"
@@ -2032,17 +2023,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Brian Macdonald (politicien)"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3433524"
+        "value" : "http://www.wikidata.org/entity/Q16981385"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Riverview"
-      },
+        "value" : "Fredericton West-Hanwell"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2926414-61284F3F-9033-432E-8614-6F59B86A9833"
@@ -2112,21 +2103,21 @@
         "type" : "literal",
         "value" : "Bruce Fitch"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3433524"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Riverview"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3197087"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Kings East"
-      },
+        "value" : "Riverview"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2926463-F419621E-EA23-42D6-8BC5-FD6A65D795C5"
@@ -2196,21 +2187,21 @@
         "type" : "literal",
         "value" : "Bruce Northrup"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3197087"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Kings-Est"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17059436"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "York"
-      },
+        "value" : "Kings East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2939005-A127CDA7-3BAB-4988-B9C0-DEEE176FC034"
@@ -2279,17 +2270,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Carl Urquhart"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16253549"
+        "value" : "http://www.wikidata.org/entity/Q17059436"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Bathurst East-Nepisiguit-Saint-Isidore"
-      },
+        "value" : "York"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3022774-A23B53F7-F347-4BD8-96A5-93AFB514B1DF"
@@ -2358,17 +2349,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Denis Landry"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3463899"
+        "value" : "http://www.wikidata.org/entity/Q16253549"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint John Lancaster"
-      },
+        "value" : "Bathurst East-Nepisiguit-Saint-Isidore"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3037187-97936698-FFA0-4C17-A5BA-1386383E9A8D"
@@ -2438,21 +2429,21 @@
         "type" : "literal",
         "value" : "Dorothy Shephard"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3463899"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Saint John Lancaster"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3463898"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint John Harbour"
-      },
+        "value" : "Saint John Lancaster"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3047163-4C20E2B4-3665-450B-8C8C-940C407E504A"
@@ -2522,21 +2513,21 @@
         "type" : "literal",
         "value" : "Ed Doherty"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3463898"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Saint John Harbour"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3463893"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint John East"
-      },
+        "value" : "Saint John Harbour"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3108698-255C6A54-D904-4895-903D-995C40CCDC7C"
@@ -2606,21 +2597,21 @@
         "type" : "literal",
         "value" : "Glen Savoie"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3463893"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Saint John-Est"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3442975"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Rothesay"
-      },
+        "value" : "Saint John East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3142247-971937B6-AED0-49AF-A5F4-AF442ABBF5EB"
@@ -2690,21 +2681,21 @@
         "type" : "literal",
         "value" : "Hugh Flemming"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3442975"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Rothesay"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2937885"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Caraquet"
-      },
+        "value" : "Rothesay"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3144572-FB372433-CB0A-49D8-BE6C-D3736D7E83F3"
@@ -2774,21 +2765,21 @@
         "type" : "literal",
         "value" : "Hédard Albert"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2937885"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Caraquet (circonscription provinciale)"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3315869"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Southwest Miramichi"
-      },
+        "value" : "Caraquet"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3160637-27D3564A-ABE9-4FE1-A1A9-BCB4C4055FC4"
@@ -2858,21 +2849,21 @@
         "type" : "literal",
         "value" : "Jake Stewart"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3315869"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Miramichi-Sud-Ouest"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17052880"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Oromocto-Lincoln"
-      },
+        "value" : "Southwest Miramichi-Bay du Vin"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3179947-E57C8443-05EF-417A-8111-9C52792E347A"
@@ -2941,17 +2932,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Jody Carr"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16981389"
+        "value" : "http://www.wikidata.org/entity/Q17052880"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fredericton-York"
-      },
+        "value" : "Oromocto-Lincoln"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3197380-02B9AD4D-458E-4B53-8C18-6AD603DAFE73"
@@ -3020,17 +3011,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Kirk MacDonald"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16981388"
+        "value" : "http://www.wikidata.org/entity/Q16981389"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fredericton-Grand Lake"
-      },
+        "value" : "Fredericton-York"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3361752-968D417D-2131-4197-AF06-9C0A2F14770D"
@@ -3099,17 +3090,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Pam Lynch"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2960932"
+        "value" : "http://www.wikidata.org/entity/Q16981388"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Charlotte-The Isles"
-      },
+        "value" : "Fredericton-Grand Lake"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3431542-FAC590BA-3EA4-47B8-A4A4-C3B656050C1E"
@@ -3179,21 +3170,21 @@
         "type" : "literal",
         "value" : "Rick Doucet"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2960932"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Charlotte-les-Îles"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3027487"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Dieppe Centre-Lewisville"
-      },
+        "value" : "Charlotte-The Isles"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3439270-B31DFA40-895E-490E-95D5-AB88B241EB64"
@@ -3263,21 +3254,21 @@
         "type" : "literal",
         "value" : "Roger Melanson"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3027487"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Dieppe-Centre—Lewisville"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16981570"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Gagetown-Petitcodiac"
-      },
+        "value" : "Dieppe Centre-Lewisville"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3442799-100C4FEA-EFAE-4AC9-8601-4728BB757628"
@@ -3346,17 +3337,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Ross Wetmore"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17090787"
+        "value" : "http://www.wikidata.org/entity/Q16981570"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moncton Southwest"
-      },
+        "value" : "Gagetown-Petitcodiac"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3481980-99D8B22F-7F77-4F8A-9C61-870111B9371B"
@@ -3425,17 +3416,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Sherry Wilson"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3463902"
+        "value" : "http://www.wikidata.org/entity/Q17090787"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saint John Portland"
-      },
+        "value" : "Moncton Southwest"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3538587-36C38C42-AAD3-4A31-9E5A-084C37AB8487"
@@ -3505,21 +3496,21 @@
         "type" : "literal",
         "value" : "Trevor Holder"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3463902"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Saint John Portland"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3481698"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Shediac-Cap-Pelé"
-      },
+        "value" : "Saint John Portland"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3557177-DFC31DEE-13A6-4FFD-A4F0-8E86F3EC3E91"
@@ -3589,21 +3580,21 @@
         "type" : "literal",
         "value" : "Victor Boudreau"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3481698"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Shediac—Cap-Pelé"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17090768"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moncton Centre"
-      },
+        "value" : "Shediac-Cap-Pelé"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q749772-38088C47-AE20-4455-A3CC-2386CE2F02F3"
@@ -3672,17 +3663,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Chris Collins"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16981383"
+        "value" : "http://www.wikidata.org/entity/Q17090768"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fredericton South"
-      },
+        "value" : "Moncton Centre"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q950184-97EE2B21-6E0F-4977-9BCF-3A66CDDDA6BF"
@@ -3752,10 +3743,19 @@
         "type" : "literal",
         "value" : "David Coon"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16981383"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Fredericton-Sud"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fredericton South"
       }
     } ]
   }

--- a/legislative/Q1516914/Q18220962/query-used.rq
+++ b/legislative/Q1516914/Q18220962/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q18220962 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q18220962 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q18220962 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q18220962 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q1517320/Q24191581/popolo-m17n.json
+++ b/legislative/Q1517320/Q24191581/popolo-m17n.json
@@ -534,6 +534,22 @@
     },
     {
       "name": {
+        "lang:en": "Jon Gerrard",
+        "lang:fr": "Jon Gerrard"
+      },
+      "id": "Q649428",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q649428"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Mohinder Saran",
         "lang:fr": "Mohinder Saran"
       },
@@ -622,6 +638,22 @@
         {
           "scheme": "wikidata",
           "identifier": "Q7436322"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Stan Struthers",
+        "lang:fr": "Stan Struthers"
+      },
+      "id": "Q7597905",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7597905"
         }
       ],
       "links": [
@@ -2364,6 +2396,39 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q2924976-5CEAEF1A-0610-4348-8601-BFBE8823CF1B",
+      "person_id": "Q2924976",
+      "organization_id": "Q1517320",
+      "area_id": "Q3078105",
+      "start_date": "2012-09-04",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19007867",
+      "role": {
+        "lang:en": "member of the Legislative Assembly of Manitoba",
+        "lang:fr": "membre de l'Assemblée législative du Manitoba"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2924976-70BE0DBC-E7CA-418C-8E5A-169ED848E0B4",
+      "person_id": "Q2924976",
+      "organization_id": "Q1517320",
+      "area_id": "Q3078105",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19007867",
+      "role": {
+        "lang:en": "member of the Legislative Assembly of Manitoba",
+        "lang:fr": "membre de l'Assemblée législative du Manitoba"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q2924976-C4F9D482-2FF1-4BF7-B8A9-AF557F62432D",
       "person_id": "Q2924976",
       "organization_id": "Q1517320",
@@ -2672,6 +2737,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q649428-501F81E4-E01B-45B2-AEE1-172AEFF2F1BF",
+      "person_id": "Q649428",
+      "organization_id": "Q1517320",
+      "area_id": "Q3433487",
+      "start_date": "1999-09-21",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19007867",
+      "role": {
+        "lang:en": "member of the Legislative Assembly of Manitoba",
+        "lang:fr": "membre de l'Assemblée législative du Manitoba"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q6894175-ECFCF641-027E-43C0-B51D-3467DA4350B0",
       "person_id": "Q6894175",
       "organization_id": "Q1517320",
@@ -2756,6 +2838,23 @@
       "person_id": "Q7436322",
       "organization_id": "Q1517320",
       "area_id": "Q3197398",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19007867",
+      "role": {
+        "lang:en": "member of the Legislative Assembly of Manitoba",
+        "lang:fr": "membre de l'Assemblée législative du Manitoba"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7597905-8F15DC51-09CA-40D0-AB37-45A42B43F6F5",
+      "person_id": "Q7597905",
+      "organization_id": "Q1517320",
+      "area_id": "Q3017030",
+      "start_date": "2011-10-04",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q1517320/Q24191581/query-results.json
+++ b/legislative/Q1517320/Q24191581/query-results.json
@@ -4,20 +4,6 @@
   },
   "results" : {
     "bindings" : [ {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3324398"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Morris"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Morris"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15733801-96FD1F25-ED1E-432E-BF83-2B232A7D6C03"
@@ -86,22 +72,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Shannon Martin"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q287870"
+        "value" : "http://www.wikidata.org/entity/Q3324398"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Arthur-Virden"
+        "value" : "Morris"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Arthur-Virden"
-      },
+        "value" : "Morris"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15733805-297CCE3F-07D4-4829-B219-9AB53194C95B"
@@ -170,22 +156,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Doyle Piwniuk"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2992091"
+        "value" : "http://www.wikidata.org/entity/Q287870"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Concordia"
+        "value" : "Arthur-Virden"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Concordia"
-      },
+        "value" : "Arthur-Virden"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244749-EFFC9C6B-FDF1-4E7E-BB43-2CFDD4943FE9"
@@ -254,22 +240,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Matt Wiebe"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3461904"
+        "value" : "http://www.wikidata.org/entity/Q2992091"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Boniface"
+        "value" : "Concordia"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "St. Boniface"
-      },
+        "value" : "Concordia"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q178944-2A061D53-65DB-437F-9584-9AC1327026F5"
@@ -338,22 +324,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Greg Selinger"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3225272"
+        "value" : "http://www.wikidata.org/entity/Q3461904"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Le Pas"
+        "value" : "Saint-Boniface"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "The Pas"
-      },
+        "value" : "St. Boniface"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q20711265-6F98B113-15D6-4A0E-A805-B56219B1FA0E"
@@ -417,22 +403,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2407519"
+        "value" : "http://www.wikidata.org/entity/Q3225272"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Riel"
+        "value" : "Le Pas"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Riel"
-      },
+        "value" : "The Pas"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053382-041A12D0-0B8B-4074-8623-0B71A2733D09"
@@ -496,22 +482,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3463068"
+        "value" : "http://www.wikidata.org/entity/Q2407519"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Norbert"
+        "value" : "Riel"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "St. Norbert"
-      },
+        "value" : "Riel"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053383-7F8F319A-38B2-430F-972A-B14870541892"
@@ -575,22 +561,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3463515"
+        "value" : "http://www.wikidata.org/entity/Q3463068"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Saint-Vital"
+        "value" : "Saint-Norbert"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "St. Vital"
-      },
+        "value" : "St. Norbert"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053390-16A39F42-DFCC-430E-B144-24BED9DDA89E"
@@ -654,8 +640,7 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3463515"
@@ -669,7 +654,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "St. Vital"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053390-40F77684-252A-4216-A83C-7546A019543B"
@@ -733,22 +719,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3478166"
+        "value" : "http://www.wikidata.org/entity/Q3463515"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Selkirk"
+        "value" : "Saint-Vital"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Selkirk"
-      },
+        "value" : "St. Vital"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053391-FDA7A8B0-8575-4211-89E6-19E4BDF735F8"
@@ -812,22 +798,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2923732"
+        "value" : "http://www.wikidata.org/entity/Q3478166"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Brandon-Est"
+        "value" : "Selkirk"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Brandon East"
-      },
+        "value" : "Selkirk"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053394-D154930B-3FC2-417A-9860-A82D0C5B6ED2"
@@ -891,22 +877,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3077999"
+        "value" : "http://www.wikidata.org/entity/Q2923732"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Fort Richmond"
+        "value" : "Brandon-Est"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fort Richmond"
-      },
+        "value" : "Brandon East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053397-F9149CF9-68BE-4300-954D-754FEB910F22"
@@ -975,22 +961,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Sarah Guillemard"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3525748"
+        "value" : "http://www.wikidata.org/entity/Q3077999"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Thompson"
+        "value" : "Fort Richmond"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Thompson"
-      },
+        "value" : "Fort Richmond"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24053398-8C759821-C05F-4719-B565-168682865BB4"
@@ -1054,22 +1040,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3073735"
+        "value" : "http://www.wikidata.org/entity/Q3525748"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Flin Flon"
+        "value" : "Thompson"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Flin Flon"
-      },
+        "value" : "Thompson"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24060859-8525198C-4C0E-4207-A021-CBD1CE6DE00D"
@@ -1133,22 +1119,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3537410"
+        "value" : "http://www.wikidata.org/entity/Q3073735"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Transcona"
+        "value" : "Flin Flon"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Transcona"
-      },
+        "value" : "Flin Flon"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24060861-BA7B496B-052E-4D92-83A4-B31B2E13F910"
@@ -1212,22 +1198,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3506427"
+        "value" : "http://www.wikidata.org/entity/Q3537410"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Swan River"
+        "value" : "Transcona"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Swan River"
-      },
+        "value" : "Transcona"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24060866-E13513ED-A87E-4A07-90AD-08EBA3D852A3"
@@ -1291,22 +1277,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3106666"
+        "value" : "http://www.wikidata.org/entity/Q3506427"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Gimli"
+        "value" : "Swan River"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Gimli"
-      },
+        "value" : "Swan River"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24060869-99AEE377-EA69-4644-9C59-28B78AE164CD"
@@ -1370,22 +1356,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3195840"
+        "value" : "http://www.wikidata.org/entity/Q3106666"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Kewatinook"
+        "value" : "Gimli"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Kewatinook"
-      },
+        "value" : "Gimli"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24191584-75581741-F762-41B7-8F3E-B7E8F7B9528C"
@@ -1449,22 +1435,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3433485"
+        "value" : "http://www.wikidata.org/entity/Q3195840"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "River East"
+        "value" : "Kewatinook"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "River East"
-      },
+        "value" : "Kewatinook"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q25189566-B1D280EA-6C4E-421A-97E6-43D71C6E3321"
@@ -1528,8 +1514,91 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3433485"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "River East"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "River East"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2924976-70BE0DBC-E7CA-418C-8E5A-169ED848E0B4"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19007867"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Manitoba"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Legislative Assembly of Manitoba"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2924976"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brian Pallister"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1517320"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Manitoba"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Manitoba"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1948"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "57"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Pallister"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3078105"
@@ -1543,7 +1612,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Fort Whyte"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2924976-C4F9D482-2FF1-4BF7-B8A9-AF557F62432D"
@@ -1613,6 +1683,20 @@
         "type" : "literal",
         "value" : "Brian Pallister"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3078105"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fort Whyte"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fort Whyte"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -1624,20 +1708,95 @@
         "value" : "1997-04-28T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2924976-5CEAEF1A-0610-4348-8601-BFBE8823CF1B"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19007867"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Manitoba"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Legislative Assembly of Manitoba"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2924976"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brian Pallister"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1517320"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Manitoba"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Manitoba"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1948"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "57"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Pallister"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3393338"
+        "value" : "http://www.wikidata.org/entity/Q3078105"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Point Douglas"
+        "value" : "Fort Whyte"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Point Douglas"
+        "value" : "Fort Whyte"
       },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-09-04T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q29964108-1F1B2AC0-85E0-4080-B15D-38BA96D0F5C5"
@@ -1706,22 +1865,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Bernadette Smith"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2867183"
+        "value" : "http://www.wikidata.org/entity/Q3393338"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Assiniboia (circonscription électorale provinciale)"
+        "value" : "Point Douglas"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Assiniboia"
-      },
+        "value" : "Point Douglas"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3499223-0A2A326F-BEF7-4316-8F83-12B14D6CCF06"
@@ -1790,8 +1949,7 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Steven Fletcher"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2867183"
@@ -1805,7 +1963,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Assiniboia"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3499223-FC4C406B-000E-41AC-B643-C156EA1D2F17"
@@ -1874,22 +2033,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Steven Fletcher"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3315625"
+        "value" : "http://www.wikidata.org/entity/Q2867183"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Minto"
+        "value" : "Assiniboia (circonscription électorale provinciale)"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Minto"
-      },
+        "value" : "Assiniboia"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q4758678-9F6EEEDB-5DEC-42A4-8610-C92460D0AC81"
@@ -1958,22 +2117,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Andrew Swan"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q668552"
+        "value" : "http://www.wikidata.org/entity/Q3315625"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Midland"
+        "value" : "Minto"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Midland"
-      },
+        "value" : "Minto"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q4923968-5ce09504-4aa3-5dec-257a-dfeb4b812504"
@@ -2043,6 +2202,20 @@
         "type" : "literal",
         "value" : "Blaine Pedersen"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q668552"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Midland"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Midland"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -2067,20 +2240,6 @@
         "value" : "blainepedersenmla"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3323853"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Morden-Winkler"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Morden-Winkler"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5026243-E0411D0F-15F5-4BEB-9386-055F72A8EF33"
@@ -2149,22 +2308,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Cameron Friesen"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3073735"
+        "value" : "http://www.wikidata.org/entity/Q3323853"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Flin Flon"
+        "value" : "Morden-Winkler"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Flin Flon"
-      },
+        "value" : "Morden-Winkler"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50275326-071C2B29-80A5-4D6B-8B2A-9F8BF582C1F8"
@@ -2228,8 +2387,7 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3073735"
@@ -2243,7 +2401,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Flin Flon"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50275326-853C84AC-8B5B-4DA3-BD2C-07C8C6AA6A1B"
@@ -2307,22 +2466,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3052176"
+        "value" : "http://www.wikidata.org/entity/Q3073735"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Emerson"
+        "value" : "Flin Flon"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Emerson"
-      },
+        "value" : "Flin Flon"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5132607-66E226E8-DF1C-4C8C-8BA5-6F8B0A2FE2EB"
@@ -2391,22 +2550,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Cliff Graydon"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3213959"
+        "value" : "http://www.wikidata.org/entity/Q3052176"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "La Vérendrye"
+        "value" : "Emerson"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "La Verendrye"
-      },
+        "value" : "Emerson"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5258969-17D22719-88C3-440B-AA5D-B0DBB7B374F4"
@@ -2475,22 +2634,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Dennis Smook"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2398974"
+        "value" : "http://www.wikidata.org/entity/Q3213959"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Southdale"
+        "value" : "La Vérendrye"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Southdale"
-      },
+        "value" : "La Verendrye"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q53673454-430E94A2-024B-4609-860A-ABB47CC44BC7"
@@ -2554,22 +2713,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "57"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3257846"
+        "value" : "http://www.wikidata.org/entity/Q2398974"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Logan"
+        "value" : "Southdale"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Logan"
-      },
+        "value" : "Southdale"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5460234-F399B01E-4AB6-401F-8C0E-0E7AB6A1ED62"
@@ -2638,22 +2797,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Flor Marcelino"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3542476"
+        "value" : "http://www.wikidata.org/entity/Q3257846"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Tuxedo"
+        "value" : "Logan"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Tuxedo"
-      },
+        "value" : "Logan"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5694126-37901210-722A-4838-912A-0F7D83353089"
@@ -2722,8 +2881,7 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Heather Stefanson"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3542476"
@@ -2737,7 +2895,8 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Tuxedo"
-      },
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5694126-6D813617-98E1-470A-A870-A1168FF9195A"
@@ -2806,22 +2965,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Heather Stefanson"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3398737"
+        "value" : "http://www.wikidata.org/entity/Q3542476"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Portage-la-Prairie"
+        "value" : "Tuxedo"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Portage La Prairie"
-      },
+        "value" : "Tuxedo"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5983306-BBD6C43B-D96B-4883-A7B2-9AFE67C1EE14"
@@ -2890,22 +3049,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Ian Wishart"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3077876"
+        "value" : "http://www.wikidata.org/entity/Q3398737"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Fort Garry-Riverview"
+        "value" : "Portage-la-Prairie"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fort Garry-Riverview"
-      },
+        "value" : "Portage La Prairie"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6128662-FA279935-7CEE-424B-8C2A-7A36ED1B7C99"
@@ -2974,22 +3133,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "James Allum"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3051611"
+        "value" : "http://www.wikidata.org/entity/Q3077876"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Elmwood"
+        "value" : "Fort Garry-Riverview"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Elmwood"
-      },
+        "value" : "Fort Garry-Riverview"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6196595-BDED4715-C84B-4E1F-8F59-E9072461064B"
@@ -3058,22 +3217,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Jim Maloway"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3498073"
+        "value" : "http://www.wikidata.org/entity/Q3051611"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Steinbach"
+        "value" : "Elmwood"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Steinbach"
-      },
+        "value" : "Elmwood"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6386656-38BBCDDE-FE1B-44EF-A660-32675EC56CBB"
@@ -3142,22 +3301,111 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Kelvin Goertzen"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3521776"
+        "value" : "http://www.wikidata.org/entity/Q3498073"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "The Maples"
+        "value" : "Steinbach"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "The Maples"
+        "value" : "Steinbach"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q649428-501F81E4-E01B-45B2-AEE1-172AEFF2F1BF"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19007867"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Manitoba"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Legislative Assembly of Manitoba"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q649428"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jon Gerrard"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1517320"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Manitoba"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Manitoba"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1948"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "57"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jon Gerrard"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3433487"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "River Heights"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "River Heights"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1999-09-21T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6894175-ECFCF641-027E-43C0-B51D-3467DA4350B0"
@@ -3226,22 +3474,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Mohinder Saran"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2960784"
+        "value" : "http://www.wikidata.org/entity/Q3521776"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Charleswood"
+        "value" : "The Maples"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Charleswood"
-      },
+        "value" : "The Maples"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6948386-A56EF5D3-5EE0-431A-B3AE-0CEAD11CD8B4"
@@ -3310,22 +3558,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Myrna Driedger"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3216480"
+        "value" : "http://www.wikidata.org/entity/Q2960784"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Lakeside"
+        "value" : "Charleswood"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lakeside"
-      },
+        "value" : "Charleswood"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7287446-EF3641B6-6D5E-43D7-8C22-A0EB4BBEBBC1"
@@ -3394,22 +3642,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Ralph Eichler"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2923733"
+        "value" : "http://www.wikidata.org/entity/Q3216480"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Brandon-Ouest"
+        "value" : "Lakeside"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Brandon West"
-      },
+        "value" : "Lakeside"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7307793-588C9624-76B6-49CD-B30A-376C40490A5D"
@@ -3478,22 +3726,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Reg Helwer"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3569733"
+        "value" : "http://www.wikidata.org/entity/Q2923733"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Wolseley"
+        "value" : "Brandon-Ouest"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Wolseley"
-      },
+        "value" : "Brandon West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7339940-7006450C-C6EB-483E-B536-7C1C5B1F4E27"
@@ -3562,22 +3810,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Rob Altemeyer"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3197398"
+        "value" : "http://www.wikidata.org/entity/Q3569733"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Kirkfield Park"
+        "value" : "Wolseley"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Kirkfield Park"
-      },
+        "value" : "Wolseley"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7436322-A5DD050B-CE36-496F-BEF4-C97A77748370"
@@ -3646,22 +3894,111 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Scott Fielding"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3078005"
+        "value" : "http://www.wikidata.org/entity/Q3197398"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Fort Rouge"
+        "value" : "Kirkfield Park"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fort Rouge"
+        "value" : "Kirkfield Park"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7597905-8F15DC51-09CA-40D0-AB37-45A42B43F6F5"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19007867"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Manitoba"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Legislative Assembly of Manitoba"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7597905"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stan Struthers"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1517320"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Manitoba"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Manitoba"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1948"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "57"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stan Struthers"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3017030"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dauphin"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dauphin"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-04T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7958591-748516E9-3677-477D-B315-278229E95993"
@@ -3730,22 +4067,22 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Wab Kinew"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3214679"
+        "value" : "http://www.wikidata.org/entity/Q3078005"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Lac-du-Bonnet"
+        "value" : "Fort Rouge"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lac du Bonnet"
-      },
+        "value" : "Fort Rouge"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7976219-6BE5C2D6-C3C7-48B0-A7F1-B2C37DEB3E32"
@@ -3814,6 +4151,20 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Wayne Ewasko"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3214679"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lac-du-Bonnet"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lac du Bonnet"
       }
     } ]
   }

--- a/legislative/Q1517320/Q24191581/query-used.rq
+++ b/legislative/Q1517320/Q24191581/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q24191581 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q24191581 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q24191581 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q24191581 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q1537375/Q49224615/popolo-m17n.json
+++ b/legislative/Q1537375/Q49224615/popolo-m17n.json
@@ -324,6 +324,22 @@
     },
     {
       "name": {
+        "lang:en": "Brad Wall",
+        "lang:fr": "Brad Wall"
+      },
+      "id": "Q437816",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q437816"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Todd Goudy"
       },
       "id": "Q50321907",
@@ -2525,6 +2541,23 @@
       "person_id": "Q3086800",
       "organization_id": "Q1537375",
       "area_id": "Q5046704",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18675661",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Saskatchewan",
+        "lang:fr": "membre de l'assemblée législative de la Saskatchewan"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q437816-A04F191F-321D-4F2A-A1A0-6DABF67328BA",
+      "person_id": "Q437816",
+      "organization_id": "Q1537375",
+      "area_id": "Q7656032",
+      "start_date": "1999-08-16",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q1537375/Q49224615/query-results.json
+++ b/legislative/Q1537375/Q49224615/query-results.json
@@ -4,15 +4,6 @@
   },
   "results" : {
     "bindings" : [ {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q14875009"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Rosetown-Elrose"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16244486-C44F3C57-AF26-4435-96DD-E9300C9A1B52"
@@ -81,17 +72,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Jim Reiter"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6662843"
+        "value" : "http://www.wikidata.org/entity/Q14875009"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lloydminster"
-      },
+        "value" : "Rosetown-Elrose"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q21062862-185D9091-D2B4-4E51-B47C-AFC9422B8F6C"
@@ -155,17 +146,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191390"
+        "value" : "http://www.wikidata.org/entity/Q6662843"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina University"
-      },
+        "value" : "Lloydminster"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881382-7346E1C4-97EB-4E28-B096-1C0C52910CA1"
@@ -229,17 +220,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q944820"
+        "value" : "http://www.wikidata.org/entity/Q24191390"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Prince Albert Carlton"
-      },
+        "value" : "Regina University"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881385-8A603A1E-FC28-4AB3-99D8-F0868ADE29A2"
@@ -304,21 +295,21 @@
         "type" : "literal",
         "value" : "61"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q944820"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Prince Albert Carlton"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Prince Albert Carlton"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7425689"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saskatoon University"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881387-91D6CFC5-9295-4603-8661-B79886B4AE3A"
@@ -382,17 +373,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3423460"
+        "value" : "http://www.wikidata.org/entity/Q7425689"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina Lakeview"
-      },
+        "value" : "Saskatoon University"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881390-CDF7C9F0-FF51-4800-9702-FF29B4EC2715"
@@ -457,21 +448,21 @@
         "type" : "literal",
         "value" : "61"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3423460"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Regina Lakeview"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Regina-Lakeview"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3363810"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Regina Douglas Park"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881392-9B892A29-A263-4506-B11A-0EDFC103A646"
@@ -541,21 +532,21 @@
         "type" : "literal",
         "value" : "Nicole Sarauer"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3363810"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Regina Douglas Park"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Parc Douglas de Regina"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191367"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saskatoon Stonebridge-Dakota"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881397-6F5FD369-CB38-48B7-A854-17AC812C75C2"
@@ -619,17 +610,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6908700"
+        "value" : "http://www.wikidata.org/entity/Q24191367"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moosomin"
-      },
+        "value" : "Saskatoon Stonebridge-Dakota"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881399-9942C447-EDDF-4804-AC96-943BFA066192"
@@ -693,17 +684,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5033449"
+        "value" : "http://www.wikidata.org/entity/Q6908700"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Canora-Pelly"
-      },
+        "value" : "Moosomin"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881401-4E4B658D-75E2-48D0-B7F6-046C42408F3C"
@@ -767,17 +758,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6386771"
+        "value" : "http://www.wikidata.org/entity/Q5033449"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Kelvington-Wadena"
-      },
+        "value" : "Canora-Pelly"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881406-E9E972A4-1345-4AF6-A892-C8E6D92C6418"
@@ -841,17 +832,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191386"
+        "value" : "http://www.wikidata.org/entity/Q6386771"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina Pasqua"
-      },
+        "value" : "Kelvington-Wadena"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881408-DE3D56AA-911B-4255-A93A-7885BC9655CD"
@@ -915,17 +906,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6813848"
+        "value" : "http://www.wikidata.org/entity/Q24191386"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Melville-Saltcoats"
-      },
+        "value" : "Regina Pasqua"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881411-FB478ECA-71C9-4FD0-8E49-17A2E45A4845"
@@ -989,17 +980,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5200338"
+        "value" : "http://www.wikidata.org/entity/Q6813848"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Cypress Hills"
-      },
+        "value" : "Melville-Saltcoats"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881416-EF510234-851C-4A44-B1D1-2F6177FEA897"
@@ -1064,21 +1055,21 @@
         "type" : "literal",
         "value" : "61"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5200338"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cypress Hills"
+      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2016-04-04T00:00:00Z"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5401086"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Estevan"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23881420-714BAF42-10B4-44E8-B07C-74B9721A5C34"
@@ -1143,21 +1134,21 @@
         "type" : "literal",
         "value" : "61"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5401086"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Estevan"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Estevan"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191380"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saskatoon Westview"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q24262406-C99C7305-1458-4577-B1D1-1576E0D65C7B"
@@ -1221,17 +1212,17 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "61"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7425676"
+        "value" : "http://www.wikidata.org/entity/Q24191380"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saskatoon Riversdale"
-      },
+        "value" : "Saskatoon Westview"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3014970-3CF7DBD7-45DF-4DDA-AAB8-BCF26F13C242"
@@ -1301,21 +1292,21 @@
         "type" : "literal",
         "value" : "Danielle Chartier"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7425676"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saskatoon Riversdale"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Saskatoon Riversdale"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4869450"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Batoche"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3021498-30522D65-CD45-4DE3-9475-56E0F01F4DEF"
@@ -1384,17 +1375,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Delbert Kirsch"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191357"
+        "value" : "http://www.wikidata.org/entity/Q4869450"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Humboldt-Watrous"
-      },
+        "value" : "Batoche"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3036768-9B0FF85D-4DD9-41AF-87CA-BCCDDAC17BCF"
@@ -1463,17 +1454,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Donna Harpauer"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5193828"
+        "value" : "http://www.wikidata.org/entity/Q24191357"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Cumberland"
-      },
+        "value" : "Humboldt-Watrous"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3038389-4D69B842-2C90-4A2E-BA70-68BD0AAA3FA8"
@@ -1542,17 +1533,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Doyle Vermette"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5046704"
+        "value" : "http://www.wikidata.org/entity/Q5193828"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Carrot River Valley"
-      },
+        "value" : "Cumberland"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3086800-D78F82B4-08BA-46C4-9079-F7321B345296"
@@ -1621,17 +1612,101 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Fred Bradshaw"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3305031"
+        "value" : "http://www.wikidata.org/entity/Q5046704"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Melfort"
+        "value" : "Carrot River Valley"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q437816-A04F191F-321D-4F2A-A1A0-6DABF67328BA"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18675661"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative de la Saskatchewan"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Saskatchewan"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q437816"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brad Wall"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1537375"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de la Saskatchewan"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Saskatchewan"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1989"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "61"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brad Wall"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7656032"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Swift Current"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1999-08-16T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50321907-D1810B18-FAFF-4E5C-8BC4-6A06E2743FB1"
@@ -1696,21 +1771,21 @@
         "type" : "literal",
         "value" : "61"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305031"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Melfort"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Melfort"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7425668"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saskatoon Nutana"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5053496-07E026DD-7346-460C-B1A7-E01402552FA0"
@@ -1779,17 +1854,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Cathy Sproule"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7308554"
+        "value" : "http://www.wikidata.org/entity/Q7425668"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina Wascana Plains"
-      },
+        "value" : "Saskatoon Nutana"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5111203-2ACE9A67-1F94-450B-AB94-10A732689C0B"
@@ -1858,17 +1933,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Christine Tell"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3473795"
+        "value" : "http://www.wikidata.org/entity/Q7308554"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saskatoon Centre"
-      },
+        "value" : "Regina Wascana Plains"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5233726-DD95FE36-4170-42EE-BBA2-1C3D5B7624DA"
@@ -1938,21 +2013,21 @@
         "type" : "literal",
         "value" : "David Forbes"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3473795"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saskatoon Centre"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Saskatoon-Centre"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7425683"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saskatoon Southeast"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5293173-EE6B2541-A542-4781-BE28-C4C751D7DBFD"
@@ -2021,17 +2096,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Don Morgan"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191384"
+        "value" : "http://www.wikidata.org/entity/Q7425683"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina Gardiner Park"
-      },
+        "value" : "Saskatoon Southeast"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5531332-6AA5FBEB-80EB-4175-A8C0-C68A575E03FB"
@@ -2100,17 +2175,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Gene Makowsky"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3218399"
+        "value" : "http://www.wikidata.org/entity/Q24191384"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Last Mountain-Touchwood"
-      },
+        "value" : "Regina Gardiner Park"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5567792-D0C882DA-AF68-42EB-9B3F-417293DE6A85"
@@ -2180,21 +2255,21 @@
         "type" : "literal",
         "value" : "Glen Hart"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3218399"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Last Mountain-Touchwood"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Last Mountain-Touchwood"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7425667"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saskatoon Northwest"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5586020-78471347-A934-4FE4-9895-A6DEADB94DC9"
@@ -2263,17 +2338,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Gordon Wyant"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4792462"
+        "value" : "http://www.wikidata.org/entity/Q7425667"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Arm River"
-      },
+        "value" : "Saskatoon Northwest"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5605335-A2F8FF5B-9CCE-4332-B60C-2B333EC84150"
@@ -2342,17 +2417,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Greg Brkich"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3323622"
+        "value" : "http://www.wikidata.org/entity/Q4792462"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moose Jaw Wakamow"
-      },
+        "value" : "Arm River"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5605887-20DCCCFA-5CA1-4E66-A4E6-0D3FA5DCA062"
@@ -2422,21 +2497,21 @@
         "type" : "literal",
         "value" : "Greg Lawrence"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3323622"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Moose Jaw Wakamow"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Moose Jaw-Wakamow"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q8055786"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Yorkton"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5606088-12021313-2EC8-45A0-9985-CBE84B8A6BB7"
@@ -2505,17 +2580,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Greg Ottenbreit"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7715914"
+        "value" : "http://www.wikidata.org/entity/Q8055786"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "The Battlefords"
-      },
+        "value" : "Yorkton"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5732891-C28CA294-B204-438E-B441-C7CB50FFA8AF"
@@ -2584,17 +2659,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Herb Cox"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3215052"
+        "value" : "http://www.wikidata.org/entity/Q7715914"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Meadow Lake"
-      },
+        "value" : "The Battlefords"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6181454-CA7B16C5-A1DA-441F-9369-4511978F4949"
@@ -2664,21 +2739,21 @@
         "type" : "literal",
         "value" : "Jeremy Harrison"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3215052"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Meadow Lake"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "lac Meadow"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191382"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Saskatoon Willowgrove"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6387442-FC266BA0-DBB1-422B-9009-E3757E5CCA69"
@@ -2747,17 +2822,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Ken Cheveldayoff"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5196636"
+        "value" : "http://www.wikidata.org/entity/Q24191382"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Cut Knife-Turtleford"
-      },
+        "value" : "Saskatoon Willowgrove"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6490206-BE6926B5-9D47-4719-8857-1D102B655F81"
@@ -2826,17 +2901,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Larry Doke"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191388"
+        "value" : "http://www.wikidata.org/entity/Q5196636"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina Rochdale"
-      },
+        "value" : "Cut Knife-Turtleford"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6499381-3051B3A3-15C8-4EF1-A73B-F49D517D98DF"
@@ -2905,17 +2980,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Laura Ross"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3363804"
+        "value" : "http://www.wikidata.org/entity/Q24191388"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina Coronation Park"
-      },
+        "value" : "Regina Rochdale"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6767386-4E883E29-409F-40DE-AEE0-00B30CFEE787"
@@ -2985,21 +3060,21 @@
         "type" : "literal",
         "value" : "Mark Docherty"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3363804"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Regina Coronation Park"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Parc Coronation de Regina"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191359"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Martensville-Warman"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q6962741-229B898D-9044-4A44-BE4F-FA6379F1110A"
@@ -3068,17 +3143,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Nancy Heppner"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191365"
+        "value" : "http://www.wikidata.org/entity/Q24191359"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saskatoon Silverspring-Sutherland"
-      },
+        "value" : "Martensville-Warman"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7152469-51AD7B77-F1C1-4471-9644-95D4C30B19C4"
@@ -3147,17 +3222,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Paul Merriman"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q24191355"
+        "value" : "http://www.wikidata.org/entity/Q24191365"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Biggar-Sask Valley"
-      },
+        "value" : "Saskatoon Silverspring-Sutherland"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7292505-07D9309A-F805-4CA4-BE05-C77ED45E49C4"
@@ -3226,17 +3301,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Randy Weekes"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3473800"
+        "value" : "http://www.wikidata.org/entity/Q24191355"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Saskatoon Meewasin"
-      },
+        "value" : "Biggar-Sask Valley"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7384329-A86873A2-24C7-468C-8A04-B1B28C74C0FB"
@@ -3306,21 +3381,21 @@
         "type" : "literal",
         "value" : "Ryan Meili"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3473800"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saskatoon Meewasin"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Saskatoon-Meewasin"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q3423462"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Regina Rosemont"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7838480-DE641D7F-2725-4C81-A152-1DA55BFB8722"
@@ -3390,21 +3465,21 @@
         "type" : "literal",
         "value" : "Trent Wotherspoon"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3423462"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Regina Rosemont"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Regina-Rosemont"
       }
     }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7308465"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Regina Elphinstone-Centre"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7970380-3F5B4982-7E4C-4AC6-8972-802176B4C2A4"
@@ -3473,17 +3548,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Warren McCall"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q14874996"
+        "value" : "http://www.wikidata.org/entity/Q7308465"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Moose Jaw North"
-      },
+        "value" : "Regina Elphinstone-Centre"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7970387-FB118FC5-D70E-48B3-825D-4F097584EE1C"
@@ -3552,17 +3627,17 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Warren Michelson"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2394580"
+        "value" : "http://www.wikidata.org/entity/Q14874996"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Regina Walsh Acres"
-      },
+        "value" : "Moose Jaw North"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7970499-73078AE6-C4CE-4605-A974-2A42B83BEE8A"
@@ -3631,6 +3706,15 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Warren Steinley"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2394580"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Regina Walsh Acres"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",

--- a/legislative/Q1537375/Q49224615/query-used.rq
+++ b/legislative/Q1537375/Q49224615/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q49224615 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q49224615 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q49224615 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q49224615 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q16251180/2018-01-01-to-2018-12-31/query-used.rq
+++ b/legislative/Q16251180/2018-01-01-to-2018-12-31/query-used.rq
@@ -28,6 +28,10 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +42,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +66,6 @@ OPTIONAL {
 }
 
   }
-  
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q17029808/2018-01-01-to-2018-12-31/query-used.rq
+++ b/legislative/Q17029808/2018-01-01-to-2018-12-31/query-used.rq
@@ -28,6 +28,10 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +42,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +66,6 @@ OPTIONAL {
 }
 
   }
-  
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q17107607/Q55096053/query-used.rq
+++ b/legislative/Q17107607/Q55096053/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55096053 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55096053 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55096053 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55096053 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q1809086/Q17183093/query-results.json
+++ b/legislative/Q1809086/Q17183093/query-results.json
@@ -1,8 +1,0 @@
-{
-  "head" : {
-    "vars" : [ "statement", "item", "name_en", "name_fr", "party", "party_name_en", "party_name_fr", "district", "district_name_en", "district_name_fr", "role", "role_en", "role_fr", "role_superclass", "role_superclass_en", "role_superclass_fr", "start", "end", "facebook", "org", "org_en", "org_fr", "org_jurisdiction", "org_seat_count" ]
-  },
-  "results" : {
-    "bindings" : [ ]
-  }
-}

--- a/legislative/Q1809086/Q55075009/popolo-m17n.json
+++ b/legislative/Q1809086/Q55075009/popolo-m17n.json
@@ -1,9 +1,417 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:en": "Glen Murray",
+        "lang:fr": "Glen Murray"
+      },
+      "id": "Q1530835",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1530835"
+        }
+      ],
+      "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Wayne Gates",
+        "lang:fr": "Wayne Gates"
+      },
+      "id": "Q16243982",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16243982"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "John Fraser",
+        "lang:fr": "John Fraser"
+      },
+      "id": "Q16729089",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16729089"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Yvan Baker",
+        "lang:fr": "Yvan Baker"
+      },
+      "id": "Q17180515",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q17180515"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/yvanbaker"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Arthur Potts",
+        "lang:fr": "Arthur Potts"
+      },
+      "id": "Q17180770",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q17180770"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/mpparthurpotts"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Sophie Kiwala",
+        "lang:fr": "Sophie Kiwala"
+      },
+      "id": "Q17198255",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q17198255"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/SKiwala"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Kathleen Wynne",
+        "lang:fr": "Kathleen Wynne"
+      },
+      "id": "Q3786221",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3786221"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/WynneFans"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Eric Hoskins",
+        "lang:fr": "Eric Hoskins"
+      },
+      "id": "Q5386756",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5386756"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Bob Chiarelli",
+        "lang:fr": "Bob Chiarelli"
+      },
+      "id": "Q580287",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q580287"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Jack MacLaren",
+        "lang:fr": "Jack MacLaren"
+      },
+      "id": "Q6113811",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6113811"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/JackMacLarenMPP"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Jeff Yurek",
+        "lang:fr": "Jeff Yurek"
+      },
+      "id": "Q6175309",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6175309"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/jeffyurekpc"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Jim Wilson",
+        "lang:fr": "Jim Wilson"
+      },
+      "id": "Q6198969",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6198969"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "John Yakabuski",
+        "lang:fr": "John Yakabuski"
+      },
+      "id": "Q6265083",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6265083"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/John-Yakabuski-MPP-1275580362468884"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Michael Harris",
+        "lang:fr": "Michael Harris"
+      },
+      "id": "Q6830967",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6830967"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Michael Mantha",
+        "lang:fr": "Michael Mantha"
+      },
+      "id": "Q6832503",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6832503"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/MichaelMantha"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Monique Taylor",
+        "lang:fr": "Monique Taylor"
+      },
+      "id": "Q6900388",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6900388"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/MPPTaylor"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Monte McNaughton",
+        "lang:fr": "Monte McNaughton"
+      },
+      "id": "Q6904822",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6904822"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/MPPMonteMcNaughton"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Paul Miller",
+        "lang:fr": "Paul Miller"
+      },
+      "id": "Q7152522",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7152522"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Vic Fedeli",
+        "lang:fr": "Victor Fedeli"
+      },
+      "id": "Q7925897",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7925897"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/vicfedeli"
+        }
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:en": "Legislative Assembly of Ontario",
+        "lang:fr": "Assemblée législative de l'Ontario"
+      },
+      "id": "Q1809086",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1809086"
+        }
+      ],
+      "area_id": "Q1904",
+      "seat_counts": {
+        "Q3305347": "107"
+      }
+    },
+    {
+      "name": {
+        "lang:en": "Ontario Liberal Party",
+        "lang:fr": "Parti libéral de l'Ontario"
+      },
+      "id": "Q1553186",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1553186"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Trillium Party of Ontario"
+      },
+      "id": "Q29467157",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q29467157"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Progressive Conservative Party of Ontario",
+        "lang:fr": "Parti progressiste-conservateur de l'Ontario"
+      },
+      "id": "Q826977",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q826977"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Ontario New Democratic Party",
+        "lang:fr": "Nouveau Parti démocratique de l'Ontario"
+      },
+      "id": "Q827589",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q827589"
+        }
+      ]
+    }
   ],
   "areas": [
     {
@@ -2626,6 +3034,338 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1530835-6AF85816-341B-4DB8-817D-DD54949E5EA3",
+      "person_id": "Q1530835",
+      "organization_id": "Q1809086",
+      "area_id": "Q7826304",
+      "start_date": "2010-01-01",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16243982-7641D745-FE45-4698-B9AE-FD2029EE59D4",
+      "person_id": "Q16243982",
+      "organization_id": "Q1809086",
+      "area_id": "Q7023645",
+      "start_date": "2018-07-11",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16729089-284acd60-473e-c9c1-b527-2ff5d11a2bfe",
+      "person_id": "Q16729089",
+      "organization_id": "Q1809086",
+      "area_id": "Q3357749",
+      "start_date": "2014-06-12",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q17180515-FBBB6845-1733-4832-B82A-B7B9015BE0A5",
+      "person_id": "Q17180515",
+      "on_behalf_of_id": "Q1553186",
+      "organization_id": "Q1809086",
+      "area_id": "Q5404733",
+      "start_date": "2014-06-12",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q17180770-981BE51F-0F84-4F6B-95DA-81994E693A69",
+      "person_id": "Q17180770",
+      "on_behalf_of_id": "Q1553186",
+      "organization_id": "Q1809086",
+      "area_id": "Q4875861",
+      "start_date": "2014-06-12",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q17198255-2DA97FCB-1FA4-47F5-9FE8-CF2C98358129",
+      "person_id": "Q17198255",
+      "on_behalf_of_id": "Q1553186",
+      "organization_id": "Q1809086",
+      "area_id": "Q16861334",
+      "start_date": "2014-06-12",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3786221-2874a53e-4d9c-54b7-170f-fd4ea2fba4bb",
+      "person_id": "Q3786221",
+      "organization_id": "Q1809086",
+      "area_id": "Q5293650",
+      "start_date": "2003-10-02",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5386756-0381C116-D028-4F97-9453-5E4593FDB26D",
+      "person_id": "Q5386756",
+      "organization_id": "Q1809086",
+      "area_id": "Q7591014",
+      "start_date": "2009-01-01",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q580287-58308D62-8FD1-4257-8AA2-0D5A343A6BBA",
+      "person_id": "Q580287",
+      "organization_id": "Q1809086",
+      "area_id": "Q7109274",
+      "start_date": "2010-01-01",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6113811-02c87ee4-4304-c740-4690-cce32b812d3f",
+      "person_id": "Q6113811",
+      "on_behalf_of_id": "Q29467157",
+      "organization_id": "Q1809086",
+      "area_id": "Q5041265",
+      "start_date": "2017-05-28",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6175309-D6F7DFB4-7BDA-4615-BAEA-A39496C9C624",
+      "person_id": "Q6175309",
+      "on_behalf_of_id": "Q826977",
+      "organization_id": "Q1809086",
+      "area_id": "Q5360083",
+      "start_date": "2011-10-06",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6198969-9F59368E-E20F-45CD-88C8-241CB33C204E",
+      "person_id": "Q6198969",
+      "organization_id": "Q1809086",
+      "area_id": "Q14875423",
+      "start_date": "2018-07-11",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6265083-CF2A0404-0328-477C-8A3B-78DDF65BEC43",
+      "person_id": "Q6265083",
+      "on_behalf_of_id": "Q826977",
+      "organization_id": "Q1809086",
+      "area_id": "Q14875403",
+      "start_date": "2003-10-02",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6830967-346B7E9F-7448-4A77-B3F6-606206C66ABC",
+      "person_id": "Q6830967",
+      "organization_id": "Q1809086",
+      "area_id": "Q16861336",
+      "start_date": "2011-10-06",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6832503-9D691AB9-B261-43F6-BEC1-FD7D44F4441E",
+      "person_id": "Q6832503",
+      "on_behalf_of_id": "Q827589",
+      "organization_id": "Q1809086",
+      "area_id": "Q4724311",
+      "start_date": "2011-10-06",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6900388-CFAB9AB8-E0AC-4939-9B0B-EDEC60AF5B1B",
+      "person_id": "Q6900388",
+      "on_behalf_of_id": "Q827589",
+      "organization_id": "Q1809086",
+      "area_id": "Q16860714",
+      "start_date": "2011-10-06",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6904822-A7BE3321-E13C-4644-898E-FBB09F025E4F",
+      "person_id": "Q6904822",
+      "on_behalf_of_id": "Q826977",
+      "organization_id": "Q1809086",
+      "area_id": "Q6481611",
+      "start_date": "2011-10-06",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7152522-B039DBB6-478E-4955-8020-BC64C2741131",
+      "person_id": "Q7152522",
+      "organization_id": "Q1809086",
+      "area_id": "Q14875164",
+      "start_date": "2007-01-01",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7925897-34C200B7-06E0-44FC-A99F-0956040E4E76",
+      "person_id": "Q7925897",
+      "on_behalf_of_id": "Q826977",
+      "organization_id": "Q1809086",
+      "area_id": "Q7039511",
+      "start_date": "2011-10-06",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q3305347",
+      "role": {
+        "lang:en": "Member of Ontario Provincial Parliament",
+        "lang:fr": "membre du Parlement provincial"
+      }
+    }
   ]
 }

--- a/legislative/Q1809086/Q55075009/query-results.json
+++ b/legislative/Q1809086/Q55075009/query-results.json
@@ -1,0 +1,1878 @@
+{
+  "head" : {
+    "vars" : [ "statement", "item", "name_en", "name_fr", "party", "party_name_en", "party_name_fr", "district", "district_name_en", "district_name_fr", "role", "role_en", "role_fr", "role_superclass", "role_superclass_en", "role_superclass_fr", "start", "end", "facebook", "org", "org_en", "org_fr", "org_jurisdiction", "org_seat_count" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1530835-6AF85816-341B-4DB8-817D-DD54949E5EA3"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1530835"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Glen Murray"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7826304"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Toronto Centre"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Glen Murray"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Toronto-Centre"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-01-01T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16243982-7641D745-FE45-4698-B9AE-FD2029EE59D4"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16243982"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Wayne Gates"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7023645"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Niagara Falls"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wayne Gates"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Niagara Falls"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-07-11T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16729089-284acd60-473e-c9c1-b527-2ff5d11a2bfe"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16729089"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "John Fraser"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3357749"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ottawa South"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Fraser"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ottawa-Sud"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-06-12T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q17180515-FBBB6845-1733-4832-B82A-B7B9015BE0A5"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17180515"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yvan Baker"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5404733"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Etobicoke Centre"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Yvan Baker"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Etobicoke-Centre"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-06-12T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1553186"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ontario Liberal Party"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "yvanbaker"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q17180770-981BE51F-0F84-4F6B-95DA-81994E693A69"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17180770"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Arthur Potts"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4875861"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Beaches—East York"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Arthur Potts"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Beaches—East York"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-06-12T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1553186"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ontario Liberal Party"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "mpparthurpotts"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q17198255-2DA97FCB-1FA4-47F5-9FE8-CF2C98358129"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17198255"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sophie Kiwala"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16861334"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kingston and the Islands (provincial electoral district)"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sophie Kiwala"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kingston et les Îles (circonscription provinciale)"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2014-06-12T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1553186"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ontario Liberal Party"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "SKiwala"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3786221-2874a53e-4d9c-54b7-170f-fd4ea2fba4bb"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3786221"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kathleen Wynne"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5293650"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Don Valley West"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kathleen Wynne"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Don Valley-Ouest"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-10-02T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "WynneFans"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5386756-0381C116-D028-4F97-9453-5E4593FDB26D"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5386756"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eric Hoskins"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7591014"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "St. Paul's"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Eric Hoskins"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "St. Paul's"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2009-01-01T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q580287-58308D62-8FD1-4257-8AA2-0D5A343A6BBA"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q580287"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bob Chiarelli"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7109274"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ottawa West—Nepean"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Chiarelli"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ottawa-Ouest—Nepean (circonscription provinciale)"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-01-01T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6113811-02c87ee4-4304-c740-4690-cce32b812d3f"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6113811"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jack MacLaren"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5041265"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Carleton—Mississippi Mills"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jack MacLaren"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Carleton—Mississippi Mills"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-28T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q29467157"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Trillium Party of Ontario"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "JackMacLarenMPP"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6175309-D6F7DFB4-7BDA-4615-BAEA-A39496C9C624"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6175309"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jeff Yurek"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5360083"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Elgin—Middlesex—London"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jeff Yurek"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Elgin—Middlesex—London"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-06T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q826977"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti progressiste-conservateur de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Party of Ontario"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "jeffyurekpc"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6198969-9F59368E-E20F-45CD-88C8-241CB33C204E"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6198969"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jim Wilson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14875423"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Simcoe—Grey (provincial electoral district)"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jim Wilson"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Simcoe—Grey"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-07-11T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6265083-CF2A0404-0328-477C-8A3B-78DDF65BEC43"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6265083"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "John Yakabuski"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14875403"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Renfrew—Nipissing—Pembroke (provincial electoral district)"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Yakabuski"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Renfrew—Nipissing—Pembroke"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-10-02T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q826977"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti progressiste-conservateur de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Party of Ontario"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "John-Yakabuski-MPP-1275580362468884"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6830967-346B7E9F-7448-4A77-B3F6-606206C66ABC"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6830967"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Michael Harris"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16861336"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kitchener—Conestoga"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Harris"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kitchener—Conestoga (circonscription provinciale)"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-06T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6832503-9D691AB9-B261-43F6-BEC1-FD7D44F4441E"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6832503"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Michael Mantha"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4724311"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Algoma—Manitoulin"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Mantha"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Algoma—Manitoulin"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-06T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q827589"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ontario New Democratic Party"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "MichaelMantha"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6900388-CFAB9AB8-E0AC-4939-9B0B-EDEC60AF5B1B"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6900388"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Monique Taylor"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16860714"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Hamilton Mountain (provincial electoral district)"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Monique Taylor"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hamilton Mountain (circonscription provinciale)"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-06T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q827589"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ontario New Democratic Party"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "MPPTaylor"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6904822-A7BE3321-E13C-4644-898E-FBB09F025E4F"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6904822"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Monte McNaughton"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6481611"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lambton—Kent—Middlesex"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Monte McNaughton"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lambton—Kent—Middlesex"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-06T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q826977"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti progressiste-conservateur de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Party of Ontario"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "MPPMonteMcNaughton"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7152522-B039DBB6-478E-4955-8020-BC64C2741131"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7152522"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paul Miller"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14875164"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Hamilton East—Stoney Creek"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Paul Miller"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hamilton-Est—Stoney Creek"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2007-01-01T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7925897-34C200B7-06E0-44FC-A99F-0956040E4E76"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3305347"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Parlement provincial"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Ontario Provincial Parliament"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7925897"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Vic Fedeli"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1809086"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Ontario"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Ontario"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "107"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7039511"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nipissing"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Victor Fedeli"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nipissing"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-06T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q826977"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti progressiste-conservateur de l'Ontario"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Party of Ontario"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "vicfedeli"
+      }
+    } ]
+  }
+}

--- a/legislative/Q1809086/Q55075009/query-used.rq
+++ b/legislative/Q1809086/Q55075009/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55075009 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55075009 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55075009 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q17183093 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q1812866/Q19876139/popolo-m17n.json
+++ b/legislative/Q1812866/Q19876139/popolo-m17n.json
@@ -1038,6 +1038,22 @@
     },
     {
       "name": {
+        "lang:en": "Brian Jean",
+        "lang:fr": "Brian Jean"
+      },
+      "id": "Q2421201",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2421201"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Brian Mason",
         "lang:fr": "Brian Mason"
       },
@@ -1078,6 +1094,22 @@
         {
           "scheme": "wikidata",
           "identifier": "Q3162959"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Alison Redford",
+        "lang:fr": "Alison Redford"
+      },
+      "id": "Q459603",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q459603"
         }
       ],
       "links": [
@@ -1138,6 +1170,22 @@
         {
           "scheme": "wikidata",
           "identifier": "Q51463051"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Dave Hancock",
+        "lang:fr": "Dave Hancock"
+      },
+      "id": "Q5228907",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5228907"
         }
       ],
       "links": [
@@ -1325,6 +1373,20 @@
       "seat_counts": {
         "Q15964815": "87"
       }
+    },
+    {
+      "name": {
+        "lang:en": "Alberta New Democratic Party",
+        "lang:fr": "Nouveau Parti démocratique de l'Alberta"
+      },
+      "id": "Q3345044",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3345044"
+        }
+      ]
     }
   ],
   "areas": [
@@ -3582,6 +3644,24 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q19861370-11ba1e2e-4bd6-ce83-8921-3bd95f084cb3",
+      "person_id": "Q19861370",
+      "on_behalf_of_id": "Q3345044",
+      "organization_id": "Q1812866",
+      "area_id": "Q7619584",
+      "start_date": "2015-05-05",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q15964815",
+      "role": {
+        "lang:en": "member of Alberta Legislative Assembly",
+        "lang:fr": "membre de l'assemblée législative d'Alberta"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q19861370-1F7D6193-0F2B-472A-976D-B52CBD1D2382",
       "person_id": "Q19861370",
       "organization_id": "Q1812866",
@@ -4526,6 +4606,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q2421201-15b6f5b8-428c-5a28-4c86-41e9ad9ff49f",
+      "person_id": "Q2421201",
+      "organization_id": "Q1812866",
+      "area_id": "Q5471643",
+      "start_date": "2015-01-01",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q15964815",
+      "role": {
+        "lang:en": "member of Alberta Legislative Assembly",
+        "lang:fr": "membre de l'assemblée législative d'Alberta"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q2924949-23C31EEB-BD6A-4C4E-87F9-7366AC8F054C",
       "person_id": "Q2924949",
       "organization_id": "Q1812866",
@@ -4562,6 +4659,23 @@
       "person_id": "Q3162959",
       "organization_id": "Q1812866",
       "area_id": "Q5019612",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q15964815",
+      "role": {
+        "lang:en": "member of Alberta Legislative Assembly",
+        "lang:fr": "membre de l'assemblée législative d'Alberta"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q459603-2128aee3-4424-5264-065d-4b367b3c6ab4",
+      "person_id": "Q459603",
+      "organization_id": "Q1812866",
+      "area_id": "Q5019601",
+      "start_date": "2008-03-03",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -4674,6 +4788,23 @@
       "person_id": "Q51463051",
       "organization_id": "Q1812866",
       "area_id": "Q5338987",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q15964815",
+      "role": {
+        "lang:en": "member of Alberta Legislative Assembly",
+        "lang:fr": "membre de l'assemblée législative d'Alberta"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5228907-bd711eee-4ef0-979f-cee2-3be84497eeeb",
+      "person_id": "Q5228907",
+      "organization_id": "Q1812866",
+      "area_id": "Q5339003",
+      "start_date": "1997-03-11",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q1812866/Q19876139/query-results.json
+++ b/legislative/Q1812866/Q19876139/query-results.json
@@ -4,20 +4,6 @@
   },
   "results" : {
     "bindings" : [ {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019605"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Calgary-Fort"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Calgary-Fort"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16243821-9454D94A-445C-447B-B9E4-A63E697539FD"
@@ -54,6 +40,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16243821"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joe Ceci"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -82,26 +73,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Joe Ceci"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019627"
+        "value" : "http://www.wikidata.org/entity/Q5019605"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Sud-Est"
+        "value" : "Calgary-Fort"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-South East"
+        "value" : "Calgary-Fort"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16243821-9454D94A-445C-447B-B9E4-A63E697539FD"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16243821"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joe Ceci"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Joe Ceci"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019605"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Fort"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Fort"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16243964-F6120447-66C9-448C-8933-2529F6AC340A"
@@ -138,6 +208,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16243964"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rick Fraser"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -166,26 +241,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rick Fraser"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019601"
+        "value" : "http://www.wikidata.org/entity/Q5019627"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Elbow"
+        "value" : "Calgary-Sud-Est"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Elbow"
+        "value" : "Calgary-South East"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16243964-F6120447-66C9-448C-8933-2529F6AC340A"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16243964"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rick Fraser"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rick Fraser"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019627"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Sud-Est"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-South East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q16728072-C00DB7BA-34A4-43EB-8C60-6FBAA9A40408"
@@ -222,6 +376,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16728072"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Greg Clark"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -250,26 +409,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Greg Clark"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019610"
+        "value" : "http://www.wikidata.org/entity/Q5019601"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Hawkwood"
+        "value" : "Calgary-Elbow"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Hawkwood"
+        "value" : "Calgary-Elbow"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16728072-C00DB7BA-34A4-43EB-8C60-6FBAA9A40408"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16728072"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Greg Clark"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Greg Clark"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019601"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Elbow"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Elbow"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18167865-A3F0F672-48CE-4F27-90B9-7817C9D14AD7"
@@ -306,6 +544,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18167865"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Connolly"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -334,26 +577,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michael Connolly"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019628"
+        "value" : "http://www.wikidata.org/entity/Q5019610"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Ouest"
+        "value" : "Calgary-Hawkwood"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-West"
+        "value" : "Calgary-Hawkwood"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q18167865-A3F0F672-48CE-4F27-90B9-7817C9D14AD7"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18167865"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Connolly"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Michael Connolly"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019610"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Hawkwood"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Hawkwood"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18344762-73FC9221-9CB6-48A0-93BF-A8D06740EC04"
@@ -390,6 +712,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18344762"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mike Ellis"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -418,26 +745,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mike Ellis"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7622133"
+        "value" : "http://www.wikidata.org/entity/Q5019628"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Strathmore-Brooks"
+        "value" : "Calgary-Ouest"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Strathmore-Brooks"
+        "value" : "Calgary-West"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q18344762-73FC9221-9CB6-48A0-93BF-A8D06740EC04"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18344762"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mike Ellis"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mike Ellis"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019628"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q18705159-C40489D6-0B30-4297-948B-657AB20E8F95"
@@ -474,6 +880,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18705159"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Derek Fildebrandt"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -502,26 +913,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Derek Fildebrandt"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6512765"
+        "value" : "http://www.wikidata.org/entity/Q7622133"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Leduc-Beaumont"
+        "value" : "Strathmore-Brooks"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Leduc-Beaumont"
+        "value" : "Strathmore-Brooks"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q18705159-C40489D6-0B30-4297-948B-657AB20E8F95"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18705159"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Derek Fildebrandt"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Derek Fildebrandt"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7622133"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Strathmore-Brooks"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Strathmore-Brooks"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861366-DC931DB9-358E-4194-BB9F-B38B38D23718"
@@ -558,6 +1048,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861366"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Shaye Anderson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -586,26 +1081,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Shaye Anderson"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7619584"
+        "value" : "http://www.wikidata.org/entity/Q6512765"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Stony Plain"
+        "value" : "Leduc-Beaumont"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Stony Plain"
+        "value" : "Leduc-Beaumont"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861366-DC931DB9-358E-4194-BB9F-B38B38D23718"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861366"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Shaye Anderson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Shaye Anderson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6512765"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Leduc-Beaumont"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Leduc-Beaumont"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861370-1F7D6193-0F2B-472A-976D-B52CBD1D2382"
@@ -642,6 +1216,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861370"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Erin Babcock"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -670,30 +1249,327 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7619584"
+      },
+      "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Erin Babcock"
+        "value" : "Stony Plain"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stony Plain"
       },
       "facebook" : {
         "type" : "literal",
         "value" : "erinndp"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861370-1F7D6193-0F2B-472A-976D-B52CBD1D2382"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861370"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Erin Babcock"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Erin Babcock"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17102277"
+        "value" : "http://www.wikidata.org/entity/Q7619584"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Whitecourt-Sainte-Anne"
+        "value" : "Stony Plain"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Whitecourt-Ste. Anne"
+        "value" : "Stony Plain"
       },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "erinndp"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861370-11ba1e2e-4bd6-ce83-8921-3bd95f084cb3"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861370"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Erin Babcock"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Erin Babcock"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7619584"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stony Plain"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stony Plain"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "erinndp"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3345044"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique de l'Alberta"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alberta New Democratic Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-05-05T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861370-11ba1e2e-4bd6-ce83-8921-3bd95f084cb3"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861370"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Erin Babcock"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Erin Babcock"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7619584"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stony Plain"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stony Plain"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "erinndp"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3345044"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique de l'Alberta"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alberta New Democratic Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-05-05T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861372-013D459E-D042-4971-854B-5E7AFAEE17E4"
@@ -730,6 +1606,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861372"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Oneil Carlier"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -758,26 +1639,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Oneil Carlier"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338994"
+        "value" : "http://www.wikidata.org/entity/Q17102277"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Meadowlark"
+        "value" : "Whitecourt-Sainte-Anne"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Meadowlark"
+        "value" : "Whitecourt-Ste. Anne"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861372-013D459E-D042-4971-854B-5E7AFAEE17E4"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861372"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Oneil Carlier"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Oneil Carlier"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17102277"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Whitecourt-Sainte-Anne"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Whitecourt-Ste. Anne"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861374-42198EDE-4EE2-4AB8-B072-3E044DD0DA27"
@@ -814,6 +1774,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861374"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jon Carson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -842,26 +1807,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jon Carson"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019611"
+        "value" : "http://www.wikidata.org/entity/Q5338994"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Klein"
+        "value" : "Edmonton-Meadowlark"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Klein"
+        "value" : "Edmonton-Meadowlark"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861374-42198EDE-4EE2-4AB8-B072-3E044DD0DA27"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861374"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jon Carson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jon Carson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338994"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Meadowlark"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Meadowlark"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861472-DC22623A-C325-41E5-9F5C-A2F9B57A2174"
@@ -898,6 +1942,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861472"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Craig Coolahan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -926,26 +1975,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Craig Coolahan"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7622060"
+        "value" : "http://www.wikidata.org/entity/Q5019611"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Strathcona-Sherwood Park"
+        "value" : "Calgary-Klein"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Strathcona-Sherwood Park"
+        "value" : "Calgary-Klein"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861472-DC22623A-C325-41E5-9F5C-A2F9B57A2174"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861472"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Craig Coolahan"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Craig Coolahan"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019611"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Klein"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Klein"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861476-ABFE64C9-27B0-4463-8901-34576C086F28"
@@ -982,6 +2110,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861476"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Estefania Cortes-Vargas"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1010,26 +2143,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Estefania Cortes-Vargas"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338993"
+        "value" : "http://www.wikidata.org/entity/Q7622060"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-McClung"
+        "value" : "Strathcona-Sherwood Park"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-McClung"
+        "value" : "Strathcona-Sherwood Park"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861476-ABFE64C9-27B0-4463-8901-34576C086F28"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861476"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Estefania Cortes-Vargas"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Estefania Cortes-Vargas"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7622060"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Strathcona-Sherwood Park"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Strathcona-Sherwood Park"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861477-2A8C4696-71B5-4FE4-924E-8DA42F45C6DF"
@@ -1066,6 +2278,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861477"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lorne Dach"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1094,26 +2311,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Lorne Dach"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5339001"
+        "value" : "http://www.wikidata.org/entity/Q5338993"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Sud-Ouest"
+        "value" : "Edmonton-McClung"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-South West"
+        "value" : "Edmonton-McClung"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861477-2A8C4696-71B5-4FE4-924E-8DA42F45C6DF"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861477"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lorne Dach"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lorne Dach"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338993"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-McClung"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-McClung"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19861478-D4F5745D-F395-48AA-951F-225B7A197C63"
@@ -1150,6 +2446,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19861478"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Thomas Dang"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1178,26 +2479,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Thomas Dang"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019593"
+        "value" : "http://www.wikidata.org/entity/Q5339001"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Bow"
+        "value" : "Edmonton-Sud-Ouest"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Bow"
+        "value" : "Edmonton-South West"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19861478-D4F5745D-F395-48AA-951F-225B7A197C63"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19861478"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Thomas Dang"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Thomas Dang"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5339001"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Sud-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-South West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862149-4B6DA198-9143-47B3-BC07-E4070FBBF4F1"
@@ -1234,6 +2614,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862149"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Deborah Drever"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1262,26 +2647,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Deborah Drever"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338999"
+        "value" : "http://www.wikidata.org/entity/Q5019593"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Rutherford"
+        "value" : "Calgary-Bow"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Rutherford"
+        "value" : "Calgary-Bow"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862149-4B6DA198-9143-47B3-BC07-E4070FBBF4F1"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862149"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Deborah Drever"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Deborah Drever"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019593"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Bow"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Bow"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862155-5004E108-5E72-4EC6-B43E-372735F376F8"
@@ -1318,6 +2782,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862155"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Feehan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1346,26 +2815,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Richard Feehan"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6533280"
+        "value" : "http://www.wikidata.org/entity/Q5338999"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Lethbridge-Est"
+        "value" : "Edmonton-Rutherford"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lethbridge-East"
+        "value" : "Edmonton-Rutherford"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862155-5004E108-5E72-4EC6-B43E-372735F376F8"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862155"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Feehan"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Richard Feehan"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338999"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Rutherford"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Rutherford"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862156-CC7C171E-FCDD-4927-AFB9-CC2BFF1A8343"
@@ -1402,6 +2950,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862156"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maria Fitzpatrick"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1430,26 +2983,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Maria Fitzpatrick"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019596"
+        "value" : "http://www.wikidata.org/entity/Q6533280"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Buffalo"
+        "value" : "Lethbridge-Est"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Buffalo"
+        "value" : "Lethbridge-East"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862156-CC7C171E-FCDD-4927-AFB9-CC2BFF1A8343"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862156"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maria Fitzpatrick"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Maria Fitzpatrick"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6533280"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lethbridge-Est"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lethbridge-East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862157-1B78D009-3A0E-4386-8978-B833FE4EA7C9"
@@ -1486,6 +3118,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862157"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kathleen Ganley"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1514,26 +3151,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kathleen Ganley"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338985"
+        "value" : "http://www.wikidata.org/entity/Q5019596"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Castle Downs"
+        "value" : "Calgary-Buffalo"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Castle Downs"
+        "value" : "Calgary-Buffalo"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862157-1B78D009-3A0E-4386-8978-B833FE4EA7C9"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862157"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kathleen Ganley"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kathleen Ganley"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019596"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Buffalo"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Buffalo"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862158-3C096AD0-5DEB-499C-974A-44688EF500C1"
@@ -1570,6 +3286,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862158"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nicole Goehring"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1598,26 +3319,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Nicole Goehring"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338996"
+        "value" : "http://www.wikidata.org/entity/Q5338985"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Mill Woods"
+        "value" : "Edmonton-Castle Downs"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Mill Woods"
+        "value" : "Edmonton-Castle Downs"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862158-3C096AD0-5DEB-499C-974A-44688EF500C1"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862158"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nicole Goehring"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nicole Goehring"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338985"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Castle Downs"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Castle Downs"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862159-589C3543-0743-4354-A6E0-58F8755A0391"
@@ -1654,6 +3454,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862159"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Christina Gray"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1682,26 +3487,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Christina Gray"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338989"
+        "value" : "http://www.wikidata.org/entity/Q5338996"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Glenora"
+        "value" : "Edmonton-Mill Woods"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Glenora"
+        "value" : "Edmonton-Mill Woods"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862159-589C3543-0743-4354-A6E0-58F8755A0391"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862159"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Christina Gray"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Christina Gray"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338996"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Mill Woods"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Mill Woods"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862161-B3A28928-1DE8-4883-A9E5-528280053FD6"
@@ -1738,6 +3622,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862161"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sarah Hoffman"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1766,26 +3655,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sarah Hoffman"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7581403"
+        "value" : "http://www.wikidata.org/entity/Q5338989"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Spruce Grove-Saint-Albert"
+        "value" : "Edmonton-Glenora"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Spruce Grove-St. Albert"
+        "value" : "Edmonton-Glenora"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862161-B3A28928-1DE8-4883-A9E5-528280053FD6"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862161"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sarah Hoffman"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sarah Hoffman"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338989"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Glenora"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Glenora"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862162-C0BBFFF1-0FDC-4B2A-AD22-4D19DC159A79"
@@ -1822,6 +3790,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862162"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Trevor Horne"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1850,26 +3823,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Trevor Horne"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7157431"
+        "value" : "http://www.wikidata.org/entity/Q7581403"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Peace River"
+        "value" : "Spruce Grove-Saint-Albert"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Peace River"
+        "value" : "Spruce Grove-St. Albert"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862162-C0BBFFF1-0FDC-4B2A-AD22-4D19DC159A79"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862162"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Trevor Horne"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Trevor Horne"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7581403"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Spruce Grove-Saint-Albert"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Spruce Grove-St. Albert"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862164-85F0F23E-3CEA-4D1A-B802-B74AD75F0B53"
@@ -1906,6 +3958,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862164"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Debbie Jabbour"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1934,26 +3991,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Debbie Jabbour"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019622"
+        "value" : "http://www.wikidata.org/entity/Q7157431"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Collines-du-nord"
+        "value" : "Peace River"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Northern Hills"
+        "value" : "Peace River"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862164-85F0F23E-3CEA-4D1A-B802-B74AD75F0B53"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862164"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Debbie Jabbour"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Debbie Jabbour"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7157431"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Peace River"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Peace River"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862165-E9EB0DFB-43A3-4676-842C-B07F4B72ED55"
@@ -1990,6 +4126,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862165"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jamie Kleinsteuber"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2018,26 +4159,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jamie Kleinsteuber"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6531525"
+        "value" : "http://www.wikidata.org/entity/Q5019622"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Lesser Slave Lake"
+        "value" : "Calgary-Collines-du-nord"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lesser Slave Lake"
+        "value" : "Calgary-Northern Hills"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862165-E9EB0DFB-43A3-4676-842C-B07F4B72ED55"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862165"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jamie Kleinsteuber"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jamie Kleinsteuber"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019622"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Collines-du-nord"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Northern Hills"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862168-B9FAA64C-4583-4F54-9000-984786F848AE"
@@ -2074,6 +4294,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862168"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Danielle Larivee"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2102,26 +4327,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Danielle Larivee"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5471982"
+        "value" : "http://www.wikidata.org/entity/Q6531525"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Fort Saskatchewan-Vegreville"
+        "value" : "Lesser Slave Lake"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fort Saskatchewan-Vegreville"
+        "value" : "Lesser Slave Lake"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862168-B9FAA64C-4583-4F54-9000-984786F848AE"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862168"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Danielle Larivee"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Danielle Larivee"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6531525"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lesser Slave Lake"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lesser Slave Lake"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862170-E49538EC-E1AD-41E3-84EF-C145A9EA17CE"
@@ -2158,6 +4462,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862170"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jessica Littlewood"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2186,26 +4495,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jessica Littlewood"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338988"
+        "value" : "http://www.wikidata.org/entity/Q5471982"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Ellerslie"
+        "value" : "Fort Saskatchewan-Vegreville"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Ellerslie"
+        "value" : "Fort Saskatchewan-Vegreville"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862170-E49538EC-E1AD-41E3-84EF-C145A9EA17CE"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862170"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jessica Littlewood"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jessica Littlewood"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5471982"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fort Saskatchewan-Vegreville"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fort Saskatchewan-Vegreville"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862173-149B91ED-046A-49A8-96F7-ECA8E43D03AD"
@@ -2242,6 +4630,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862173"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rod Loyola"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2270,26 +4663,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rod Loyola"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019599"
+        "value" : "http://www.wikidata.org/entity/Q5338988"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Est"
+        "value" : "Edmonton-Ellerslie"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-East"
+        "value" : "Edmonton-Ellerslie"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862173-149B91ED-046A-49A8-96F7-ECA8E43D03AD"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862173"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rod Loyola"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rod Loyola"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338988"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Ellerslie"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Ellerslie"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862174-8F812FE7-9EA6-40B1-B471-4CA2C7C1F367"
@@ -2326,6 +4798,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862174"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robyn Luff"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2354,26 +4831,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Robyn Luff"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2933896"
+        "value" : "http://www.wikidata.org/entity/Q5019599"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Currie"
+        "value" : "Calgary-Est"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Currie"
+        "value" : "Calgary-East"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862174-8F812FE7-9EA6-40B1-B471-4CA2C7C1F367"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862174"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robyn Luff"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Robyn Luff"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019599"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Est"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862177-A43F004A-1F65-443D-B1A5-AEFCB0960E22"
@@ -2410,6 +4966,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862177"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Malkinson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2438,26 +4999,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Brian Malkinson"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5315788"
+        "value" : "http://www.wikidata.org/entity/Q2933896"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Dunvegan-Central Peace-Notley"
+        "value" : "Calgary-Currie"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Dunvegan-Central Peace-Notley"
+        "value" : "Calgary-Currie"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862177-A43F004A-1F65-443D-B1A5-AEFCB0960E22"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862177"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Malkinson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brian Malkinson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2933896"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Currie"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Currie"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19862181-0860875C-8364-4935-AC6B-DDCBC187583A"
@@ -2494,6 +5134,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19862181"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Margaret McCuaig-Boyd"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2522,26 +5167,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Margaret McCuaig-Boyd"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5760060"
+        "value" : "http://www.wikidata.org/entity/Q5315788"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Highwood"
+        "value" : "Dunvegan-Central Peace-Notley"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Highwood"
+        "value" : "Dunvegan-Central Peace-Notley"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19862181-0860875C-8364-4935-AC6B-DDCBC187583A"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19862181"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Margaret McCuaig-Boyd"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Margaret McCuaig-Boyd"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5315788"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dunvegan-Central Peace-Notley"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dunvegan-Central Peace-Notley"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19876298-2EC5E32B-7A82-4F46-B187-20B803B51BF5"
@@ -2578,6 +5302,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19876298"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wayne Anderson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2606,26 +5335,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Wayne Anderson"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7085720"
+        "value" : "http://www.wikidata.org/entity/Q5760060"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Olds-Didsbury-Three Hills"
+        "value" : "Highwood"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Olds-Didsbury-Three Hills"
+        "value" : "Highwood"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19876298-2EC5E32B-7A82-4F46-B187-20B803B51BF5"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19876298"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wayne Anderson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Wayne Anderson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5760060"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Highwood"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Highwood"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19877168-D0FA40C3-F454-4C33-A73F-3627D18061EF"
@@ -2662,6 +5470,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19877168"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nathan Cooper"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2690,26 +5503,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Nathan Cooper"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4942531"
+        "value" : "http://www.wikidata.org/entity/Q7085720"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Bonnyville-Cold Lake"
+        "value" : "Olds-Didsbury-Three Hills"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Bonnyville-Cold Lake"
+        "value" : "Olds-Didsbury-Three Hills"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19877168-D0FA40C3-F454-4C33-A73F-3627D18061EF"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19877168"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nathan Cooper"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nathan Cooper"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7085720"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Olds-Didsbury-Three Hills"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Olds-Didsbury-Three Hills"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19877251-5597EFBF-FA76-4923-A2C5-48DEE7E1DC36"
@@ -2746,6 +5638,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19877251"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Scott Cyr"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2774,26 +5671,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Scott Cyr"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019602"
+        "value" : "http://www.wikidata.org/entity/Q4942531"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Fish Creek"
+        "value" : "Bonnyville-Cold Lake"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Fish Creek"
+        "value" : "Bonnyville-Cold Lake"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19877251-5597EFBF-FA76-4923-A2C5-48DEE7E1DC36"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19877251"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Scott Cyr"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Scott Cyr"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4942531"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bonnyville-Cold Lake"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bonnyville-Cold Lake"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19878354-5DB3D62E-C977-40A6-BC01-022A602E56D6"
@@ -2830,6 +5806,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19878354"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Gotfried"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2858,26 +5839,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Richard Gotfried"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6467844"
+        "value" : "http://www.wikidata.org/entity/Q5019602"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Lac La Biche-Saint-Paul-Two Hills"
+        "value" : "Calgary-Fish Creek"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lac La Biche-St. Paul-Two Hills"
+        "value" : "Calgary-Fish Creek"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19878354-5DB3D62E-C977-40A6-BC01-022A602E56D6"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19878354"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Gotfried"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Richard Gotfried"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019602"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Fish Creek"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Fish Creek"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19878585-35C306D2-5C8B-430A-90AF-7AD281997491"
@@ -2914,6 +5974,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19878585"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dave Hanson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2942,26 +6007,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dave Hanson"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5038801"
+        "value" : "http://www.wikidata.org/entity/Q6467844"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Cardston-Taber-Warner"
+        "value" : "Lac La Biche-Saint-Paul-Two Hills"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Cardston-Taber-Warner"
+        "value" : "Lac La Biche-St. Paul-Two Hills"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19878585-35C306D2-5C8B-430A-90AF-7AD281997491"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19878585"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dave Hanson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dave Hanson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6467844"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lac La Biche-Saint-Paul-Two Hills"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lac La Biche-St. Paul-Two Hills"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19878887-199F5354-4C14-4673-B025-8629EE8BBF20"
@@ -2998,6 +6142,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19878887"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Grant Hunter"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3026,26 +6175,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Grant Hunter"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019626"
+        "value" : "http://www.wikidata.org/entity/Q5038801"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Varsity"
+        "value" : "Cardston-Taber-Warner"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Varsity"
+        "value" : "Cardston-Taber-Warner"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19878887-199F5354-4C14-4673-B025-8629EE8BBF20"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19878887"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Grant Hunter"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Grant Hunter"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5038801"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cardston-Taber-Warner"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cardston-Taber-Warner"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880392-235C6264-9C76-46E3-9C8E-AAB8E272DCBC"
@@ -3082,6 +6310,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880392"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stephanie McLean"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3110,26 +6343,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Stephanie McLean"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019614"
+        "value" : "http://www.wikidata.org/entity/Q5019626"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Mackay-Nose Hill"
+        "value" : "Calgary-Varsity"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Mackay-Nose Hill"
+        "value" : "Calgary-Varsity"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880392-235C6264-9C76-46E3-9C8E-AAB8E272DCBC"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880392"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stephanie McLean"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stephanie McLean"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019626"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Varsity"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Varsity"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880417-9A688A82-19DC-439D-891C-50A51004FEEC"
@@ -3166,6 +6478,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880417"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karen McPherson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3194,26 +6511,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Karen McPherson"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7303983"
+        "value" : "http://www.wikidata.org/entity/Q5019614"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Red Deer-Sud"
+        "value" : "Calgary-Mackay-Nose Hill"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Red Deer-South"
+        "value" : "Calgary-Mackay-Nose Hill"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880417-9A688A82-19DC-439D-891C-50A51004FEEC"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880417"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karen McPherson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Karen McPherson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019614"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Mackay-Nose Hill"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Mackay-Nose Hill"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880428-D7757A45-BF1E-4906-B97B-36803A34B7AE"
@@ -3250,6 +6646,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880428"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Barb Miller"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3278,26 +6679,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Barb Miller"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019598"
+        "value" : "http://www.wikidata.org/entity/Q7303983"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Cross"
+        "value" : "Red Deer-Sud"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Cross"
+        "value" : "Red Deer-South"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880428-D7757A45-BF1E-4906-B97B-36803A34B7AE"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880428"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Barb Miller"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Barb Miller"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7303983"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Red Deer-Sud"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Red Deer-South"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880448-AEEFDC6B-C7D8-4A5F-8B00-69D57D716FE7"
@@ -3334,6 +6814,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880448"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ricardo Miranda"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3362,26 +6847,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ricardo Miranda"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338987"
+        "value" : "http://www.wikidata.org/entity/Q5019598"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Decore"
+        "value" : "Calgary-Cross"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Decore"
+        "value" : "Calgary-Cross"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880448-AEEFDC6B-C7D8-4A5F-8B00-69D57D716FE7"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880448"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ricardo Miranda"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ricardo Miranda"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019598"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Cross"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Cross"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880479-3d2f6230-4ce6-ca65-d0b4-e751770a9766"
@@ -3418,6 +6982,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880479"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chris Nielsen (homme politique)"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3446,26 +7015,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Chris Nielsen (homme politique)"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019592"
+        "value" : "http://www.wikidata.org/entity/Q5338987"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Acadia"
+        "value" : "Edmonton-Decore"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Acadia"
+        "value" : "Edmonton-Decore"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880479-3d2f6230-4ce6-ca65-d0b4-e751770a9766"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880479"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chris Nielsen (homme politique)"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Chris Nielsen"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338987"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Decore"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Decore"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880743-2B7DADE8-DED7-4ED0-8F60-F172CB1CF8BA"
@@ -3502,6 +7150,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880743"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brandy Payne"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3530,26 +7183,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Brandy Payne"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6533282"
+        "value" : "http://www.wikidata.org/entity/Q5019592"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Lethbridge-Ouest"
+        "value" : "Calgary-Acadia"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Lethbridge-West"
+        "value" : "Calgary-Acadia"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880743-2B7DADE8-DED7-4ED0-8F60-F172CB1CF8BA"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880743"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brandy Payne"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brandy Payne"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019592"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Acadia"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Acadia"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880757-3CFAC0C6-6E17-4DDB-96B4-7B959F837F76"
@@ -3586,6 +7318,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880757"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Shannon Phillips"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3614,12 +7351,6 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Shannon Phillips"
-      }
-    }, {
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6533282"
@@ -3633,7 +7364,92 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Lethbridge-West"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880757-3CFAC0C6-6E17-4DDB-96B4-7B959F837F76"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880757"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Shannon Phillips"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Shannon Phillips"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6533282"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lethbridge-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lethbridge-West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880757-DBA08382-2992-49BF-8E1B-4B886AD2FBF2"
@@ -3670,6 +7486,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880757"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Shannon Phillips"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3698,26 +7519,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Shannon Phillips"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4813163"
+        "value" : "http://www.wikidata.org/entity/Q6533282"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Athabasca-Sturgeon-Redwater"
+        "value" : "Lethbridge-Ouest"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Athabasca-Sturgeon-Redwater"
+        "value" : "Lethbridge-West"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880757-DBA08382-2992-49BF-8E1B-4B886AD2FBF2"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880757"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Shannon Phillips"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Shannon Phillips"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6533282"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lethbridge-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lethbridge-West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880779-7EE58E23-08D5-4483-99C6-12E44FE7E4FB"
@@ -3754,6 +7654,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880779"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Colin Piquette"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3782,26 +7687,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Colin Piquette"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7987026"
+        "value" : "http://www.wikidata.org/entity/Q4813163"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Yellowhead-Ouest"
+        "value" : "Athabasca-Sturgeon-Redwater"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "West Yellowhead"
+        "value" : "Athabasca-Sturgeon-Redwater"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880779-7EE58E23-08D5-4483-99C6-12E44FE7E4FB"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880779"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Colin Piquette"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colin Piquette"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4813163"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Athabasca-Sturgeon-Redwater"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Athabasca-Sturgeon-Redwater"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880834-93B363FD-013E-491C-896E-E67EFA10C443"
@@ -3838,6 +7822,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880834"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Eric Rosendahl"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3866,26 +7855,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Eric Rosendahl"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019615"
+        "value" : "http://www.wikidata.org/entity/Q7987026"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-McCall"
+        "value" : "Yellowhead-Ouest"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-McCall"
+        "value" : "West Yellowhead"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880834-93B363FD-013E-491C-896E-E67EFA10C443"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880834"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Eric Rosendahl"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eric Rosendahl"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7987026"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Yellowhead-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "West Yellowhead"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880846-DF881B12-DFED-41A8-82ED-6B851BAF0F9F"
@@ -3922,6 +7990,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880846"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Irfan Sabir"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3950,26 +8023,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Irfan Sabir"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338990"
+        "value" : "http://www.wikidata.org/entity/Q5019615"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Gold Bar"
+        "value" : "Calgary-McCall"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Gold Bar"
+        "value" : "Calgary-McCall"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880846-DF881B12-DFED-41A8-82ED-6B851BAF0F9F"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880846"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Irfan Sabir"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Irfan Sabir"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019615"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-McCall"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-McCall"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880876-F27321A2-58AF-4973-BE63-D15AC16E1AA2"
@@ -4006,6 +8158,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880876"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marlin Schmidt"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4034,21 +8191,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marlin Schmidt"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7303982"
+        "value" : "http://www.wikidata.org/entity/Q5338990"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Gold Bar"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Red Deer-North"
+        "value" : "Edmonton-Gold Bar"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880876-F27321A2-58AF-4973-BE63-D15AC16E1AA2"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880876"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marlin Schmidt"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Marlin Schmidt"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338990"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Gold Bar"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Gold Bar"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880900-C428D9BB-3D39-4000-A1A2-1CC1B4440805"
@@ -4085,6 +8326,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880900"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kim Schreiner"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4113,26 +8359,95 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kim Schreiner"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338986"
-      },
-      "district_name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Edmonton-Centre"
+        "value" : "http://www.wikidata.org/entity/Q7303982"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Centre"
+        "value" : "Red Deer-North"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880900-C428D9BB-3D39-4000-A1A2-1CC1B4440805"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880900"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kim Schreiner"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kim Schreiner"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7303982"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Red Deer-North"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880928-B2806062-CFB8-4DA1-8185-36CF82C7C2B1"
@@ -4169,6 +8484,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880928"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Shepherd (homme politique canadien)"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4197,26 +8517,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Shepherd (homme politique canadien)"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338998"
+        "value" : "http://www.wikidata.org/entity/Q5338986"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Riverview"
+        "value" : "Edmonton-Centre"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Riverview"
+        "value" : "Edmonton-Centre"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880928-B2806062-CFB8-4DA1-8185-36CF82C7C2B1"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880928"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Shepherd (homme politique canadien)"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "David Shepherd"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338986"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Centre"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Centre"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19880978-D99B19AC-0331-4C3C-BFE8-D9C0C297D628"
@@ -4253,6 +8652,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19880978"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lori Sigurdson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4281,26 +8685,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Lori Sigurdson"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019625"
+        "value" : "http://www.wikidata.org/entity/Q5338998"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Shaw"
+        "value" : "Edmonton-Riverview"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Shaw"
+        "value" : "Edmonton-Riverview"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19880978-D99B19AC-0331-4C3C-BFE8-D9C0C297D628"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19880978"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lori Sigurdson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lori Sigurdson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338998"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Riverview"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Riverview"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19881030-3BB04D84-1114-43AC-B61A-AEEECD36D836"
@@ -4337,6 +8820,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19881030"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Graham Sucha"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4365,26 +8853,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Graham Sucha"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338992"
+        "value" : "http://www.wikidata.org/entity/Q5019625"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Manning"
+        "value" : "Calgary-Shaw"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Manning"
+        "value" : "Calgary-Shaw"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19881030-3BB04D84-1114-43AC-B61A-AEEECD36D836"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19881030"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Graham Sucha"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Graham Sucha"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019625"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Shaw"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Shaw"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19881098-1D5FD922-AF4D-4B39-81DF-2FF4F929627A"
@@ -4421,6 +8988,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19881098"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Heather Sweet"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4449,26 +9021,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Heather Sweet"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6806708"
+        "value" : "http://www.wikidata.org/entity/Q5338992"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Medicine Hat"
+        "value" : "Edmonton-Manning"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Medicine Hat"
+        "value" : "Edmonton-Manning"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19881098-1D5FD922-AF4D-4B39-81DF-2FF4F929627A"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19881098"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Heather Sweet"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Heather Sweet"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338992"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Manning"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Manning"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19881159-E1D51DA5-A3FF-47E3-B8B5-DE5102BCE888"
@@ -4505,6 +9156,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19881159"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Wanner"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4533,26 +9189,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bob Wanner"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4854858"
+        "value" : "http://www.wikidata.org/entity/Q6806708"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Banff-Cochrane"
+        "value" : "Medicine Hat"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Banff-Cochrane"
+        "value" : "Medicine Hat"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19881159-E1D51DA5-A3FF-47E3-B8B5-DE5102BCE888"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19881159"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Wanner"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bob Wanner"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6806708"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Medicine Hat"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Medicine Hat"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19890835-73E81B57-F271-45BD-9062-838502C5B8EF"
@@ -4589,6 +9324,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19890835"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cam Westhead"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4617,26 +9357,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Cam Westhead"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338995"
+        "value" : "http://www.wikidata.org/entity/Q4854858"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Mill Creek"
+        "value" : "Banff-Cochrane"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Mill Creek"
+        "value" : "Banff-Cochrane"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19890835-73E81B57-F271-45BD-9062-838502C5B8EF"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19890835"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cam Westhead"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cam Westhead"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4854858"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Banff-Cochrane"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Banff-Cochrane"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19890836-8EEDCC36-6AF9-48D4-8F2F-FB0221174EA8"
@@ -4673,6 +9492,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19890836"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Denise Woollard"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4701,26 +9525,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Denise Woollard"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5595327"
+        "value" : "http://www.wikidata.org/entity/Q5338995"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Grande Prairie-Smoky"
+        "value" : "Edmonton-Mill Creek"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Grande Prairie-Smoky"
+        "value" : "Edmonton-Mill Creek"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19890836-8EEDCC36-6AF9-48D4-8F2F-FB0221174EA8"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19890836"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Denise Woollard"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Denise Woollard"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338995"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Mill Creek"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Mill Creek"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q19890840-69F78335-D32C-4A57-B9BB-919478E69697"
@@ -4757,6 +9660,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19890840"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Todd Loewen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4785,26 +9693,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Todd Loewen"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019607"
+        "value" : "http://www.wikidata.org/entity/Q5595327"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Glenmore"
+        "value" : "Grande Prairie-Smoky"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Glenmore"
+        "value" : "Grande Prairie-Smoky"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q19890840-69F78335-D32C-4A57-B9BB-919478E69697"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19890840"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Todd Loewen"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Todd Loewen"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5595327"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Grande Prairie-Smoky"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Grande Prairie-Smoky"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q20744475-6A8E1255-7759-4D3E-BBC1-5A99F45AE8ED"
@@ -4868,22 +9855,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7334415"
+        "value" : "http://www.wikidata.org/entity/Q5019607"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Rimbey-Rocky Mountain House-Sundre"
+        "value" : "Calgary-Glenmore"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Rimbey-Rocky Mountain House-Sundre"
+        "value" : "Calgary-Glenmore"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q20744475-6A8E1255-7759-4D3E-BBC1-5A99F45AE8ED"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20744475"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Anam Kazim"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019607"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Glenmore"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Glenmore"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q20744580-C87C18B3-F898-43B1-B672-192D188C791F"
@@ -4920,6 +9986,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20744580"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jason Nixon"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4948,26 +10019,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jason Nixon"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4698604"
+        "value" : "http://www.wikidata.org/entity/Q7334415"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Airdrie"
+        "value" : "Rimbey-Rocky Mountain House-Sundre"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Airdrie"
+        "value" : "Rimbey-Rocky Mountain House-Sundre"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q20744580-C87C18B3-F898-43B1-B672-192D188C791F"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20744580"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jason Nixon"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jason Nixon"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7334415"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rimbey-Rocky Mountain House-Sundre"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rimbey-Rocky Mountain House-Sundre"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q20744630-3463D982-0909-4260-8A27-A24AD0EC3243"
@@ -5004,6 +10154,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20744630"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Angela Pitt"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5032,26 +10187,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Angela Pitt"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5471642"
+        "value" : "http://www.wikidata.org/entity/Q4698604"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Fort McMurray-Wood Buffalo"
+        "value" : "Airdrie"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Fort McMurray-Wood Buffalo"
+        "value" : "Airdrie"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q20744630-3463D982-0909-4260-8A27-A24AD0EC3243"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20744630"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Angela Pitt"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Angela Pitt"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4698604"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Airdrie"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Airdrie"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q20859180-64E9F245-ED77-4A1F-B4F3-267E8BB723B6"
@@ -5115,22 +10349,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4863462"
+        "value" : "http://www.wikidata.org/entity/Q5471642"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Barrhead-Morinville-Westlock"
+        "value" : "Fort McMurray-Wood Buffalo"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Barrhead-Morinville-Westlock"
+        "value" : "Fort McMurray-Wood Buffalo"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q20859180-64E9F245-ED77-4A1F-B4F3-267E8BB723B6"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20859180"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tany Yao"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5471642"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fort McMurray-Wood Buffalo"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fort McMurray-Wood Buffalo"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q21062976-0327215A-671A-4621-AB0A-BDBE55C63430"
@@ -5194,22 +10507,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4870100"
+        "value" : "http://www.wikidata.org/entity/Q4863462"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Battle River-Wainwright"
+        "value" : "Barrhead-Morinville-Westlock"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Battle River-Wainwright"
+        "value" : "Barrhead-Morinville-Westlock"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q21062976-0327215A-671A-4621-AB0A-BDBE55C63430"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21062976"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Glenn van Dijken"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4863462"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Barrhead-Morinville-Westlock"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Barrhead-Morinville-Westlock"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q21062977-1273FFB4-F7F2-4FBE-96A3-34E17A47D9FB"
@@ -5273,22 +10665,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5306132"
+        "value" : "http://www.wikidata.org/entity/Q4870100"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Drayton Valley-Devon"
+        "value" : "Battle River-Wainwright"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Drayton Valley-Devon"
+        "value" : "Battle River-Wainwright"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q21062977-1273FFB4-F7F2-4FBE-96A3-34E17A47D9FB"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21062977"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Wes Taylor"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4870100"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Battle River-Wainwright"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Battle River-Wainwright"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q21062979-1c511808-44f2-f26a-0354-8ab07ddd5be3"
@@ -5352,22 +10823,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019603"
+        "value" : "http://www.wikidata.org/entity/Q5306132"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Foothills"
+        "value" : "Drayton Valley-Devon"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Foothills"
+        "value" : "Drayton Valley-Devon"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q21062979-1c511808-44f2-f26a-0354-8ab07ddd5be3"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21062979"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mark Smith"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5306132"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Drayton Valley-Devon"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Drayton Valley-Devon"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q21066549-5F84675C-5334-4817-9BDA-9DC257E599AC"
@@ -5431,22 +10981,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019608"
+        "value" : "http://www.wikidata.org/entity/Q5019603"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Greenway"
+        "value" : "Calgary-Foothills"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Greenway"
+        "value" : "Calgary-Foothills"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q21066549-5F84675C-5334-4817-9BDA-9DC257E599AC"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21066549"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Prasad Panda"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019603"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Foothills"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Foothills"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q23771651-EDC39ADD-586B-4ED3-9C01-9EFDC4EB8BA5"
@@ -5510,22 +11139,279 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338991"
+        "value" : "http://www.wikidata.org/entity/Q5019608"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Highlands-Norwood"
+        "value" : "Calgary-Greenway"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Highlands-Norwood"
+        "value" : "Calgary-Greenway"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q23771651-EDC39ADD-586B-4ED3-9C01-9EFDC4EB8BA5"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q23771651"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Prabhdeep Gill"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019608"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Greenway"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Greenway"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2421201-15b6f5b8-428c-5a28-4c86-41e9ad9ff49f"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2421201"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Jean"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brian Jean"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5471643"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fort McMurray-Conklin"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fort McMurray-Conklin"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-01-01T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2421201-15b6f5b8-428c-5a28-4c86-41e9ad9ff49f"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2421201"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Jean"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brian Jean"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5471643"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fort McMurray-Conklin"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fort McMurray-Conklin"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-01-01T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2924949-23C31EEB-BD6A-4C4E-87F9-7366AC8F054C"
@@ -5562,6 +11448,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2924949"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Mason"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5590,26 +11481,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Brian Mason"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019619"
+        "value" : "http://www.wikidata.org/entity/Q5338991"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Mountain View"
+        "value" : "Edmonton-Highlands-Norwood"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Mountain View"
+        "value" : "Edmonton-Highlands-Norwood"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2924949-23C31EEB-BD6A-4C4E-87F9-7366AC8F054C"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2924949"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Mason"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brian Mason"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338991"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Highlands-Norwood"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Highlands-Norwood"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3018840-43CCBB50-CD15-4A69-9C3F-2AFB1D1035B3"
@@ -5646,6 +11616,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3018840"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Swann"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5674,26 +11649,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Swann"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019612"
+        "value" : "http://www.wikidata.org/entity/Q5019619"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Lougheed"
+        "value" : "Calgary-Mountain View"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Lougheed"
+        "value" : "Calgary-Mountain View"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3018840-43CCBB50-CD15-4A69-9C3F-2AFB1D1035B3"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3018840"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Swann"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "David Swann"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019619"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Mountain View"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Mountain View"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q3162959-578B5006-74CE-4AEA-A5D6-911248F48E81"
@@ -5730,6 +11784,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3162959"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jason Kenney"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5758,26 +11817,283 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jason Kenney"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q7990040"
+        "value" : "http://www.wikidata.org/entity/Q5019612"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Wetaskiwin-Camrose"
+        "value" : "Calgary-Lougheed"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Wetaskiwin-Camrose"
+        "value" : "Calgary-Lougheed"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3162959-578B5006-74CE-4AEA-A5D6-911248F48E81"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3162959"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jason Kenney"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jason Kenney"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019612"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Lougheed"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Lougheed"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q459603-2128aee3-4424-5264-065d-4b367b3c6ab4"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q459603"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alison Redford"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alison Redford"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019601"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Elbow"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Elbow"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-03-03T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q459603-2128aee3-4424-5264-065d-4b367b3c6ab4"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q459603"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alison Redford"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alison Redford"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019601"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Elbow"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Elbow"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-03-03T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50272442-398706CC-9F79-411B-AE1A-84EAAD2C8042"
@@ -5841,8 +12157,7 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7990040"
@@ -5856,7 +12171,87 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Wetaskiwin-Camrose"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q50272442-398706CC-9F79-411B-AE1A-84EAAD2C8042"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50272442"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bruce Hinckley"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7990040"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wetaskiwin-Camrose"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Wetaskiwin-Camrose"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50272442-4896D0BA-A949-4E0C-87C0-B6F278B5465C"
@@ -5920,22 +12315,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6659705"
+        "value" : "http://www.wikidata.org/entity/Q7990040"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Livingstone-Macleod"
+        "value" : "Wetaskiwin-Camrose"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Livingstone-Macleod"
+        "value" : "Wetaskiwin-Camrose"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q50272442-4896D0BA-A949-4E0C-87C0-B6F278B5465C"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50272442"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bruce Hinckley"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7990040"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wetaskiwin-Camrose"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Wetaskiwin-Camrose"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50272899-8D0D8411-8080-4F8B-9761-75F15B337AB7"
@@ -5999,8 +12473,7 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6659705"
@@ -6014,7 +12487,87 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Livingstone-Macleod"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q50272899-8D0D8411-8080-4F8B-9761-75F15B337AB7"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50272899"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pat Steir"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6659705"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Livingstone-Macleod"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Livingstone-Macleod"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50272899-93B05EB8-D9B9-4DCD-978D-7A20B9C75D68"
@@ -6078,22 +12631,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5339003"
+        "value" : "http://www.wikidata.org/entity/Q6659705"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Whitemud"
+        "value" : "Livingstone-Macleod"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Whitemud"
+        "value" : "Livingstone-Macleod"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q50272899-93B05EB8-D9B9-4DCD-978D-7A20B9C75D68"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50272899"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pat Steir"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6659705"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Livingstone-Macleod"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Livingstone-Macleod"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50273050-43AB1E47-7CAD-4D4A-A67B-0569A7758F95"
@@ -6157,8 +12789,7 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5339003"
@@ -6172,7 +12803,87 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Edmonton-Whitemud"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q50273050-43AB1E47-7CAD-4D4A-A67B-0569A7758F95"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50273050"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dr. Bob Turner"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5339003"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q50273050-AC9EF98F-A843-44CC-925E-A8C52E6C9B74"
@@ -6236,22 +12947,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338987"
+        "value" : "http://www.wikidata.org/entity/Q5339003"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Decore"
+        "value" : "Edmonton-Whitemud"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Decore"
+        "value" : "Edmonton-Whitemud"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q50273050-AC9EF98F-A843-44CC-925E-A8C52E6C9B74"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50273050"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dr. Bob Turner"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5339003"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q51463051-C3A812DC-92F5-482A-83BF-FD9478DA24A5"
@@ -6315,22 +13105,279 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338984"
+        "value" : "http://www.wikidata.org/entity/Q5338987"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Calder"
+        "value" : "Edmonton-Decore"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Calder"
+        "value" : "Edmonton-Decore"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q51463051-C3A812DC-92F5-482A-83BF-FD9478DA24A5"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51463051"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Chris Nielson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338987"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Decore"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Decore"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5228907-bd711eee-4ef0-979f-cee2-3be84497eeeb"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5228907"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dave Hancock"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dave Hancock"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5339003"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1997-03-11T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5228907-bd711eee-4ef0-979f-cee2-3be84497eeeb"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5228907"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dave Hancock"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dave Hancock"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5339003"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Whitemud"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1997-03-11T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5233308-F829A2F8-3EEB-47E2-973B-5A42FB8AFD17"
@@ -6367,6 +13414,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5233308"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Eggen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6395,26 +13447,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Eggen"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5338983"
+        "value" : "http://www.wikidata.org/entity/Q5338984"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Beverly-Clareview"
+        "value" : "Edmonton-Calder"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Beverly-Clareview"
+        "value" : "Edmonton-Calder"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5233308-F829A2F8-3EEB-47E2-973B-5A42FB8AFD17"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5233308"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Eggen"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "David Eggen"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338984"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Calder"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Calder"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5262909-C973A6C7-F024-4018-9566-FE082EC0EE10"
@@ -6451,6 +13582,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5262909"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Deron Bilous"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6479,26 +13615,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Deron Bilous"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5200302"
+        "value" : "http://www.wikidata.org/entity/Q5338983"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Cypress-Medicine Hat"
+        "value" : "Edmonton-Beverly-Clareview"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Cypress-Medicine Hat"
+        "value" : "Edmonton-Beverly-Clareview"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5262909-C973A6C7-F024-4018-9566-FE082EC0EE10"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5262909"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Deron Bilous"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Deron Bilous"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5338983"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Beverly-Clareview"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Beverly-Clareview"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5307128-D9E249DA-AB9C-4912-97F8-71D4BACB28C5"
@@ -6535,6 +13750,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5307128"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Drew Barnes"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6563,12 +13783,6 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Drew Barnes"
-      }
-    }, {
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5200302"
@@ -6582,7 +13796,92 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Cypress-Medicine Hat"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5307128-D9E249DA-AB9C-4912-97F8-71D4BACB28C5"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5307128"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Drew Barnes"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Drew Barnes"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5200302"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cypress-Medicine Hat"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cypress-Medicine Hat"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5307128-2B018DAC-53F1-4DF2-9474-D6D391674154"
@@ -6619,6 +13918,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5307128"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Drew Barnes"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6647,10 +13951,19 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5200302"
+      },
+      "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Drew Barnes"
+        "value" : "Cypress-Medicine Hat"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cypress-Medicine Hat"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -6658,20 +13971,95 @@
         "value" : "2012-04-23T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5307128-2B018DAC-53F1-4DF2-9474-D6D391674154"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5307128"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Drew Barnes"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Drew Barnes"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6649233"
+        "value" : "http://www.wikidata.org/entity/Q5200302"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Little Bow"
+        "value" : "Cypress-Medicine Hat"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Little Bow"
+        "value" : "Cypress-Medicine Hat"
       },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-04-23T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q53722688-07DA733F-E03C-4CD8-9967-6DB8E814AD9D"
@@ -6735,22 +14123,101 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "87"
-      }
-    }, {
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5339002"
+        "value" : "http://www.wikidata.org/entity/Q6649233"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Edmonton-Strathcona"
+        "value" : "Little Bow"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Edmonton-Strathcona"
+        "value" : "Little Bow"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q53722688-07DA733F-E03C-4CD8-9967-6DB8E814AD9D"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q53722688"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "David Schneider"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6649233"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Little Bow"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Little Bow"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7279347-E77CFA70-1876-424E-BF20-00F5929CC21A"
@@ -6787,6 +14254,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7279347"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rachel Notley"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6815,16 +14287,6 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rachel Notley"
-      },
-      "facebook" : {
-        "type" : "literal",
-        "value" : "rachelnotley"
-      }
-    }, {
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5339002"
@@ -6839,6 +14301,99 @@
         "type" : "literal",
         "value" : "Edmonton-Strathcona"
       },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "rachelnotley"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7279347-E77CFA70-1876-424E-BF20-00F5929CC21A"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7279347"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rachel Notley"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rachel Notley"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5339002"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Edmonton-Strathcona"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Strathcona"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "rachelnotley"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7279347-4A2916EA-4F3F-4621-B37A-C11FA741989E"
@@ -6875,6 +14430,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7279347"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rachel Notley"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6903,10 +14463,19 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5339002"
+      },
+      "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Rachel Notley"
+        "value" : "Edmonton-Strathcona"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Edmonton-Strathcona"
       },
       "facebook" : {
         "type" : "literal",
@@ -6918,20 +14487,99 @@
         "value" : "2008-03-03T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7279347-4A2916EA-4F3F-4621-B37A-C11FA741989E"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7279347"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rachel Notley"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rachel Notley"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019609"
+        "value" : "http://www.wikidata.org/entity/Q5339002"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Hays"
+        "value" : "Edmonton-Strathcona"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-Hays"
+        "value" : "Edmonton-Strathcona"
       },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "rachelnotley"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-03-03T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7322476-1C392335-4D0A-4DCC-BC06-3EE019A8C02C"
@@ -6968,6 +14616,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7322476"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ric McIver"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6996,26 +14649,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ric McIver"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q17101661"
+        "value" : "http://www.wikidata.org/entity/Q5019609"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Vermilion-Lloydminster"
+        "value" : "Calgary-Hays"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Vermilion-Lloydminster"
+        "value" : "Calgary-Hays"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7322476-1C392335-4D0A-4DCC-BC06-3EE019A8C02C"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7322476"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ric McIver"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ric McIver"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019609"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Hays"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-Hays"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7329227-7FD2C859-7DE3-44D1-8D1F-54F3EB398E2E"
@@ -7052,6 +14784,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7329227"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Starke"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7080,26 +14817,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Richard Starke"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5309164"
+        "value" : "http://www.wikidata.org/entity/Q17101661"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Drumheller-Stettler"
+        "value" : "Vermilion-Lloydminster"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Drumheller-Stettler"
+        "value" : "Vermilion-Lloydminster"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7329227-7FD2C859-7DE3-44D1-8D1F-54F3EB398E2E"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7329227"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Starke"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Richard Starke"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17101661"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Vermilion-Lloydminster"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Vermilion-Lloydminster"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7331780-45201906-4B9A-42E1-B98C-F874925E92CA"
@@ -7136,6 +14952,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7331780"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rick Strankman"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7164,26 +14985,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rick Strankman"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5019621"
+        "value" : "http://www.wikidata.org/entity/Q5309164"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Calgary-Nord-Ouest"
+        "value" : "Drumheller-Stettler"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Calgary-North West"
+        "value" : "Drumheller-Stettler"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7331780-45201906-4B9A-42E1-B98C-F874925E92CA"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7331780"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rick Strankman"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rick Strankman"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5309164"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Drumheller-Stettler"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Drumheller-Stettler"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7416647-4F200CA6-692F-4498-AA46-723DB4F101E0"
@@ -7220,6 +15120,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7416647"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sandra Jansen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7248,26 +15153,105 @@
         "type" : "literal",
         "value" : "87"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sandra Jansen"
-      }
-    }, {
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5595328"
+        "value" : "http://www.wikidata.org/entity/Q5019621"
       },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Grande Prairie-Wapiti"
+        "value" : "Calgary-Nord-Ouest"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Grande Prairie-Wapiti"
+        "value" : "Calgary-North West"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7416647-4F200CA6-692F-4498-AA46-723DB4F101E0"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7416647"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sandra Jansen"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sandra Jansen"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5019621"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary-Nord-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary-North West"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7976189-0CF479BD-D560-4A8A-ABD5-4D6BD0E48E9B"
@@ -7304,6 +15288,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7976189"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wayne Drysdale"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7332,10 +15321,103 @@
         "type" : "literal",
         "value" : "87"
       },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5595328"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Grande Prairie-Wapiti"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Grande Prairie-Wapiti"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7976189-0CF479BD-D560-4A8A-ABD5-4D6BD0E48E9B"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964815"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'assemblée législative d'Alberta"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Alberta Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7976189"
+      },
       "name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Wayne Drysdale"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Wayne Drysdale"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1812866"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Alberta"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Alberta"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "87"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5595328"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Grande Prairie-Wapiti"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Grande Prairie-Wapiti"
       }
     } ]
   }

--- a/legislative/Q1812866/Q19876139/query-used.rq
+++ b/legislative/Q1812866/Q19876139/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q19876139 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q19876139 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q19876139 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q19876139 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q2444341/Q18353522/popolo-m17n.json
+++ b/legislative/Q2444341/Q18353522/popolo-m17n.json
@@ -95,6 +95,24 @@
     },
     {
       "name": {
+        "lang:en": "Neethan Shan"
+      },
+      "id": "Q28823469",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q28823469"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/CouncillorShan"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Jim Karygiannis",
         "lang:fr": "Jim Karygiannis"
       },
@@ -342,6 +360,25 @@
       ],
       "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Joe Mihevc",
+        "lang:fr": "Joe Mihevc"
+      },
+      "id": "Q6211354",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6211354"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/joemihevc"
+        }
       ]
     },
     {
@@ -621,6 +658,20 @@
       "seat_counts": {
         "Q45413990": "45"
       }
+    },
+    {
+      "name": {
+        "lang:en": "New Democratic Party",
+        "lang:fr": "Nouveau Parti démocratique"
+      },
+      "id": "Q130765",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q130765"
+        }
+      ]
     }
   ],
   "areas": [
@@ -1804,6 +1855,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q28823469-596502c1-4f9c-c877-5a69-b9122de7eecc",
+      "person_id": "Q28823469",
+      "on_behalf_of_id": "Q130765",
+      "organization_id": "Q2444341",
+      "area_id": "Q47455625",
+      "start_date": "2017-02-13",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45413990",
+      "role": {
+        "lang:en": "Member of Toronto City Council"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3178858-9A1146B4-D8F6-412A-A74A-80A508B9FE88",
       "person_id": "Q3178858",
       "organization_id": "Q2444341",
@@ -2044,6 +2112,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q6211354-09cdcdb3-4fa0-c4b5-30c8-7a10d63eec6d",
+      "person_id": "Q6211354",
+      "organization_id": "Q2444341",
+      "area_id": "Q47455604",
+      "start_date": "2000-12-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45413990",
+      "role": {
+        "lang:en": "Member of Toronto City Council"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q6233112-FBA4874A-27C5-460C-A8D8-1ACC060BBE3D",
       "person_id": "Q6233112",
       "organization_id": "Q2444341",
@@ -2078,6 +2162,22 @@
       "person_id": "Q6438493",
       "organization_id": "Q2444341",
       "area_id": "Q47455610",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45413990",
+      "role": {
+        "lang:en": "Member of Toronto City Council"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6438493-972c70eb-494f-381b-b283-c38f724b0954",
+      "person_id": "Q6438493",
+      "organization_id": "Q2444341",
+      "area_id": "Q47455610",
+      "start_date": "2010-12-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
         "lang:en": "councillor",
@@ -2168,6 +2268,21 @@
       "person_id": "Q6834861",
       "organization_id": "Q2444341",
       "area_id": "Q47455620",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45413990",
+      "role": {
+        "lang:en": "Member of Toronto City Council"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6836923-8d2ac137-4c8e-84e7-ec5e-7edcefd653df",
+      "person_id": "Q6836923",
+      "organization_id": "Q2444341",
+      "start_date": "2010-12-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
         "lang:en": "councillor",

--- a/legislative/Q2444341/Q18353522/query-results.json
+++ b/legislative/Q2444341/Q18353522/query-results.json
@@ -440,6 +440,98 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455625"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "42 Scarborough-Rouge River"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q28823469-596502c1-4f9c-c877-5a69-b9122de7eecc"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45413990"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Toronto City Council"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28823469"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Neethan Shan"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2444341"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Toronto"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Toronto City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q172"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "45"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-02-13T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q130765"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "New Democratic Party"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "CouncillorShan"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q47455622"
       },
       "district_name_en" : {
@@ -1599,6 +1691,89 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455604"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "21 St. Paul's"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6211354-09cdcdb3-4fa0-c4b5-30c8-7a10d63eec6d"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45413990"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Toronto City Council"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6211354"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Joe Mihevc"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2444341"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Toronto"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Toronto City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q172"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "45"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joe Mihevc"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2000-12-01T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "joemihevc"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q47455606"
       },
       "district_name_en" : {
@@ -1817,6 +1992,89 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Kristyn Wong-Tam"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "KristynWongTamTO"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455610"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "27 Toronto Centre-Rosedale"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6438493-972c70eb-494f-381b-b283-c38f724b0954"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45413990"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Toronto City Council"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6438493"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kristyn Wong-Tam"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2444341"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Toronto"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Toronto City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q172"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "45"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kristyn Wong-Tam"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-12-01T00:00:00Z"
       },
       "facebook" : {
         "type" : "literal",
@@ -2334,6 +2592,76 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Michelle Berardinetti"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6836923-8d2ac137-4c8e-84e7-ec5e-7edcefd653df"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45413990"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of Toronto City Council"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6836923"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Michelle Berardinetti"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2444341"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Toronto"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Toronto City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q172"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "45"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michelle Berardinetti"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-12-01T00:00:00Z"
       }
     }, {
       "district" : {

--- a/legislative/Q2444341/Q18353522/query-used.rq
+++ b/legislative/Q2444341/Q18353522/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q18353522 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q18353522 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q18353522 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q18353522 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q258843/Q25000468/popolo-m17n.json
+++ b/legislative/Q258843/Q25000468/popolo-m17n.json
@@ -1,9 +1,41 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:en": "Gerry Byrne",
+        "lang:fr": "Gerry Byrne"
+      },
+      "id": "Q3104325",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3104325"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:en": "Newfoundland and Labrador House of Assembly",
+        "lang:fr": "chambre d'Assemblée de Terre-Neuve-et-Labrador"
+      },
+      "id": "Q258843",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q258843"
+        }
+      ],
+      "area_id": "Q2003",
+      "seat_counts": {
+        "Q19403853": "40"
+      }
+    }
   ],
   "areas": [
     {
@@ -979,6 +1011,22 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3104325-5FBBF97F-F294-4016-A1CB-0EC881CEE6A2",
+      "person_id": "Q3104325",
+      "organization_id": "Q258843",
+      "area_id": "Q22079861",
+      "start_date": "2015-11-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q19403853",
+      "role": {
+        "lang:en": "Member of the Newfoundland and Labrador House of Assembly",
+        "lang:fr": "membre de la chambre d'Assemblée de Terre-Neuve-et-Labrador"
+      }
+    }
   ]
 }

--- a/legislative/Q258843/Q25000468/query-results.json
+++ b/legislative/Q258843/Q25000468/query-results.json
@@ -3,6 +3,90 @@
     "vars" : [ "statement", "item", "name_en", "name_fr", "party", "party_name_en", "party_name_fr", "district", "district_name_en", "district_name_fr", "role", "role_en", "role_fr", "role_superclass", "role_superclass_en", "role_superclass_fr", "start", "end", "facebook", "org", "org_en", "org_fr", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22079861"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Corner Brook"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3104325-5FBBF97F-F294-4016-A1CB-0EC881CEE6A2"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19403853"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de la chambre d'Assemblée de Terre-Neuve-et-Labrador"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Newfoundland and Labrador House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3104325"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gerry Byrne"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gerry Byrne"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q258843"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'Assemblée de Terre-Neuve-et-Labrador"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Newfoundland and Labrador House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2003"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "40"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-30T00:00:00Z"
+      }
+    } ]
   }
 }

--- a/legislative/Q258843/Q25000468/query-used.rq
+++ b/legislative/Q258843/Q25000468/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q25000468 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q25000468 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q25000468 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q25000468 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q2867078/Q48698545/popolo-m17n.json
+++ b/legislative/Q2867078/Q48698545/popolo-m17n.json
@@ -1,9 +1,202 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:en": "Caroline Cochrane-Johnson"
+      },
+      "id": "Q22277389",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q22277389"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/CarolineRangeLake"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Daniel McNeely"
+      },
+      "id": "Q22279154",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q22279154"
+        }
+      ],
+      "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Herbert Nakimayak"
+      },
+      "id": "Q22279355",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q22279355"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/HerbNakimayakMLA"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Kevin O'Reilly"
+      },
+      "id": "Q22279500",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q22279500"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/kevin.oreilly.982"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Cory Vanthuyne"
+      },
+      "id": "Q23761321",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q23761321"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/cory.vanthuyne"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Rocky Simpson"
+      },
+      "id": "Q23761322",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q23761322"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/RJSimpsonMLA"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Shane Thompson"
+      },
+      "id": "Q23761324",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q23761324"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/Shane-Thompson-Nahendeh-MLA-1680351638951201"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Alfred Moses",
+        "lang:fr": "Alfred Moses"
+      },
+      "id": "Q4723182",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4723182"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/alfred.moses.100"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Glen Abernethy",
+        "lang:fr": "Glen Abernethy"
+      },
+      "id": "Q5567554",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5567554"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/Glen-Abernethy-MLA-Great-Slave-533940360092655"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Michael Nadli",
+        "lang:fr": "Michael Nadli"
+      },
+      "id": "Q6833011",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6833011"
+        }
+      ],
+      "links": [
+
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:en": "Legislative Assembly of the Northwest Territories",
+        "lang:fr": "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "id": "Q2867078",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2867078"
+        }
+      ],
+      "area_id": "Q2007",
+      "seat_counts": {
+        "Q45308871": "19"
+      }
+    }
   ],
   "areas": [
     {
@@ -496,6 +689,165 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q22277389-55009838-43c4-4768-de2c-a2fe0ae32e1f",
+      "person_id": "Q22277389",
+      "organization_id": "Q2867078",
+      "area_id": "Q7292672",
+      "start_date": "2015-11-23",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q22279154-4bac5b5e-4ac8-f5a6-98dc-9d7318b329d3",
+      "person_id": "Q22279154",
+      "organization_id": "Q2867078",
+      "area_id": "Q7399745",
+      "start_date": "2015-11-23",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q22279355-3f431173-4dbc-075d-013e-1ebf4515009e",
+      "person_id": "Q22279355",
+      "organization_id": "Q2867078",
+      "area_id": "Q7069727",
+      "start_date": "2015-11-23",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q22279500-6032e421-4265-e87e-aa9e-a5e40b9f3bee",
+      "person_id": "Q22279500",
+      "organization_id": "Q2867078",
+      "area_id": "Q5477888",
+      "start_date": "2015-11-23",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q23761321-044a2609-4d69-7825-a150-04d27700942e",
+      "person_id": "Q23761321",
+      "organization_id": "Q2867078",
+      "area_id": "Q24190816",
+      "start_date": "2015-11-23",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q23761322-1290038c-4ac0-861d-8587-486aa1d3916e",
+      "person_id": "Q23761322",
+      "organization_id": "Q2867078",
+      "area_id": "Q5685861",
+      "start_date": "2015-11-23",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q23761324-b0b287d1-4414-8e25-fe72-f4c706ad92ff",
+      "person_id": "Q23761324",
+      "organization_id": "Q2867078",
+      "area_id": "Q6959245",
+      "start_date": "2015-11-23",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4723182-fda6bcba-492b-556a-2e84-e862fd7de650",
+      "person_id": "Q4723182",
+      "organization_id": "Q2867078",
+      "area_id": "Q6059367",
+      "start_date": "2007-10-03",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5567554-92665f42-4783-4505-d78a-94b18aac7ea1",
+      "person_id": "Q5567554",
+      "organization_id": "Q2867078",
+      "area_id": "Q5599968",
+      "start_date": "2007-10-01",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6833011-ba826892-47bf-55e4-7f7d-45bc1b9d78df",
+      "person_id": "Q6833011",
+      "organization_id": "Q2867078",
+      "area_id": "Q3021281",
+      "start_date": "2011-10-03",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308871",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of the Northwest Territories"
+      }
+    }
   ]
 }

--- a/legislative/Q2867078/Q48698545/query-results.json
+++ b/legislative/Q2867078/Q48698545/query-results.json
@@ -3,6 +3,803 @@
     "vars" : [ "statement", "item", "name_en", "name_fr", "party", "party_name_en", "party_name_fr", "district", "district_name_en", "district_name_fr", "role", "role_en", "role_fr", "role_superclass", "role_superclass_en", "role_superclass_fr", "start", "end", "facebook", "org", "org_en", "org_fr", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7292672"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Range Lake"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q22277389-55009838-43c4-4768-de2c-a2fe0ae32e1f"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22277389"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Caroline Cochrane-Johnson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-23T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "CarolineRangeLake"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7399745"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sahtu"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q22279154-4bac5b5e-4ac8-f5a6-98dc-9d7318b329d3"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22279154"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Daniel McNeely"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-23T00:00:00Z"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7069727"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nunakput"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q22279355-3f431173-4dbc-075d-013e-1ebf4515009e"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22279355"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Herbert Nakimayak"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-23T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "HerbNakimayakMLA"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5477888"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Frame Lake"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q22279500-6032e421-4265-e87e-aa9e-a5e40b9f3bee"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22279500"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kevin O'Reilly"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-23T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "kevin.oreilly.982"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q24190816"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yellowknife North"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q23761321-044a2609-4d69-7825-a150-04d27700942e"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q23761321"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cory Vanthuyne"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-23T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "cory.vanthuyne"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5685861"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Hay River North"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q23761322-1290038c-4ac0-861d-8587-486aa1d3916e"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q23761322"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rocky Simpson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-23T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "RJSimpsonMLA"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hay River North"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6959245"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nahendeh"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q23761324-b0b287d1-4414-8e25-fe72-f4c706ad92ff"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q23761324"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Shane Thompson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-23T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "Shane-Thompson-Nahendeh-MLA-1680351638951201"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6059367"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Inuvik Boot Lake"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q4723182-fda6bcba-492b-556a-2e84-e862fd7de650"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4723182"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alfred Moses"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2007-10-03T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "alfred.moses.100"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alfred Moses"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5599968"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Great Slave"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5567554-92665f42-4783-4505-d78a-94b18aac7ea1"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5567554"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Glen Abernethy"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2007-10-01T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "Glen-Abernethy-MLA-Great-Slave-533940360092655"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Glen Abernethy"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3021281"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Deh Cho"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6833011-ba826892-47bf-55e4-7f7d-45bc1b9d78df"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308871"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of the Northwest Territories"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6833011"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Michael Nadli"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867078"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative des Territoires du Nord-Ouest"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of the Northwest Territories"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2007"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-03T00:00:00Z"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Deh Cho"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Nadli"
+      }
+    } ]
   }
 }

--- a/legislative/Q2867078/Q48698545/query-used.rq
+++ b/legislative/Q2867078/Q48698545/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q48698545 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q48698545 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q48698545 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q48698545 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q2867082/Q15301541/query-used.rq
+++ b/legislative/Q2867082/Q15301541/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q15301541 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q15301541 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q15301541 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q15301541 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q2867082/Q47484115/popolo-m17n.json
+++ b/legislative/Q2867082/Q47484115/popolo-m17n.json
@@ -2,6 +2,25 @@
   "persons": [
     {
       "name": {
+        "lang:en": "Tony Akoak",
+        "lang:fr": "Tony Akoak"
+      },
+      "id": "Q16145801",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16145801"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/100010121023931"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Paul Quassa",
         "lang:fr": "Paul Quassa"
       },
@@ -14,6 +33,134 @@
       ],
       "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "George Hickes",
+        "lang:fr": "George Hickes"
+      },
+      "id": "Q16244044",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16244044"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Pauloosie Keyootak"
+      },
+      "id": "Q20983369",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q20983369"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Allan Rumbolt",
+        "lang:fr": "Allan Rumbolt"
+      },
+      "id": "Q2837763",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2837763"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Mila Adjukak Kamingoak"
+      },
+      "id": "Q41540312",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q41540312"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Adam Arreak-Lightstone"
+      },
+      "id": "Q42427188",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q42427188"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/Adam-Arreak-Lightstone-MLA-For-Iqaluit-Manirajak-1937484636536815"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Margaret Nakashuk"
+      },
+      "id": "Q42427576",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q42427576"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Joelie Kaernerk"
+      },
+      "id": "Q42427578",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q42427578"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Cathy Towtongie"
+      },
+      "id": "Q42427693",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q42427693"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/cathy.towtongie"
+        }
       ]
     }
   ],
@@ -598,10 +745,170 @@
   ],
   "memberships": [
     {
+      "id": "http://www.wikidata.org/entity/statement/Q16145801-80d3119c-4d1b-b11f-e429-60d375c95094",
+      "person_id": "Q16145801",
+      "organization_id": "Q2867082",
+      "area_id": "Q17067571",
+      "start_date": "2013-10-28",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q16151930-7c845f03-4192-fa9f-9c99-bbda102f06e9",
       "person_id": "Q16151930",
       "organization_id": "Q2867082",
       "area_id": "Q16209592",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16151930-fb18c588-4369-b7f6-7470-ac68c1ac0ee4",
+      "person_id": "Q16151930",
+      "organization_id": "Q2867082",
+      "area_id": "Q16209592",
+      "start_date": "2013-10-28",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16244044-88a1a8f1-4943-84bf-605d-349e2ddd98e1",
+      "person_id": "Q16244044",
+      "organization_id": "Q2867082",
+      "area_id": "Q17070816",
+      "start_date": "2013-10-28",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q20983369-3c777e75-4831-fb84-0c53-b7ef9a9a935d",
+      "person_id": "Q20983369",
+      "organization_id": "Q2867082",
+      "area_id": "Q7899516",
+      "start_date": "2015-02-09",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2837763-8916f788-41ec-90e1-ed47-fcdae59f9052",
+      "person_id": "Q2837763",
+      "organization_id": "Q2867082",
+      "area_id": "Q613190",
+      "start_date": "2008-10-27",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q41540312-3490dc14-46e6-854e-d4b8-ccfb4d1e0b35",
+      "person_id": "Q41540312",
+      "organization_id": "Q2867082",
+      "area_id": "Q6441985",
+      "start_date": "2017-10-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q42427188-f8b80541-4ebc-5d89-febd-f784ba20404f",
+      "person_id": "Q42427188",
+      "organization_id": "Q2867082",
+      "area_id": "Q17070798",
+      "start_date": "2017-10-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q42427576-7fc25678-49d3-f06d-3837-855bcfe4d3d3",
+      "person_id": "Q42427576",
+      "organization_id": "Q2867082",
+      "area_id": "Q14501868",
+      "start_date": "2017-10-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q42427578-b893c6ee-4f88-d3cb-ffe7-c3f3e41b1954",
+      "person_id": "Q42427578",
+      "organization_id": "Q2867082",
+      "area_id": "Q4746949",
+      "start_date": "2017-10-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q45308607",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Nunavut"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q42427693-0bd2d942-469f-f957-cc3f-3fe354f1a649",
+      "person_id": "Q42427693",
+      "organization_id": "Q2867082",
+      "area_id": "Q16211482",
+      "start_date": "2017-10-30",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q2867082/Q47484115/query-results.json
+++ b/legislative/Q2867082/Q47484115/query-results.json
@@ -6,6 +6,89 @@
     "bindings" : [ {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17067571"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gjoa Haven"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16145801-80d3119c-4d1b-b11f-e429-60d375c95094"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16145801"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tony Akoak"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-28T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Tony Akoak"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "100010121023931"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16209592"
       },
       "district_name_en" : {
@@ -44,10 +127,79 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16151930"
       },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paul Quassa"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
       "name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Paul Quassa"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16209592"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Aggu"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16151930-fb18c588-4369-b7f6-7470-ac68c1ac0ee4"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16151930"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -76,6 +228,646 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-28T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Paul Quassa"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17070816"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Iqaluit-Tasiluk"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16244044-88a1a8f1-4943-84bf-605d-349e2ddd98e1"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16244044"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "George Hickes"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-28T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "George Hickes"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7899516"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Uqqummiut"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q20983369-3c777e75-4831-fb84-0c53-b7ef9a9a935d"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20983369"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pauloosie Keyootak"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-02-09T00:00:00Z"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Uqqummiut"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q613190"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Hudson Bay"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2837763-8916f788-41ec-90e1-ed47-fcdae59f9052"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2837763"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Allan Rumbolt"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-10-27T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Allan Rumbolt"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hudson Bay"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6441985"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kugluktuk"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q41540312-3490dc14-46e6-854e-d4b8-ccfb4d1e0b35"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q41540312"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mila Adjukak Kamingoak"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-10-30T00:00:00Z"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17070798"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Iqaluit-Manirajak"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q42427188-f8b80541-4ebc-5d89-febd-f784ba20404f"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42427188"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Adam Arreak-Lightstone"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-10-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "Adam-Arreak-Lightstone-MLA-For-Iqaluit-Manirajak-1937484636536815"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14501868"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pangnirtung"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q42427576-7fc25678-49d3-f06d-3837-855bcfe4d3d3"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42427576"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Margaret Nakashuk"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-10-30T00:00:00Z"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pangnirtung"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4746949"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Amittuq"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q42427578-b893c6ee-4f88-d3cb-ffe7-c3f3e41b1954"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42427578"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Joelie Kaernerk"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-10-30T00:00:00Z"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Amittuq"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16211482"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rankin Inlet North-Chesterfield Inlet"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q42427693-0bd2d942-469f-f957-cc3f-3fe354f1a649"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45308607"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Nunavut"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42427693"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cathy Towtongie"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2867082"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Nunavut"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Nunavut"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2023"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "22"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-10-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "cathy.towtongie"
       }
     } ]
   }

--- a/legislative/Q2867082/Q47484115/query-used.rq
+++ b/legislative/Q2867082/Q47484115/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q47484115 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q47484115 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q47484115 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q47484115 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q2994125/Q55094248/query-used.rq
+++ b/legislative/Q2994125/Q55094248/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55094248 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55094248 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55094248 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55094248 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q2994129/2018-01-01-to-2018-12-31/query-results.json
+++ b/legislative/Q2994129/2018-01-01-to-2018-12-31/query-results.json
@@ -86,15 +86,15 @@
         "type" : "literal",
         "value" : "22"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jean-François Gosselin"
-      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2017-11-05T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jean-François Gosselin"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -184,15 +184,15 @@
         "type" : "literal",
         "value" : "22"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sylvain Légaré"
-      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2009-11-01T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sylvain Légaré"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -477,15 +477,15 @@
         "type" : "literal",
         "value" : "22"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Geneviève Hamelin"
-      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2009-11-01T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Geneviève Hamelin"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -579,15 +579,15 @@
         "type" : "literal",
         "value" : "22"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jean Rousseau"
-      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2017-11-05T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jean Rousseau"
       },
       "facebook" : {
         "type" : "literal",
@@ -769,15 +769,15 @@
         "type" : "literal",
         "value" : "22"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Yvon Bussières"
-      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "1993-01-01T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Yvon Bussières"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -871,15 +871,15 @@
         "type" : "literal",
         "value" : "22"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dominique Tanguay"
-      },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2013-11-03T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dominique Tanguay"
       },
       "party_name_en" : {
         "xml:lang" : "en",

--- a/legislative/Q2994129/2018-01-01-to-2018-12-31/query-used.rq
+++ b/legislative/Q2994129/2018-01-01-to-2018-12-31/query-used.rq
@@ -28,6 +28,10 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +42,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +66,6 @@ OPTIONAL {
 }
 
   }
-  
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q2994131/Q55122348/popolo-m17n.json
+++ b/legislative/Q2994131/Q55122348/popolo-m17n.json
@@ -2,6 +2,136 @@
   "persons": [
     {
       "name": {
+        "lang:en": "Magda Popeanu",
+        "lang:fr": "Magda Popeanu"
+      },
+      "id": "Q16187268",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16187268"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/mpopeanu"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Suzanne Décarie",
+        "lang:fr": "Suzanne Décarie"
+      },
+      "id": "Q16201113",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16201113"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/suzanne.decarie.7"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Christine Black",
+        "lang:fr": "Christine Black"
+      },
+      "id": "Q29889392",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q29889392"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/mairessechristineblack"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Michel Bissonnet",
+        "lang:fr": "Michel Bissonnet"
+      },
+      "id": "Q3309025",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3309025"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Anne-Marie Sigouin",
+        "lang:fr": "Anne-Marie Sigouin"
+      },
+      "id": "Q42740027",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q42740027"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/AMsigouin"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Maja Vodanovic",
+        "lang:fr": "Maja Vodanovic"
+      },
+      "id": "Q45312548",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q45312548"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/maja.vodanovic.9"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Frantz Benjamin",
+        "lang:fr": "Frantz Benjamin"
+      },
+      "id": "Q5492631",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5492631"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/frantz.benjamin.10"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Abdelhaq Sari"
       },
       "id": "Q55122408",
@@ -13,6 +143,59 @@
       ],
       "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Manon Barbe",
+        "lang:fr": "Manon Barbe"
+      },
+      "id": "Q6751263",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6751263"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Mary Deros",
+        "lang:fr": "Mary Deros"
+      },
+      "id": "Q6779315",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6779315"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/mary.deros"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Émilie Thuillier"
+      },
+      "id": "Q8078328",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8078328"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/emilie.thuillier.52"
+        }
       ]
     }
   ],
@@ -34,6 +217,48 @@
       "seat_counts": {
         "Q45414411": "65"
       }
+    },
+    {
+      "name": {
+        "lang:en": "Ensemble Montréal",
+        "lang:fr": "Ensemble Montréal"
+      },
+      "id": "Q15050564",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15050564"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Projet Montréal",
+        "lang:fr": "Projet Montréal"
+      },
+      "id": "Q3407213",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3407213"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Équipe Barbe Team",
+        "lang:fr": "Équipe Barbe Team"
+      },
+      "id": "Q47496204",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q47496204"
+        }
+      ]
     }
   ],
   "areas": [
@@ -1602,10 +1827,224 @@
   ],
   "memberships": [
     {
+      "id": "http://www.wikidata.org/entity/statement/Q16187268-7c3cc516-4b89-ec3e-adaa-c620b5a21046",
+      "person_id": "Q16187268",
+      "on_behalf_of_id": "Q3407213",
+      "organization_id": "Q2994131",
+      "area_id": "Q47455986",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16187268-d75c3ea2-4d24-bcbb-530d-74950068ccba",
+      "person_id": "Q16187268",
+      "on_behalf_of_id": "Q3407213",
+      "organization_id": "Q2994131",
+      "area_id": "Q47455986",
+      "start_date": "2013-01-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16201113-7b354342-467f-3987-d080-d3679c8213aa",
+      "person_id": "Q16201113",
+      "on_behalf_of_id": "Q15050564",
+      "organization_id": "Q2994131",
+      "area_id": "Q47456011",
+      "start_date": "2013-01-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q29889392-0e67af77-456c-7891-e0f3-512130d6b04a",
+      "person_id": "Q29889392",
+      "on_behalf_of_id": "Q15050564",
+      "organization_id": "Q2994131",
+      "area_id": "Q1714436",
+      "start_date": "2016-04-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3309025-0cba9eab-4579-1435-0e02-b93c01e8c391",
+      "person_id": "Q3309025",
+      "on_behalf_of_id": "Q15050564",
+      "organization_id": "Q2994131",
+      "area_id": "Q1325316",
+      "start_date": "2013-11-03",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q42740027-45835176-41b8-d041-f70d-2cbb53387a43",
+      "person_id": "Q42740027",
+      "on_behalf_of_id": "Q3407213",
+      "organization_id": "Q2994131",
+      "area_id": "Q47455999",
+      "start_date": "2013-01-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q42740027-f4db19f2-4312-6af9-94d1-268584e7f30a",
+      "person_id": "Q42740027",
+      "on_behalf_of_id": "Q3407213",
+      "organization_id": "Q2994131",
+      "area_id": "Q47455999",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q45312548-44eb3684-4213-296d-1a50-8ff32afa9eb4",
+      "person_id": "Q45312548",
+      "on_behalf_of_id": "Q3407213",
+      "organization_id": "Q2994131",
+      "area_id": "Q1474128",
+      "start_date": "2017-01-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5492631-073945ad-404c-367d-2222-dd24f6b42552",
+      "person_id": "Q5492631",
+      "on_behalf_of_id": "Q15050564",
+      "organization_id": "Q2994131",
+      "area_id": "Q47456023",
+      "start_date": "2013-01-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q55122408-3336177C-1938-4014-BECB-4F6502CD6977",
       "person_id": "Q55122408",
       "organization_id": "Q2994131",
       "area_id": "Q47456004",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6751263-a0be61ab-4b00-aca6-c441-7b89f3dca1e6",
+      "person_id": "Q6751263",
+      "on_behalf_of_id": "Q47496204",
+      "organization_id": "Q2994131",
+      "area_id": "Q1629121",
+      "start_date": "2013-01-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6779315-8713a04c-4825-0b61-320f-a9b2b1440252",
+      "person_id": "Q6779315",
+      "on_behalf_of_id": "Q15050564",
+      "organization_id": "Q2994131",
+      "area_id": "Q47456030",
+      "start_date": "2013-01-01",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414411",
+      "role": {
+        "lang:en": "Montreal City Councillor",
+        "lang:fr": "conseiller de la ville"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8078328-0c76926d-45a7-713c-820d-851db8dea94a",
+      "person_id": "Q8078328",
+      "on_behalf_of_id": "Q3407213",
+      "organization_id": "Q2994131",
+      "area_id": "Q403031",
+      "start_date": "2009-11-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
         "lang:en": "councillor",

--- a/legislative/Q2994131/Q55122348/query-results.json
+++ b/legislative/Q2994131/Q55122348/query-results.json
@@ -4,6 +4,959 @@
   },
   "results" : {
     "bindings" : [ {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3407213"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16187268-7c3cc516-4b89-ec3e-adaa-c620b5a21046"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455986"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Côte-des-Neiges"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Côte-des-Neiges"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16187268"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Magda Popeanu"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Magda Popeanu"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "mpopeanu"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3407213"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16187268-d75c3ea2-4d24-bcbb-530d-74950068ccba"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455986"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Côte-des-Neiges"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Côte-des-Neiges"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16187268"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Magda Popeanu"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Magda Popeanu"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "mpopeanu"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-01-01T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15050564"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16201113-7b354342-467f-3987-d080-d3679c8213aa"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47456011"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pointe-aux-Trembles"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pointe-aux-Trembles"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16201113"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Suzanne Décarie"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Suzanne Décarie"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "suzanne.decarie.7"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-01-01T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15050564"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q29889392-0e67af77-456c-7891-e0f3-512130d6b04a"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1714436"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Montréal-Nord"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montréal-Nord"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q29889392"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Christine Black"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Christine Black"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "mairessechristineblack"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-04-01T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15050564"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3309025-0cba9eab-4579-1435-0e02-b93c01e8c391"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1325316"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Saint-Léonard"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "St. Leonard"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3309025"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Michel Bissonnet"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michel Bissonnet"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-11-03T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3407213"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q42740027-f4db19f2-4312-6af9-94d1-268584e7f30a"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455999"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Saint-Paul–Émard–Saint-Henri-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saint-Paul–Émard–Saint-Henri-Ouest"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42740027"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Anne-Marie Sigouin"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anne-Marie Sigouin"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "AMsigouin"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3407213"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q42740027-45835176-41b8-d041-f70d-2cbb53387a43"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455999"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Saint-Paul–Émard–Saint-Henri-Ouest"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saint-Paul–Émard–Saint-Henri-Ouest"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42740027"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Anne-Marie Sigouin"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anne-Marie Sigouin"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "AMsigouin"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-01-01T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3407213"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q45312548-44eb3684-4213-296d-1a50-8ff32afa9eb4"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1474128"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lachine"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lachine"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45312548"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Maja Vodanovic"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maja Vodanovic"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "maja.vodanovic.9"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-01-01T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15050564"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5492631-073945ad-404c-367d-2222-dd24f6b42552"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47456023"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Saint-Michel"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saint-Michel"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5492631"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Frantz Benjamin"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Frantz Benjamin"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "frantz.benjamin.10"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-01-01T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q55122408-3336177C-1938-4014-BECB-4F6502CD6977"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q47456004"
@@ -17,10 +970,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Marie-Clarac"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q55122408-3336177C-1938-4014-BECB-4F6502CD6977"
       },
       "role_superclass" : {
         "type" : "uri",
@@ -81,6 +1030,318 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "65"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47496204"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Équipe Barbe Team"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Équipe Barbe Team"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6751263-a0be61ab-4b00-aca6-c441-7b89f3dca1e6"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1629121"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "LaSalle"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "LaSalle"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6751263"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Manon Barbe"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Manon Barbe"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-01-01T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15050564"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ensemble Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6779315-8713a04c-4825-0b61-320f-a9b2b1440252"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47456030"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parc-Extension"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Parc-Extension"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6779315"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mary Deros"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mary Deros"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "mary.deros"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-01-01T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3407213"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Projet Montréal"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q8078328-0c76926d-45a7-713c-820d-851db8dea94a"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q403031"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ahuntsic-Cartierville"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ahuntsic-Cartierville"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414411"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller de la ville"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Councillor"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q8078328"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Émilie Thuillier"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2994131"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Conseil municipal de Montréal"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Montreal City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q340"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "65"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "emilie.thuillier.52"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2009-11-01T00:00:00Z"
       }
     } ]
   }

--- a/legislative/Q2994131/Q55122348/query-used.rq
+++ b/legislative/Q2994131/Q55122348/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55122348 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55122348 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55122348 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55122348 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q320273/Q30682157/popolo-m17n.json
+++ b/legislative/Q320273/Q30682157/popolo-m17n.json
@@ -50,6 +50,44 @@
     },
     {
       "name": {
+        "lang:en": "Iain Rankin",
+        "lang:fr": "Iain Rankin (homme politique)"
+      },
+      "id": "Q15285291",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15285291"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/IainTRankin"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Patricia Arab",
+        "lang:fr": "Patricia Arab"
+      },
+      "id": "Q15285300",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15285300"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/PatriciaArab"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Margaret Miller",
         "lang:fr": "Margaret Miller"
       },
@@ -82,6 +120,25 @@
     },
     {
       "name": {
+        "lang:en": "Suzanne Lohnes-Croft",
+        "lang:fr": "Suzanne Lohnes-Croft"
+      },
+      "id": "Q15294036",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15294036"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/suzannelohnescroftns"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "John Lohr",
         "lang:fr": "John Lohr"
       },
@@ -90,6 +147,57 @@
         {
           "scheme": "wikidata",
           "identifier": "Q15296590"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Lena Diab",
+        "lang:fr": "Lena Diab"
+      },
+      "id": "Q15296602",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15296602"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/LenaDiabNS"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Rafah DiCostanzo",
+        "lang:fr": "Rafah DiCostanzo"
+      },
+      "id": "Q30094708",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q30094708"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Kim Masland",
+        "lang:fr": "Kim Masland"
+      },
+      "id": "Q30094960",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q30094960"
         }
       ],
       "links": [
@@ -114,6 +222,41 @@
     },
     {
       "name": {
+        "lang:en": "Claudia Chender",
+        "lang:fr": "Claudia Chender"
+      },
+      "id": "Q30096861",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q30096861"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/ClaudiaChenderMLA"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Tammy Martin",
+        "lang:fr": "Tammy Martin"
+      },
+      "id": "Q30096963",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q30096963"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Susan Leblanc",
         "lang:fr": "Susan Leblanc"
       },
@@ -126,6 +269,60 @@
       ],
       "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Barbara Adams",
+        "lang:fr": "Barbara Adams"
+      },
+      "id": "Q30123085",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q30123085"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/BarbaraAdamsFORColeHarbourEasternPassage"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Stephen McNeil",
+        "lang:fr": "Stephen McNeil"
+      },
+      "id": "Q3498613",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3498613"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Lenore Zann",
+        "lang:fr": "Lenore Zann"
+      },
+      "id": "Q4355859",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q4355859"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/LenoreEZann"
+        }
       ]
     },
     {
@@ -146,6 +343,25 @@
     },
     {
       "name": {
+        "lang:en": "Eddie Orrell",
+        "lang:fr": "Eddie Orrell"
+      },
+      "id": "Q5336375",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5336375"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/eddie.orrell.9"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Gary Burrill",
         "lang:fr": "Gary Burrill"
       },
@@ -158,6 +374,60 @@
       ],
       "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Karen Casey",
+        "lang:fr": "Karen Casey"
+      },
+      "id": "Q6369554",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6369554"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Keith Bain",
+        "lang:fr": "Keith Bain"
+      },
+      "id": "Q6384010",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6384010"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/keith.bain.334"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Zach Churchill",
+        "lang:fr": "Zach Churchill"
+      },
+      "id": "Q8063788",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q8063788"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/ZachChurchillNS"
+        }
       ]
     }
   ],
@@ -179,6 +449,48 @@
       "seat_counts": {
         "Q18239264": "51"
       }
+    },
+    {
+      "name": {
+        "lang:en": "Progressive Conservative Association of Nova Scotia",
+        "lang:fr": "Association progressiste-conservateur de la Nouvelle-Écosse"
+      },
+      "id": "Q2868020",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2868020"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Nova Scotia New Democratic Party",
+        "lang:fr": "Nouveau Parti démocratique de la Nouvelle-Écosse"
+      },
+      "id": "Q3345047",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3345047"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Nova Scotia Liberal Party",
+        "lang:fr": "Parti libéral de la Nouvelle-Écosse"
+      },
+      "id": "Q3366494",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3366494"
+        }
+      ]
     }
   ],
   "areas": [
@@ -1457,6 +1769,80 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q15285291-228A953C-3C26-4288-886C-C76D241F48DF",
+      "person_id": "Q15285291",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q7804704",
+      "start_date": "2013-10-08",
+      "end_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15285291-6b9b4071-4013-1efc-cf51-6fb26e5b0d44",
+      "person_id": "Q15285291",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q7804704",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15285300-01782138-4cc4-51ac-3cdb-dad511cf99dd",
+      "person_id": "Q15285300",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q16975633",
+      "start_date": "2013-10-08",
+      "end_date": "2017-05-29",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15285300-F782471C-0545-4920-A0A1-8E7492778E2A",
+      "person_id": "Q15285300",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q16975633",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q15294033-7322B260-9754-44DB-A12B-EEA711D78730",
       "person_id": "Q15294033",
       "organization_id": "Q320273",
@@ -1489,10 +1875,99 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q15294036-73B8AB67-1632-4359-ABDE-51A65819DE38",
+      "person_id": "Q15294036",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q6704214",
+      "start_date": "2013-10-08",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q15296590-AD8A922A-6C48-4762-979B-2A112DDDBA10",
       "person_id": "Q15296590",
       "organization_id": "Q320273",
       "area_id": "Q6412965",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15296602-2A5418EA-0D0F-4547-A2C2-3DA67451209C",
+      "person_id": "Q15296602",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q16983123",
+      "start_date": "2013-10-08",
+      "end_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q15296602-c8473956-4fd3-6a11-9672-957607691424",
+      "person_id": "Q15296602",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q16983123",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q30094708-42605f31-4edb-64a0-2312-b1b71fb88c5e",
+      "person_id": "Q30094708",
+      "organization_id": "Q320273",
+      "area_id": "Q16258528",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q30094960-2f96ed68-4a43-3633-a31d-c2249e0c05c3",
+      "person_id": "Q30094960",
+      "organization_id": "Q320273",
+      "area_id": "Q17092609",
+      "start_date": "2017-05-30",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -1521,10 +1996,98 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q30096861-f22aad22-43a1-b663-f747-77e630ce5163",
+      "person_id": "Q30096861",
+      "on_behalf_of_id": "Q3345047",
+      "organization_id": "Q320273",
+      "area_id": "Q5225726",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q30096963-3a5235b5-4e68-c164-29e6-c182c760c098",
+      "person_id": "Q30096963",
+      "organization_id": "Q320273",
+      "area_id": "Q5034603",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q30096966-EBB7AC8A-E096-4EDD-AB40-5F1BE1EAAB5D",
       "person_id": "Q30096966",
       "organization_id": "Q320273",
       "area_id": "Q5225716",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q30123085-aa47a48b-4940-a086-c538-9fd21fee9f29",
+      "person_id": "Q30123085",
+      "on_behalf_of_id": "Q2868020",
+      "organization_id": "Q320273",
+      "area_id": "Q5142651",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3498613-07A158F0-BA22-4DF6-A12D-CC5FCC021DA8",
+      "person_id": "Q3498613",
+      "organization_id": "Q320273",
+      "area_id": "Q4767958",
+      "start_date": "2003-08-05",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4355859-0591FD4F-9655-41DE-8A24-F7E58D4B29CE",
+      "person_id": "Q4355859",
+      "on_behalf_of_id": "Q3345047",
+      "organization_id": "Q320273",
+      "area_id": "Q7848021",
+      "start_date": "2009-06-09",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",
@@ -1553,10 +2116,81 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q5336375-1e3774a2-4357-37c1-80aa-5e7f87daef01",
+      "person_id": "Q5336375",
+      "on_behalf_of_id": "Q2868020",
+      "organization_id": "Q320273",
+      "area_id": "Q17092063",
+      "start_date": "2011-06-21",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q5524793-A3AEEF81-A045-4AAC-9F5E-44B8379E340C",
       "person_id": "Q5524793",
       "organization_id": "Q320273",
       "area_id": "Q5642136",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6369554-9BECC9C7-BAFA-4A94-B80A-65079EB86315",
+      "person_id": "Q6369554",
+      "organization_id": "Q320273",
+      "area_id": "Q5142099",
+      "start_date": "2006-06-13",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6384010-BBBA238D-0017-400A-9A64-10F5D0AD0819",
+      "person_id": "Q6384010",
+      "on_behalf_of_id": "Q2868020",
+      "organization_id": "Q320273",
+      "area_id": "Q7926536",
+      "start_date": "2017-05-30",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18239264",
+      "role": {
+        "lang:en": "member of the Nova Scotia House of Assembly",
+        "lang:fr": "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q8063788-AC7A7A45-EE90-4918-8742-8D20A177DC40",
+      "person_id": "Q8063788",
+      "on_behalf_of_id": "Q3366494",
+      "organization_id": "Q320273",
+      "area_id": "Q8049384",
+      "start_date": "2010-06-22",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q320273/Q30682157/query-results.json
+++ b/legislative/Q320273/Q30682157/query-results.json
@@ -4,15 +4,6 @@
   },
   "results" : {
     "bindings" : [ {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5142654"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Cole Harbour"
-      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15128647-05C9CE4C-289E-4851-A37B-EAA0B3147B94"
@@ -49,11 +40,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15128647"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Tony Ince"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -82,21 +68,26 @@
         "type" : "literal",
         "value" : "51"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Tony Ince"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5142654"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Cole Harbour-Portland-Valley"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6413019"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Kings South"
-      },
+        "value" : "Cole Harbour"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15280716-7042E2B3-66C5-4B97-B1A4-418CBB531E7F"
@@ -133,11 +124,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15280716"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Keith Irving"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -166,21 +152,26 @@
         "type" : "literal",
         "value" : "51"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Keith Irving"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6413019"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Kings-Sud"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5330444"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Eastern Shore"
-      },
+        "value" : "Kings South"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15284980-534FC33C-2876-4214-8B81-492DF4D2FAE2"
@@ -217,11 +208,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15284980"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kevin Murphy (homme politique canadien)"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -250,21 +236,454 @@
         "type" : "literal",
         "value" : "51"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kevin Murphy (homme politique canadien)"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5330444"
+      },
       "district_name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Eastern Shore"
-      }
-    }, {
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5651309"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Hants East"
+        "value" : "Eastern Shore"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q15285291-228A953C-3C26-4288-886C-C76D241F48DF"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15285291"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Iain Rankin"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Iain Rankin (homme politique)"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7804704"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Timberlea-Prospect"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Timberlea-Prospect"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-08T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "IainTRankin"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q15285291-6b9b4071-4013-1efc-cf51-6fb26e5b0d44"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15285291"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Iain Rankin"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Iain Rankin (homme politique)"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7804704"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Timberlea-Prospect"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Timberlea-Prospect"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "IainTRankin"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q15285300-01782138-4cc4-51ac-3cdb-dad511cf99dd"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15285300"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Patricia Arab"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Patricia Arab"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16975633"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fairview-Clayton Park"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-08T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "PatriciaArab"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-29T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q15285300-F782471C-0545-4920-A0A1-8E7492778E2A"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15285300"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Patricia Arab"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Patricia Arab"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16975633"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fairview-Clayton Park"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "PatriciaArab"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15294033-7322B260-9754-44DB-A12B-EEA711D78730"
@@ -301,11 +720,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15294033"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Margaret Miller"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -333,17 +747,22 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "51"
-      }
-    }, {
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Margaret Miller"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5642124"
+        "value" : "http://www.wikidata.org/entity/Q5651309"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Halifax Atlantic"
-      },
+        "value" : "Hants East"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15294034-4876E250-2487-4BC1-8C69-218B52541D98"
@@ -380,11 +799,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15294034"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Brendan Maguire"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -412,17 +826,124 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "51"
-      }
-    }, {
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brendan Maguire"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6412965"
+        "value" : "http://www.wikidata.org/entity/Q5642124"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Kings North"
+        "value" : "Halifax Atlantic"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q15294036-73B8AB67-1632-4359-ABDE-51A65819DE38"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15294036"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Suzanne Lohnes-Croft"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Suzanne Lohnes-Croft"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6704214"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lunenburg"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-08T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "suzannelohnescroftns"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q15296590-AD8A922A-6C48-4762-979B-2A112DDDBA10"
@@ -459,11 +980,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15296590"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John Lohr"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -491,17 +1007,399 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "51"
-      }
-    }, {
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Lohr"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5193931"
+        "value" : "http://www.wikidata.org/entity/Q6412965"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Cumberland North"
+        "value" : "Kings North"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q15296602-2A5418EA-0D0F-4547-A2C2-3DA67451209C"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15296602"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lena Diab"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lena Diab"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16983123"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Halifax Armdale"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-08T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "LenaDiabNS"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q15296602-c8473956-4fd3-6a11-9672-957607691424"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15296602"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lena Diab"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lena Diab"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16983123"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Halifax Armdale"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "LenaDiabNS"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q30094708-42605f31-4edb-64a0-2312-b1b71fb88c5e"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30094708"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rafah DiCostanzo"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rafah DiCostanzo"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16258528"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Clayton Park West"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q30094960-2f96ed68-4a43-3633-a31d-c2249e0c05c3"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30094960"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kim Masland"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kim Masland"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17092609"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Queens-Shelburne"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q30095405-577924BF-8EC4-4C48-A91C-7FCC346A4E5D"
@@ -538,11 +1436,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q30095405"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Elizabeth Smith-McCrossin"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -570,17 +1463,208 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "51"
-      }
-    }, {
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Elizabeth Smith-McCrossin"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5225716"
+        "value" : "http://www.wikidata.org/entity/Q5193931"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Dartmouth North"
+        "value" : "Cumberland North"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q30096861-f22aad22-43a1-b663-f747-77e630ce5163"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30096861"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Claudia Chender"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Claudia Chender"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5225726"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dartmouth South"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3345047"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia New Democratic Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "ClaudiaChenderMLA"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q30096963-3a5235b5-4e68-c164-29e6-c182c760c098"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30096963"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tammy Martin"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Tammy Martin"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5034603"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cape Breton Centre"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q30096966-EBB7AC8A-E096-4EDD-AB40-5F1BE1EAAB5D"
@@ -617,11 +1701,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q30096966"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Susan Leblanc"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -649,17 +1728,315 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "51"
-      }
-    }, {
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Susan Leblanc"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5651314"
+        "value" : "http://www.wikidata.org/entity/Q5225716"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Hants West"
+        "value" : "Dartmouth North"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q30123085-aa47a48b-4940-a086-c538-9fd21fee9f29"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30123085"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Barbara Adams"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Barbara Adams"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5142651"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cole-Harbour-Eastern-Passage"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cole Harbour-Eastern Passage"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2868020"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Association progressiste-conservateur de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Association of Nova Scotia"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "BarbaraAdamsFORColeHarbourEasternPassage"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3498613-07A158F0-BA22-4DF6-A12D-CC5FCC021DA8"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3498613"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stephen McNeil"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stephen McNeil"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4767958"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Annapolis"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-08-05T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q4355859-0591FD4F-9655-41DE-8A24-F7E58D4B29CE"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4355859"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lenore Zann"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lenore Zann"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7848021"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Truro-Bible Hill"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3345047"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia New Democratic Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2009-06-09T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "LenoreEZann"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5115664-8BBCC2CC-E9E4-42E5-BCD6-07899D27CEE6"
@@ -696,11 +2073,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5115664"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Chuck Porter"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -728,17 +2100,124 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "51"
-      }
-    }, {
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chuck Porter"
+      },
       "district" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5642136"
+        "value" : "http://www.wikidata.org/entity/Q5651314"
       },
       "district_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Halifax Chebucto"
+        "value" : "Hants West"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5336375-1e3774a2-4357-37c1-80aa-5e7f87daef01"
       },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5336375"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eddie Orrell"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Eddie Orrell"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17092063"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Northside-Westmount"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2868020"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Association progressiste-conservateur de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Association of Nova Scotia"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-06-21T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "eddie.orrell.9"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5524793-A3AEEF81-A045-4AAC-9F5E-44B8379E340C"
@@ -775,11 +2254,6 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5524793"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Gary Burrill"
-      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -807,6 +2281,313 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gary Burrill"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5642136"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Halifax Chebucto"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6369554-9BECC9C7-BAFA-4A94-B80A-65079EB86315"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6369554"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Karen Casey"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karen Casey"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5142099"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colchester North"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2006-06-13T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6384010-BBBA238D-0017-400A-9A64-10F5D0AD0819"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6384010"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Keith Bain"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Keith Bain"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7926536"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Victoria"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Victoria-The Lakes"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2868020"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Association progressiste-conservateur de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Progressive Conservative Association of Nova Scotia"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "keith.bain.334"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q8063788-AC7A7A45-EE90-4918-8742-8D20A177DC40"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18239264"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative de la Nouvelle-Écosse"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Nova Scotia House of Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q8063788"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Zach Churchill"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320273"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre d'assemblée de la Nouvelle-Écosse"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia House of Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1952"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "51"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Zach Churchill"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q8049384"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yarmouth"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366494"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral de la Nouvelle-Écosse"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nova Scotia Liberal Party"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-06-22T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "ZachChurchillNS"
       }
     } ]
   }

--- a/legislative/Q320273/Q30682157/query-used.rq
+++ b/legislative/Q320273/Q30682157/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q30682157 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q30682157 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q30682157 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q30682157 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q383590/Q21157957/popolo-m17n.json
+++ b/legislative/Q383590/Q21157957/popolo-m17n.json
@@ -3769,6 +3769,22 @@
     },
     {
       "name": {
+        "lang:en": "Gord Brown",
+        "lang:fr": "Gord Brown"
+      },
+      "id": "Q3110844",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3110844"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Guy Caron",
         "lang:fr": "Guy Caron"
       },
@@ -4476,6 +4492,22 @@
     },
     {
       "name": {
+        "lang:en": "Rob Anders",
+        "lang:fr": "Rob Anders"
+      },
+      "id": "Q3434145",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3434145"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Robert Aubin",
         "lang:fr": "Robert Aubin"
       },
@@ -5168,6 +5200,22 @@
         {
           "scheme": "wikidata",
           "identifier": "Q6194065"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Joe Oliver",
+        "lang:fr": "Joe Oliver"
+      },
+      "id": "Q6211627",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6211627"
         }
       ],
       "links": [
@@ -14708,6 +14756,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q16211070-b3f27950-40bc-a446-3ce3-10994cbe8b4f",
+      "person_id": "Q16211070",
+      "organization_id": "Q383590",
+      "area_id": "Q3572599",
+      "start_date": "2015-10-19",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q16211870-C7BA5B05-B71C-4860-9A91-747B83F5952D",
       "person_id": "Q16211870",
       "on_behalf_of_id": "Q488523",
@@ -14798,6 +14863,7 @@
       "on_behalf_of_id": "Q138345",
       "organization_id": "Q383590",
       "area_id": "Q3475169",
+      "start_date": "2015-12-03",
       "end_date": "2017-09-14",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
@@ -14896,6 +14962,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q1892814-988c3211-4050-1687-faf1-622df6b97fb4",
+      "person_id": "Q1892814",
+      "organization_id": "Q383590",
+      "area_id": "Q3358662",
+      "start_date": "2007-09-17",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q19060376-329B50B3-D0D3-459C-980A-6662E47044B4",
       "person_id": "Q19060376",
       "on_behalf_of_id": "Q138345",
@@ -14948,6 +15031,24 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q206-A024192D-6C5E-4D18-BDBC-9F3FDA99523C",
+      "person_id": "Q206",
+      "organization_id": "Q383590",
+      "area_id": "Q16850469",
+      "start_date": "2015-10-19",
+      "end_date": "2016-08-26",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q206-caa6392c-4522-09c6-e3db-c815fc5bae4c",
       "person_id": "Q206",
       "on_behalf_of_id": "Q488523",
@@ -14971,6 +15072,23 @@
       "on_behalf_of_id": "Q138345",
       "organization_id": "Q383590",
       "area_id": "Q2892787",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2070905-7c9c0f55-48da-87f3-2541-46c2af5a3ec2",
+      "person_id": "Q2070905",
+      "organization_id": "Q383590",
+      "area_id": "Q3423526",
+      "start_date": "1997-06-02",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
         "lang:en": "deputy",
@@ -15124,6 +15242,23 @@
       "on_behalf_of_id": "Q138345",
       "organization_id": "Q383590",
       "area_id": "Q3462967",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q21159815-c87c18ba-4dfc-ed76-ec93-1849880fde12",
+      "person_id": "Q21159815",
+      "organization_id": "Q383590",
+      "area_id": "Q3462967",
+      "start_date": "2015-10-19",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
         "lang:en": "deputy",
@@ -17848,6 +17983,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q2846724-4F35264E-0027-42C4-8FA1-551A49C04266",
+      "person_id": "Q2846724",
+      "organization_id": "Q383590",
+      "area_id": "Q3423524",
+      "start_date": "2004-06-28",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q2846724-DBBAA295-5F42-4F93-842A-344B29A1BDEC",
       "person_id": "Q2846724",
       "on_behalf_of_id": "Q488523",
@@ -18449,6 +18601,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3022854-b494913c-49f7-76ae-83dd-d46614e2c742",
+      "person_id": "Q3022854",
+      "organization_id": "Q383590",
+      "start_date": "2015-10-19",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3026209-AC4849F3-5211-4A63-A899-F9C989BA61EB",
       "person_id": "Q3026209",
       "on_behalf_of_id": "Q488523",
@@ -18585,6 +18753,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3099714-e11f7149-4e14-fc40-217b-4a4070b646a1",
+      "person_id": "Q3099714",
+      "organization_id": "Q383590",
+      "area_id": "Q3362910",
+      "start_date": "2008-10-14",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3101057-FEEFCA18-C416-492C-8295-9BE949C85ED9",
       "person_id": "Q3101057",
       "on_behalf_of_id": "Q138345",
@@ -18608,6 +18793,25 @@
       "organization_id": "Q383590",
       "area_id": "Q2891841",
       "end_date": "2017-10-02",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3110844-F101EEE4-F355-4115-998E-697BDDDC2608",
+      "person_id": "Q3110844",
+      "on_behalf_of_id": "Q488523",
+      "organization_id": "Q383590",
+      "area_id": "Q581570",
+      "start_date": "2004-06-28",
+      "end_date": "2018-05-02",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
         "lang:en": "deputy",
@@ -19373,6 +19577,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3434145-D7CFB13B-78D3-4C84-B7BC-E471479542BA",
+      "person_id": "Q3434145",
+      "organization_id": "Q383590",
+      "start_date": "1997-01-01",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3434460-58E62DD9-5E99-4B88-A922-841668968111",
       "person_id": "Q3434460",
       "on_behalf_of_id": "Q130765",
@@ -19395,6 +19615,23 @@
       "on_behalf_of_id": "Q138345",
       "organization_id": "Q383590",
       "area_id": "Q2937241",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3441197-535856AD-98F4-470C-A97D-9348FC3AE68B",
+      "person_id": "Q3441197",
+      "organization_id": "Q383590",
+      "area_id": "Q2821651",
+      "start_date": "2011-01-01",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
         "lang:en": "deputy",
@@ -19431,6 +19668,23 @@
       "area_id": "Q16977239",
       "start_date": "2015-12-03",
       "end_date": "2017-07-04",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3453615-02B74EBB-4169-40E3-897A-679BE9C72E90",
+      "person_id": "Q3453615",
+      "organization_id": "Q383590",
+      "area_id": "Q2899323",
+      "start_date": "2011-05-02",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
         "lang:en": "deputy",
@@ -19725,6 +19979,23 @@
       "on_behalf_of_id": "Q138345",
       "organization_id": "Q383590",
       "area_id": "Q16977089",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q4492815-F27992BC-FEDF-49C4-B858-85BA5BC1D75F",
+      "person_id": "Q4492815",
+      "organization_id": "Q383590",
+      "area_id": "Q16977089",
+      "start_date": "2015-10-19",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
         "lang:en": "deputy",
@@ -20140,6 +20411,23 @@
       "on_behalf_of_id": "Q138345",
       "organization_id": "Q383590",
       "area_id": "Q3569366",
+      "role_superclass_code": "Q1055894",
+      "role_superclass": {
+        "lang:en": "deputy",
+        "lang:fr": "député"
+      },
+      "role_code": "Q15964890",
+      "role": {
+        "lang:en": "member of the House of Commons of Canada",
+        "lang:fr": "député de la Chambre des communes du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6211627-a94ab211-45ea-89ca-55ed-7038252db057",
+      "person_id": "Q6211627",
+      "organization_id": "Q383590",
+      "area_id": "Q3049206",
+      "start_date": "2011-05-30",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
         "lang:en": "deputy",

--- a/legislative/Q383590/Q21157957/query-results.json
+++ b/legislative/Q383590/Q21157957/query-results.json
@@ -68,6 +68,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q206"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stephen Harper"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -96,15 +101,104 @@
         "type" : "literal",
         "value" : "338"
       },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-08-26T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q206-A024192D-6C5E-4D18-BDBC-9F3FDA99523C"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16850469"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Calgary Heritage"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary Heritage"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q206"
+      },
       "name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Stephen Harper"
       },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Stephen Harper"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2016-08-26T00:00:00Z"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-10-19T00:00:00Z"
       }
     }, {
       "party" : {
@@ -171,6 +265,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1396130"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Luc Thériault"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -198,11 +297,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Luc Thériault"
       }
     }, {
       "party" : {
@@ -269,6 +363,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15054353"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mélanie Joly"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -296,11 +395,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mélanie Joly"
       }
     }, {
       "party" : {
@@ -367,6 +461,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q15300563"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ted Falk"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -394,11 +493,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ted Falk"
       }
     }, {
       "party" : {
@@ -465,6 +559,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1566929"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rob Nicholson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -492,11 +591,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rob Nicholson"
       }
     }, {
       "party" : {
@@ -563,6 +657,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16187047"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kerry Diotte"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -590,11 +689,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kerry Diotte"
       }
     }, {
       "party" : {
@@ -661,6 +755,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16192760"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Carol Hughes"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -688,11 +787,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Carol Hughes"
       }
     }, {
       "party" : {
@@ -759,6 +853,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16194082"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pamela Goldsmith-Jones"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -786,11 +885,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pamela Goldsmith-Jones"
       }
     }, {
       "party" : {
@@ -857,6 +951,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16194184"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Martel"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -884,11 +983,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Richard Martel"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -960,6 +1054,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16195363"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hunter Tootoo"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -987,11 +1086,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Hunter Tootoo"
       }
     }, {
       "party" : {
@@ -1058,6 +1152,95 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16211070"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ahmed Hussen"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ahmed Hussen"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16211070-b3f27950-40bc-a446-3ce3-10994cbe8b4f"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3572599"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "York South—Weston"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "York South—Weston"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16211070"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ahmed Hussen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1086,10 +1269,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "Ahmed Hussen"
+        "value" : "2015-10-19T00:00:00Z"
       }
     }, {
       "party" : {
@@ -1156,6 +1339,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16211870"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kellie Leitch"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1183,11 +1371,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kellie Leitch"
       }
     }, {
       "party" : {
@@ -1254,6 +1437,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q16215273"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mark Gerretsen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1281,11 +1469,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mark Gerretsen"
       }
     }, {
       "party" : {
@@ -1352,6 +1535,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1685302"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jean-Yves Duclos"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1379,11 +1567,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jean-Yves Duclos"
       }
     }, {
       "party" : {
@@ -1450,6 +1633,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q17174697"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mario Beaulieu"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1477,11 +1665,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mario Beaulieu"
       }
     }, {
       "party" : {
@@ -1548,6 +1731,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q17305669"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Barlow"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1575,11 +1763,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John Barlow"
       }
     }, {
       "party" : {
@@ -1646,6 +1829,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q17305769"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Arnold Chan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1674,15 +1862,15 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Arnold Chan"
-      },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2017-09-14T00:00:00Z"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-12-03T00:00:00Z"
       }
     }, {
       "party" : {
@@ -1749,6 +1937,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q17386312"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "James Maloney"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1776,11 +1969,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "James Maloney"
       }
     }, {
       "party" : {
@@ -1847,6 +2035,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q17513253"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Yurdiga"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1874,11 +2067,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Yurdiga"
       }
     }, {
       "party" : {
@@ -1945,6 +2133,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1840895"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Erin O'Toole"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -1972,11 +2165,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Erin O'Toole"
       }
     }, {
       "party" : {
@@ -2043,6 +2231,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18685856"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jim Eglinski"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2070,11 +2263,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jim Eglinski"
       }
     }, {
       "party" : {
@@ -2141,6 +2329,95 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1892814"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Thomas Mulcair"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Thomas Mulcair"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1892814-988c3211-4050-1687-faf1-622df6b97fb4"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3358662"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Outremont"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Outremont"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1892814"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Thomas Mulcair"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2169,10 +2446,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "Thomas Mulcair"
+        "value" : "2007-09-17T00:00:00Z"
       }
     }, {
       "party" : {
@@ -2239,6 +2516,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19060376"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David de Burgh Graham"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2266,11 +2548,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David de Burgh Graham"
       }
     }, {
       "party" : {
@@ -2337,6 +2614,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19428856"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jane Philpott"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2364,11 +2646,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jane Philpott"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -2440,6 +2717,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q19428900"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jody Wilson-Raybould"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2467,11 +2749,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jody Wilson-Raybould"
       }
     }, {
       "party" : {
@@ -2538,6 +2815,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20676568"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nathaniel Erskine-Smith"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2565,11 +2847,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Nathaniel Erskine-Smith"
       }
     }, {
       "party" : {
@@ -2636,6 +2913,95 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2070905"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ralph Goodale"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ralph Goodale"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2070905-7c9c0f55-48da-87f3-2541-46c2af5a3ec2"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3423526"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Regina—Wascana"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Regina—Wascana"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2070905"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ralph Goodale"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2664,10 +3030,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "Ralph Goodale"
+        "value" : "1997-06-02T00:00:00Z"
       }
     }, {
       "party" : {
@@ -2734,6 +3100,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21064615"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Lametti"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2761,11 +3132,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Lametti"
       }
     }, {
       "party" : {
@@ -2832,6 +3198,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21066146"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ken McDonald"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2859,11 +3230,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ken McDonald"
       }
     }, {
       "party" : {
@@ -2930,6 +3296,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21155044"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Francis Drouin"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -2957,11 +3328,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Francis Drouin"
       }
     }, {
       "party" : {
@@ -3121,6 +3487,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21156200"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ali Ehsassi"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3148,11 +3519,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ali Ehsassi"
       }
     }, {
       "party" : {
@@ -3219,6 +3585,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21158711"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pierre Paul-Hus"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3246,11 +3617,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pierre Paul-Hus"
       }
     }, {
       "party" : {
@@ -3317,6 +3683,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21158712"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alupa Clarke"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3344,11 +3715,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Alupa Clarke"
       }
     }, {
       "party" : {
@@ -3415,6 +3781,95 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21159815"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "François-Philippe Champagne"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "François-Philippe Champagne"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q21159815-c87c18ba-4dfc-ed76-ec93-1849880fde12"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3462967"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Saint-Maurice—Champlain"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saint-Maurice—Champlain"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21159815"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "François-Philippe Champagne"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3443,10 +3898,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "François-Philippe Champagne"
+        "value" : "2015-10-19T00:00:00Z"
       }
     }, {
       "party" : {
@@ -3513,6 +3968,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21159821"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joël Lightbound"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3540,11 +4000,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Joël Lightbound"
       }
     }, {
       "party" : {
@@ -3611,6 +4066,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21159929"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rhéal Fortin"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3638,11 +4098,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rhéal Fortin"
       }
     }, {
       "party" : {
@@ -3802,6 +4257,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21162694"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maryam Monsef"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3829,11 +4289,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Maryam Monsef"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -3905,6 +4360,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21167969"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marilène Gill"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -3932,11 +4392,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marilène Gill"
       }
     }, {
       "party" : {
@@ -4003,6 +4458,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21174009"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Andy Fillmore"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4030,11 +4490,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Andy Fillmore"
       }
     }, {
       "party" : {
@@ -4101,6 +4556,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21175197"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bill Morneau"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4128,11 +4588,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bill Morneau"
       }
     }, {
       "party" : {
@@ -4199,6 +4654,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21175255"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sven Spengemann"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4226,11 +4686,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sven Spengemann"
       }
     }, {
       "party" : {
@@ -4297,6 +4752,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21177259"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gabriel Ste-Marie"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4324,11 +4784,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Gabriel Ste-Marie"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -4400,6 +4855,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21178739"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michel Picard"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4427,11 +4887,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michel Picard"
       }
     }, {
       "party" : {
@@ -4498,6 +4953,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21210275"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Geng Tan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4525,11 +4985,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Geng Tan"
       }
     }, {
       "party" : {
@@ -4596,6 +5051,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21228464"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Cannings"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4623,11 +5083,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Richard Cannings"
       }
     }, {
       "party" : {
@@ -4694,6 +5149,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21266477"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Steve MacKinnon"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4721,11 +5181,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Steve MacKinnon"
       }
     }, {
       "party" : {
@@ -4792,6 +5247,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21281905"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Greg Fergus"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4819,11 +5279,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Greg Fergus"
       }
     }, {
       "party" : {
@@ -4890,6 +5345,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21284594"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Xavier Barsalou-Duval"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -4917,11 +5377,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Xavier Barsalou-Duval"
       }
     }, {
       "party" : {
@@ -4988,6 +5443,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21286025"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Monique Pauzé"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5015,11 +5475,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Monique Pauzé"
       }
     }, {
       "party" : {
@@ -5086,6 +5541,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21296174"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alain Rayes"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5113,11 +5573,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Alain Rayes"
       }
     }, {
       "party" : {
@@ -5184,6 +5639,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21335996"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Catherine McKenna"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5211,11 +5671,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Catherine McKenna"
       }
     }, {
       "party" : {
@@ -5282,6 +5737,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21336060"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Celina Caesar-Chavannes"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5309,11 +5769,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Celina Caesar-Chavannes"
       }
     }, {
       "party" : {
@@ -5380,6 +5835,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21336098"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Diane Lebouthillier"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5407,11 +5867,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Diane Lebouthillier"
       }
     }, {
       "party" : {
@@ -5571,6 +6026,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21336246"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Harjit Sajjan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5598,11 +6058,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Harjit Sajjan"
       }
     }, {
       "party" : {
@@ -5669,6 +6124,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21356553"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marie-Claude Bibeau"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5696,11 +6156,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marie-Claude Bibeau"
       }
     }, {
       "party" : {
@@ -5767,6 +6222,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21384927"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Carla Qualtrough"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5794,11 +6254,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Carla Qualtrough"
       }
     }, {
       "party" : {
@@ -5865,6 +6320,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21400450"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Simon Marcil"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5892,11 +6352,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Simon Marcil"
       }
     }, {
       "party" : {
@@ -5963,6 +6418,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21402871"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bardish Chagger"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -5990,11 +6450,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bardish Chagger"
       }
     }, {
       "party" : {
@@ -6061,6 +6516,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21428260"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michel Boudrias"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6088,11 +6548,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michel Boudrias"
       }
     }, {
       "party" : {
@@ -6159,6 +6614,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21470126"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Saroya"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6186,11 +6646,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bob Saroya"
       }
     }, {
       "party" : {
@@ -6257,6 +6712,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21471154"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marwan Tabbara"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6284,11 +6744,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marwan Tabbara"
       }
     }, {
       "party" : {
@@ -6541,6 +6996,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21572842"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Randy Boissonnault"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6568,11 +7028,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Randy Boissonnault"
       }
     }, {
       "party" : {
@@ -6639,6 +7094,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21572911"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Serge Cormier"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6666,11 +7126,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Serge Cormier"
       }
     }, {
       "party" : {
@@ -6737,6 +7192,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21572925"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Julie Dabrusin"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6764,11 +7224,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Julie Dabrusin"
       }
     }, {
       "party" : {
@@ -6835,6 +7290,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21572945"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anju Dhillon"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6862,11 +7322,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Anju Dhillon"
       }
     }, {
       "party" : {
@@ -6933,6 +7388,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21573510"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Patricia A. Hajdu"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -6960,11 +7420,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Patricia A. Hajdu"
       }
     }, {
       "party" : {
@@ -7124,6 +7579,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21642395"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Cooper"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7151,11 +7611,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michael Cooper"
       }
     }, {
       "party" : {
@@ -7222,6 +7677,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21642488"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Peter Fragiskatos"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7249,11 +7709,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Peter Fragiskatos"
       }
     }, {
       "party" : {
@@ -7413,6 +7868,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21642507"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Garnett Genuis"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7440,11 +7900,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Garnett Genuis"
       }
     }, {
       "party" : {
@@ -7604,6 +8059,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21642848"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Nater"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7631,11 +8091,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John Nater"
       }
     }, {
       "party" : {
@@ -7702,6 +8157,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21662882"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Colin Fraser"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7729,11 +8189,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Colin Fraser"
       }
     }, {
       "party" : {
@@ -7800,6 +8255,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21713409"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "René Arseneault"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7827,11 +8287,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "René Arseneault"
       }
     }, {
       "party" : {
@@ -7898,6 +8353,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21713417"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Matt DeCourcey"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -7925,11 +8385,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Matt DeCourcey"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -8005,6 +8460,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21713419"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alaina Lockhart"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -8032,11 +8492,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Alaina Lockhart"
       }
     }, {
       "party" : {
@@ -8103,6 +8558,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21714076"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pat Finnigan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -8130,11 +8590,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pat Finnigan"
       }
     }, {
       "party" : {
@@ -8201,6 +8656,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21714336"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ginette Petitpas Taylor"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -8228,11 +8688,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ginette Petitpas Taylor"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -8308,6 +8763,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21714343"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wayne Long"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -8335,11 +8795,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Wayne Long"
       }
     }, {
       "party" : {
@@ -8499,6 +8954,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21716260"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karina Gould"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -8526,11 +8986,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Karina Gould"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -8602,6 +9057,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21716310"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jonathan Wilkinson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -8629,11 +9089,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jonathan Wilkinson"
       }
     }, {
       "party" : {
@@ -8793,6 +9248,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q21891834"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Luc Berthold"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -8820,11 +9280,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Luc Berthold"
       }
     }, {
       "party" : {
@@ -8984,6 +9439,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22003106"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Leona Alleslev"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -9011,11 +9471,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Leona Alleslev"
       }
     }, {
       "party" : {
@@ -9175,6 +9630,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22003332"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Frank Baylis"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -9202,11 +9662,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Frank Baylis"
       }
     }, {
       "party" : {
@@ -9273,6 +9728,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22003456"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Brassard"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -9300,11 +9760,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John Brassard"
       }
     }, {
       "party" : {
@@ -9650,6 +10105,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22004431"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stephen Fuhr"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -9677,11 +10137,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Stephen Fuhr"
       }
     }, {
       "party" : {
@@ -9841,6 +10296,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22005483"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gudie Hutchings"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -9868,11 +10328,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Gudie Hutchings"
       }
     }, {
       "party" : {
@@ -9939,6 +10394,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22005676"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Georgina Jolibois"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -9966,11 +10426,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Georgina Jolibois"
       }
     }, {
       "party" : {
@@ -10037,6 +10492,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22006757"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kelly McCauley"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10064,11 +10524,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kelly McCauley"
       }
     }, {
       "party" : {
@@ -10135,6 +10590,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22007401"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kyle Peterson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10162,11 +10622,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kyle Peterson"
       }
     }, {
       "party" : {
@@ -10233,6 +10688,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22080796"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brenda Shanahan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10260,11 +10720,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Brenda Shanahan"
       }
     }, {
       "party" : {
@@ -10331,6 +10786,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22080816"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rémi Massé"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10358,11 +10818,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rémi Massé"
       }
     }, {
       "party" : {
@@ -10429,6 +10884,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22080839"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stéphane Lauzon"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10456,11 +10916,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Stéphane Lauzon"
       }
     }, {
       "party" : {
@@ -10527,6 +10982,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22080847"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Angelo Iacono"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10554,11 +11014,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Angelo Iacono"
       }
     }, {
       "party" : {
@@ -10625,6 +11080,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22086193"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karine Trudel"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10652,11 +11112,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Karine Trudel"
       }
     }, {
       "party" : {
@@ -10723,6 +11178,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22086204"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Julie Dzerowicz"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -10750,11 +11210,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Julie Dzerowicz"
       }
     }, {
       "party" : {
@@ -11193,6 +11648,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22114010"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Shannon Stubbs"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11220,11 +11680,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Shannon Stubbs"
       }
     }, {
       "party" : {
@@ -11291,6 +11746,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22114152"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert-Falcon Ouellette"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11318,11 +11778,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Robert-Falcon Ouellette"
       }
     }, {
       "party" : {
@@ -11389,6 +11844,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22116843"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cathay Wagantall"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11416,11 +11876,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Cathay Wagantall"
       },
       "facebook" : {
         "type" : "literal",
@@ -11491,6 +11946,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22116845"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mike Bossio"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11518,11 +11978,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mike Bossio"
       }
     }, {
       "party" : {
@@ -11589,6 +12044,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22121196"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Peter Schiefke"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11616,11 +12076,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Peter Schiefke"
       }
     }, {
       "party" : {
@@ -11687,6 +12142,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22132668"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sheila Malcolmson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11714,11 +12174,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sheila Malcolmson"
       },
       "facebook" : {
         "type" : "literal",
@@ -11789,6 +12244,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22132668"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sheila Malcolmson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11816,11 +12276,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sheila Malcolmson"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -11896,6 +12351,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22276751"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Aldag"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -11923,11 +12383,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John Aldag"
       }
     }, {
       "party" : {
@@ -11994,6 +12449,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22276800"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "William Amos"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -12021,11 +12481,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "William Amos"
       }
     }, {
       "party" : {
@@ -12185,6 +12640,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22276910"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ramez Ayoub"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -12212,11 +12672,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ramez Ayoub"
       }
     }, {
       "party" : {
@@ -12376,6 +12831,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22277033"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sheri Benson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -12403,11 +12863,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sheri Benson"
       },
       "facebook" : {
         "type" : "literal",
@@ -12478,6 +12933,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22277033"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sheri Benson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -12505,11 +12965,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sheri Benson"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -12585,6 +13040,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22277165"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pierre Breton"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -12612,11 +13072,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pierre Breton"
       }
     }, {
       "party" : {
@@ -12869,6 +13324,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22277583"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nicola Di Iorio"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -12896,11 +13356,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Nicola Di Iorio"
       }
     }, {
       "party" : {
@@ -13246,6 +13701,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22277957"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joël Godin"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -13273,11 +13733,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Joël Godin"
       }
     }, {
       "party" : {
@@ -13623,6 +14078,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22278145"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Thomas Harvey"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -13650,11 +14110,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Thomas Harvey"
       }
     }, {
       "party" : {
@@ -14093,6 +14548,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22278594"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fayçal El-Khoury"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -14120,11 +14580,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Fayçal El-Khoury"
       }
     }, {
       "party" : {
@@ -14191,6 +14646,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22278635"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert Kitchen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -14218,11 +14678,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Robert Kitchen"
       }
     }, {
       "party" : {
@@ -14382,6 +14837,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22278827"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Paul Lefebvre"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -14409,11 +14869,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Paul Lefebvre"
       }
     }, {
       "party" : {
@@ -14480,6 +14935,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22278836"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Denis Lemieux"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -14507,11 +14967,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Denis Lemieux"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -14583,6 +15038,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22278851"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Levitt"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -14610,11 +15070,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michael Levitt"
       }
     }, {
       "party" : {
@@ -15053,6 +15508,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22279214"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marc Miller"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -15080,11 +15540,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marc Miller"
       }
     }, {
       "party" : {
@@ -15151,6 +15606,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22279365"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Eva Nassif"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -15178,11 +15638,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Eva Nassif"
       }
     }, {
       "party" : {
@@ -15435,6 +15890,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22279481"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Oliver"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -15462,11 +15922,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John Oliver"
       }
     }, {
       "party" : {
@@ -15533,6 +15988,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22279696"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jean-Claude Poissant"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -15560,11 +16020,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jean-Claude Poissant"
       }
     }, {
       "party" : {
@@ -15724,6 +16179,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22280066"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Yves Robillard"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -15751,11 +16211,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Yves Robillard"
       }
     }, {
       "party" : {
@@ -15822,6 +16277,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22280112"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sherry Romanado"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -15849,11 +16309,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sherry Romanado"
       }
     }, {
       "party" : {
@@ -16385,6 +16840,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22280296"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brigitte Sansoucy"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -16412,11 +16872,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Brigitte Sansoucy"
       }
     }, {
       "party" : {
@@ -16855,6 +17310,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22282385"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Salma Zahid"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -16882,11 +17342,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Salma Zahid"
       }
     }, {
       "party" : {
@@ -16953,6 +17408,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22442799"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marc Serré"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -16980,11 +17440,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marc Serré"
       }
     }, {
       "party" : {
@@ -17051,6 +17506,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22704261"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karen Vecchio"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17078,11 +17538,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Karen Vecchio"
       }
     }, {
       "party" : {
@@ -17149,6 +17604,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22704263"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nick Whalen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17176,11 +17636,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Nick Whalen"
       }
     }, {
       "party" : {
@@ -17247,6 +17702,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22704264"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Arif Virani"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17274,11 +17734,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Arif Virani"
       }
     }, {
       "party" : {
@@ -17531,6 +17986,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22770985"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Filomena Tassi"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17558,11 +18018,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Filomena Tassi"
       }
     }, {
       "party" : {
@@ -17629,6 +18084,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22770987"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Martin Shields"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17656,11 +18116,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Martin Shields"
       }
     }, {
       "party" : {
@@ -17727,6 +18182,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22770988"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sonia Sidhu"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17754,11 +18214,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sonia Sidhu"
       }
     }, {
       "party" : {
@@ -17825,6 +18280,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22770989"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kevin Waugh"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17852,11 +18312,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kevin Waugh"
       }
     }, {
       "party" : {
@@ -17923,6 +18378,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q22811360"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wayne Stetski"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -17950,11 +18410,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Wayne Stetski"
       }
     }, {
       "party" : {
@@ -18114,6 +18569,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2347478"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Steven Blaney"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18141,11 +18601,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Steven Blaney"
       }
     }, {
       "party" : {
@@ -18212,6 +18667,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2402044"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Deepak Obhrai"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18239,11 +18699,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Deepak Obhrai"
       }
     }, {
       "party" : {
@@ -18310,6 +18765,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2403422"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Carolyn Bennett"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18337,11 +18797,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Carolyn Bennett"
       }
     }, {
       "party" : {
@@ -18506,6 +18961,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2833301"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alexandra Mendès"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18533,11 +18993,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Alexandra Mendès"
       }
     }, {
       "party" : {
@@ -18604,6 +19059,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2833494"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alexandre Boulerice"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18631,11 +19091,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Alexandre Boulerice"
       }
     }, {
       "party" : {
@@ -18702,6 +19157,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q283788"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Christine Moore"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18729,11 +19189,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Christine Moore"
       }
     }, {
       "party" : {
@@ -18800,6 +19255,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2846662"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Andrew Leslie"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18827,11 +19287,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Andrew Leslie"
       }
     }, {
       "party" : {
@@ -18898,6 +19353,95 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2846724"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Andrew Scheer"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Andrew Scheer"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2846724-4F35264E-0027-42C4-8FA1-551A49C04266"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3423524"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Regina—Qu'Appelle"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Regina—Qu'Appelle"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2846724"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Andrew Scheer"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -18926,10 +19470,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "Andrew Scheer"
+        "value" : "2004-06-28T00:00:00Z"
       }
     }, {
       "party" : {
@@ -18996,6 +19540,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2851214"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anne Minh Thu Quach"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19023,11 +19572,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Anne Minh Thu Quach"
       }
     }, {
       "party" : {
@@ -19094,6 +19638,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2852943"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anthony Rota"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19121,11 +19670,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Anthony Rota"
       }
     }, {
       "party" : {
@@ -19192,6 +19736,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2895501"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ben Lobb"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19219,11 +19768,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ben Lobb"
       }
     }, {
       "party" : {
@@ -19290,6 +19834,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2898026"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bernard Généreux"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19317,11 +19866,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bernard Généreux"
       }
     }, {
       "party" : {
@@ -19388,6 +19932,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2900366"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bev Shipley"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19415,11 +19964,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bev Shipley"
       }
     }, {
       "party" : {
@@ -19486,6 +20030,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2903153"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bill Casey"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19513,11 +20062,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bill Casey"
       }
     }, {
       "party" : {
@@ -19584,6 +20128,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2905717"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Blaine Calkins"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19611,11 +20160,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Blaine Calkins"
       }
     }, {
       "party" : {
@@ -19682,6 +20226,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2905842"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Blake Richards"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19709,11 +20258,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Blake Richards"
       }
     }, {
       "party" : {
@@ -19780,6 +20324,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2907780"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Nault"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19807,11 +20356,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bob Nault"
       }
     }, {
       "party" : {
@@ -19878,6 +20422,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2911380"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Borys Wrzesnewskyj"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -19905,11 +20454,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Borys Wrzesnewskyj"
       }
     }, {
       "party" : {
@@ -19976,6 +20520,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q29138522"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mona Fortier"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20003,11 +20552,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mona Fortier"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -20079,6 +20623,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q29139192"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Benzen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20106,11 +20655,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bob Benzen"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -20186,6 +20730,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q29139548"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mary Ng"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20213,11 +20762,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mary Ng"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -20293,6 +20837,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q29139551"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stephanie Kusie"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20320,11 +20869,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Stephanie Kusie"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -20400,6 +20944,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q29139554"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Emmanuella Lambropoulos"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20427,11 +20976,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Emmanuella Lambropoulos"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -20507,6 +21051,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2923494"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bradley Trost"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20534,11 +21083,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bradley Trost"
       }
     }, {
       "party" : {
@@ -20605,6 +21149,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2926478"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bruce Stanton"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20632,11 +21181,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bruce Stanton"
       }
     }, {
       "party" : {
@@ -20703,6 +21247,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2936261"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Candice Bergen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20730,11 +21279,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Candice Bergen"
       }
     }, {
       "party" : {
@@ -20801,6 +21345,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2942205"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cathy McLeod"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20828,11 +21377,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Cathy McLeod"
       }
     }, {
       "party" : {
@@ -20899,6 +21443,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2960818"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Charlie Angus"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -20926,11 +21475,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Charlie Angus"
       }
     }, {
       "party" : {
@@ -20997,6 +21541,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2962814"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Cheryl Gallant"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21024,11 +21573,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Cheryl Gallant"
       }
     }, {
       "party" : {
@@ -21095,6 +21639,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2964888"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chris Warkentin"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21122,11 +21671,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Chris Warkentin"
       }
     }, {
       "party" : {
@@ -21193,6 +21737,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2982579"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Colin Carrie"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21220,11 +21769,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Colin Carrie"
       }
     }, {
       "party" : {
@@ -21291,6 +21835,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3013003"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dan Albas"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21318,11 +21867,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dan Albas"
       }
     }, {
       "party" : {
@@ -21389,6 +21933,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3017193"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dave MacKenzie"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21416,11 +21965,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dave MacKenzie"
       }
     }, {
       "party" : {
@@ -21487,6 +22031,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3017287"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dave Van Kesteren"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21514,11 +22063,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dave Van Kesteren"
       }
     }, {
       "party" : {
@@ -21585,6 +22129,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3017380"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Anderson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21612,11 +22161,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Anderson"
       }
     }, {
       "party" : {
@@ -21683,6 +22227,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3017669"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Christopherson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21710,11 +22259,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Christopherson"
       }
     }, {
       "party" : {
@@ -21781,6 +22325,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3018407"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David McGuinty"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21808,11 +22357,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David McGuinty"
       }
     }, {
       "party" : {
@@ -21879,6 +22423,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3018841"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Sweet"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -21906,11 +22455,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Sweet"
       }
     }, {
       "party" : {
@@ -21977,6 +22521,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3018882"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Tilson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22004,11 +22553,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "David Tilson"
       }
     }, {
       "party" : {
@@ -22075,6 +22619,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3020613"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dean Allison"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22102,11 +22651,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dean Allison"
       }
     }, {
       "party" : {
@@ -22173,6 +22717,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3022785"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Denis Lebel"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22200,11 +22749,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Denis Lebel"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -22276,6 +22820,81 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3022854"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Denis Paradis"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Denis Paradis"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3022854-b494913c-49f7-76ae-83dd-d46614e2c742"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3022854"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Denis Paradis"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22304,10 +22923,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "Denis Paradis"
+        "value" : "2015-10-19T00:00:00Z"
       }
     }, {
       "party" : {
@@ -22374,6 +22993,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3026209"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Diane Finley"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22401,11 +23025,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Diane Finley"
       }
     }, {
       "party" : {
@@ -22472,6 +23091,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3034854"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dominic LeBlanc"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22499,11 +23123,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dominic LeBlanc"
       }
     }, {
       "party" : {
@@ -22570,6 +23189,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3035763"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Don Davies"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22597,11 +23221,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Don Davies"
       }
     }, {
       "party" : {
@@ -22668,6 +23287,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3046379"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Earl Dreeshen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22695,11 +23319,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Earl Dreeshen"
       }
     }, {
       "party" : {
@@ -22766,6 +23385,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3047171"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ed Fast"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22793,11 +23417,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ed Fast"
       }
     }, {
       "party" : {
@@ -22864,6 +23483,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3052684"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Emmanuel Dubourg"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22891,11 +23515,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Emmanuel Dubourg"
       }
     }, {
       "party" : {
@@ -22962,6 +23581,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3084255"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "François Choquette"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -22989,11 +23613,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "François Choquette"
       }
     }, {
       "party" : {
@@ -23060,6 +23679,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3099714"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Justin Trudeau"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23088,10 +23712,98 @@
         "type" : "literal",
         "value" : "338"
       },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "JustinPJTrudeau"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3099714-e11f7149-4e14-fc40-217b-4a4070b646a1"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3362910"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Papineau"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Papineau"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3099714"
+      },
       "name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Justin Trudeau"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Justin Trudeau"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-10-14T00:00:00Z"
       },
       "facebook" : {
         "type" : "literal",
@@ -23162,6 +23874,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3101057"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Geoff Regan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23189,11 +23906,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Geoff Regan"
       }
     }, {
       "party" : {
@@ -23260,6 +23972,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3104348"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gerry Ritz"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23288,15 +24005,118 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Gerry Ritz"
-      },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2017-10-02T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q488523"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti conservateur du Canada"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Conservative Party of Canada"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3110844-F101EEE4-F355-4115-998E-697BDDDC2608"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q581570"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Leeds-Grenville-Thousand Islands and Rideau Lakes"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Leeds-Grenville-Thousand Islands and Rideau Lakes"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3110844"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gord Brown"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gord Brown"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-05-02T00:00:00Z"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-06-28T00:00:00Z"
       }
     }, {
       "party" : {
@@ -23363,6 +24183,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3121631"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Guy Caron"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23390,11 +24215,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Guy Caron"
       }
     }, {
       "party" : {
@@ -23461,6 +24281,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3121921"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Guy Lauzon"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23488,11 +24313,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Guy Lauzon"
       }
     }, {
       "party" : {
@@ -23559,6 +24379,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3123899"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gérard Deltell"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23586,11 +24411,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Gérard Deltell"
       }
     }, {
       "party" : {
@@ -23657,6 +24477,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3129348"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hedy Fry"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23684,11 +24509,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Hedy Fry"
       }
     }, {
       "party" : {
@@ -23755,6 +24575,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3144797"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Hélène Laverdière"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23782,11 +24607,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Hélène Laverdière"
       }
     }, {
       "party" : {
@@ -23853,6 +24673,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3154320"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Irene Mathyssen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23880,11 +24705,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Irene Mathyssen"
       }
     }, {
       "party" : {
@@ -23951,6 +24771,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3160939"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "James Bezan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -23978,11 +24803,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "James Bezan"
       }
     }, {
       "party" : {
@@ -24049,6 +24869,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3162959"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jason Kenney"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24076,11 +24901,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jason Kenney"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -24152,6 +24972,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3174346"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jean Rioux"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24179,11 +25004,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jean Rioux"
       }
     }, {
       "party" : {
@@ -24250,6 +25070,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3178831"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jim Hillyer"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24277,11 +25102,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jim Hillyer"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -24353,6 +25173,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3182037"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John McCallum"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24380,11 +25205,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John McCallum"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -24456,6 +25276,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3182063"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John McKay"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24483,11 +25308,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "John McKay"
       }
     }, {
       "party" : {
@@ -24554,6 +25374,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3187235"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joyce Murray"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24581,11 +25406,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Joyce Murray"
       }
     }, {
       "party" : {
@@ -24652,6 +25472,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3188045"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Judy Sgro"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24679,11 +25504,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Judy Sgro"
       }
     }, {
       "party" : {
@@ -24750,6 +25570,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3195160"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kennedy Stewart"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24777,11 +25602,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kennedy Stewart"
       }
     }, {
       "party" : {
@@ -24848,6 +25668,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3195738"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kevin Lamoureux"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24875,11 +25700,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kevin Lamoureux"
       }
     }, {
       "party" : {
@@ -24946,6 +25766,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3195810"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kevin Sorenson"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -24973,11 +25798,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kevin Sorenson"
       }
     }, {
       "party" : {
@@ -25044,6 +25864,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3197422"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kirsty Duncan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25071,11 +25896,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kirsty Duncan"
       }
     }, {
       "party" : {
@@ -25142,6 +25962,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3218024"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Larry Bagnell"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25169,11 +25994,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Larry Bagnell"
       }
     }, {
       "party" : {
@@ -25240,6 +26060,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3218085"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Larry Miller"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25267,11 +26092,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Larry Miller"
       }
     }, {
       "party" : {
@@ -25338,6 +26158,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3219913"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lawrence MacAulay"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25365,11 +26190,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Lawrence MacAulay"
       }
     }, {
       "party" : {
@@ -25436,6 +26256,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3241331"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Linda Duncan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25463,11 +26288,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Linda Duncan"
       }
     }, {
       "party" : {
@@ -25534,6 +26354,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3241356"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Linda Lapointe"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25561,11 +26386,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Linda Lapointe"
       }
     }, {
       "party" : {
@@ -25632,6 +26452,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3262931"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Louis Plamondon"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25659,11 +26484,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Louis Plamondon"
       }
     }, {
       "party" : {
@@ -25730,6 +26550,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3293930"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marjolaine Boutin-Sweet"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25757,11 +26582,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marjolaine Boutin-Sweet"
       }
     }, {
       "party" : {
@@ -25828,6 +26648,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3294068"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mark Eyking"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25855,11 +26680,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mark Eyking"
       }
     }, {
       "party" : {
@@ -25926,6 +26746,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3294109"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mark Holland"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -25953,11 +26778,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mark Holland"
       }
     }, {
       "party" : {
@@ -26024,6 +26844,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3299702"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Matthew Dubé"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26051,11 +26876,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Matthew Dubé"
       }
     }, {
       "party" : {
@@ -26122,6 +26942,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3301645"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mauril Bélanger"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26149,11 +26974,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mauril Bélanger"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -26225,6 +27045,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3308109"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael Chong"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26252,11 +27077,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michael Chong"
       }
     }, {
       "party" : {
@@ -26323,6 +27143,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3311457"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michelle Rempel"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26350,11 +27175,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michelle Rempel"
       }
     }, {
       "party" : {
@@ -26421,6 +27241,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3313399"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mike Lake"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26448,11 +27273,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mike Lake"
       }
     }, {
       "party" : {
@@ -26519,6 +27339,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3336713"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nathan Cullen"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26546,11 +27371,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Nathan Cullen"
       }
     }, {
       "party" : {
@@ -26617,6 +27437,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3337237"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Navdeep Bains"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26644,11 +27469,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Navdeep Bains"
       }
     }, {
       "party" : {
@@ -26715,6 +27535,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3341504"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Niki Ashton"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26742,11 +27567,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Niki Ashton"
       }
     }, {
       "party" : {
@@ -26813,6 +27633,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3351821"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Omar Alghabra"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26840,11 +27665,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Omar Alghabra"
       }
     }, {
       "party" : {
@@ -26911,6 +27731,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3359999"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pablo Rodriguez"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -26938,11 +27763,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pablo Rodriguez"
       }
     }, {
       "party" : {
@@ -27009,6 +27829,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3376681"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Peter Julian"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27036,11 +27861,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Peter Julian"
       }
     }, {
       "party" : {
@@ -27107,6 +27927,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3376692"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Peter Kent"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27134,11 +27959,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Peter Kent"
       }
     }, {
       "party" : {
@@ -27205,6 +28025,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3376938"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Peter Van Loan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27232,11 +28057,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Peter Van Loan"
       }
     }, {
       "party" : {
@@ -27303,6 +28123,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3383312"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pierre-Luc Dusseault"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27330,11 +28155,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pierre-Luc Dusseault"
       }
     }, {
       "party" : {
@@ -27401,6 +28221,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3386416"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pierre Nantel"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27428,11 +28253,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pierre Nantel"
       }
     }, {
       "party" : {
@@ -27499,6 +28319,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3386636"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pierre Poilievre"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27526,11 +28351,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Pierre Poilievre"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -27606,6 +28426,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3418804"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Randall Garrison"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27633,11 +28458,81 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3434145-D7CFB13B-78D3-4C84-B7BC-E471479542BA"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3434145"
       },
       "name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Randall Garrison"
+        "value" : "Rob Anders"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rob Anders"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1997-01-01T00:00:00Z"
       }
     }, {
       "party" : {
@@ -27704,6 +28599,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3434460"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert Aubin"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27731,11 +28631,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Robert Aubin"
       }
     }, {
       "party" : {
@@ -27802,6 +28697,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3438181"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rodger Cuzner"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27829,11 +28729,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rodger Cuzner"
       }
     }, {
       "party" : {
@@ -27900,6 +28795,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3441197"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Romeo Saganash"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -27928,10 +28828,98 @@
         "type" : "literal",
         "value" : "338"
       },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "RomeoSaganash"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3441197-535856AD-98F4-470C-A97D-9348FC3AE68B"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2821651"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Abitibi—Baie-James—Nunavik—Eeyou"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Abitibi—Baie-James—Nunavik—Eeyou"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3441197"
+      },
       "name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Romeo Saganash"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Romeo Saganash"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-01-01T00:00:00Z"
       },
       "facebook" : {
         "type" : "literal",
@@ -28002,6 +28990,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3441480"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rona Ambrose"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28029,11 +29022,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rona Ambrose"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -28110,6 +29098,95 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3453615"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ruth Ellen Brosseau"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ruth Ellen Brosseau"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3453615-02B74EBB-4169-40E3-897A-679BE9C72E90"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2899323"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Berthier—Maskinongé"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Berthier—Maskinongé"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3453615"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ruth Ellen Brosseau"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28138,10 +29215,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "Ruth Ellen Brosseau"
+        "value" : "2011-05-02T00:00:00Z"
       }
     }, {
       "party" : {
@@ -28208,6 +29285,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3476240"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Scott Jeffrey Reid"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28235,11 +29317,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Scott Jeffrey Reid"
       }
     }, {
       "party" : {
@@ -28306,6 +29383,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3476307"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Scott Simms"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28333,11 +29415,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Scott Simms"
       }
     }, {
       "party" : {
@@ -28404,6 +29481,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3476701"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sean Casey"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28431,11 +29513,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sean Casey"
       }
     }, {
       "party" : {
@@ -28502,6 +29579,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q349836"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Scott Brison"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28529,11 +29611,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Scott Brison"
       }
     }, {
       "party" : {
@@ -28600,6 +29677,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3503377"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sukh Dhaliwal"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28627,11 +29709,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sukh Dhaliwal"
       }
     }, {
       "party" : {
@@ -28698,6 +29775,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3507287"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sylvie Boucher"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28725,11 +29807,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Sylvie Boucher"
       }
     }, {
       "party" : {
@@ -28796,6 +29873,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3530781"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Tom Lukiwski"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28823,11 +29905,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Tom Lukiwski"
       }
     }, {
       "party" : {
@@ -28894,6 +29971,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3531723"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Tony Clement"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -28921,11 +30003,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Tony Clement"
       }
     }, {
       "party" : {
@@ -28992,6 +30069,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3566825"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wayne Easter"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29019,11 +30101,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Wayne Easter"
       }
     }, {
       "party" : {
@@ -29090,6 +30167,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3571913"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Yasmin Ratansi"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29117,11 +30199,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Yasmin Ratansi"
       }
     }, {
       "party" : {
@@ -29188,6 +30265,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q366456"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Stéphane Dion"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29215,11 +30297,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Stéphane Dion"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -29296,6 +30373,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q42308682"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Richard Hébert"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29323,11 +30405,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Richard Hébert"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -29399,6 +30476,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q42308688"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dane Lloyd"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29426,11 +30508,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dane Lloyd"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -29506,6 +30583,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q42666524"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rosemarie Falk"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29533,11 +30615,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rosemarie Falk"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -29609,6 +30686,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q445620"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Elizabeth May"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29636,11 +30718,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Elizabeth May"
       }
     }, {
       "party" : {
@@ -29707,6 +30784,95 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4492815"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chrystia Freeland"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Chrystia Freeland"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q4492815-F27992BC-FEDF-49C4-B858-85BA5BC1D75F"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16977089"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "University—Rosedale"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "University—Rosedale"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4492815"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chrystia Freeland"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29735,10 +30901,10 @@
         "type" : "literal",
         "value" : "338"
       },
-      "name_fr" : {
-        "xml:lang" : "fr",
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "Chrystia Freeland"
+        "value" : "2015-10-19T00:00:00Z"
       }
     }, {
       "party" : {
@@ -29805,6 +30971,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q45311068"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Churence Rogers"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29832,11 +31003,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Churence Rogers"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -29908,6 +31074,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q45311888"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jean Yip"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -29935,11 +31106,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jean Yip"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -30015,6 +31181,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4679921"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Adam Vaughan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30042,11 +31213,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Adam Vaughan"
       }
     }, {
       "party" : {
@@ -30113,6 +31279,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4726162"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alice Wong"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30140,11 +31311,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Alice Wong"
       }
     }, {
       "party" : {
@@ -30211,6 +31377,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4740296"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Amarjeet Sohi"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30238,11 +31409,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Amarjeet Sohi"
       },
       "facebook" : {
         "type" : "literal",
@@ -30313,6 +31479,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4740296"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Amarjeet Sohi"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30340,11 +31511,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Amarjeet Sohi"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -30420,6 +31586,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4772746"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anthony Housefather"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30447,11 +31618,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Anthony Housefather"
       }
     }, {
       "party" : {
@@ -30518,6 +31684,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q48746674"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karen Ludwig"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30545,11 +31716,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Karen Ludwig"
       }
     }, {
       "party" : {
@@ -30616,6 +31782,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4908168"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bill Blair"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30643,11 +31814,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bill Blair"
       }
     }, {
       "party" : {
@@ -30714,6 +31880,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4931915"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Bratina"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30741,11 +31912,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bob Bratina"
       }
     }, {
       "party" : {
@@ -30812,6 +31978,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4934493"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Zimmer"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30839,11 +32010,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bob Zimmer"
       }
     }, {
       "party" : {
@@ -30910,6 +32076,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4935396"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bobby Morrissey"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -30937,11 +32108,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Bobby Morrissey"
       }
     }, {
       "party" : {
@@ -31008,6 +32174,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q513969"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mark Warawa"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31035,11 +32206,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mark Warawa"
       }
     }, {
       "party" : {
@@ -31106,6 +32272,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q516940"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maxime Bernier"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31133,11 +32304,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Maxime Bernier"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -31209,6 +32375,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q516940"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Maxime Bernier"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31236,11 +32407,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Maxime Bernier"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -31312,6 +32478,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5214525"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dan Vandal"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31339,11 +32510,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dan Vandal"
       }
     }, {
       "party" : {
@@ -31410,6 +32576,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5225530"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Darshan Kang"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31437,11 +32608,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Darshan Kang"
       }
     }, {
       "party" : {
@@ -31508,6 +32674,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5271706"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dianne Watts"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31535,11 +32706,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Dianne Watts"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -31611,6 +32777,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q529968"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brian Masse"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31638,11 +32809,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Brian Masse"
       }
     }, {
       "party" : {
@@ -31709,6 +32875,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5389236"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Erin Weir"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31736,11 +32907,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Erin Weir"
       }
     }, {
       "party" : {
@@ -31807,6 +32973,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5449316"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fin Donnelly"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31834,11 +33005,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Fin Donnelly"
       }
     }, {
       "party" : {
@@ -31905,6 +33071,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5585302"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Gordon Hogg"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -31932,11 +33103,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Gordon Hogg"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -32008,6 +33174,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6179373"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jenny Kwan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32035,11 +33206,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jenny Kwan"
       }
     }, {
       "party" : {
@@ -32106,6 +33272,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6194065"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jim Carr"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32133,11 +33304,95 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6211627-a94ab211-45ea-89ca-55ed-7038252db057"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3049206"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Eglinton—Lawrence"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eglinton—Lawrence"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15964890"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de la Chambre des communes du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the House of Commons of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6211627"
       },
       "name_fr" : {
         "xml:lang" : "fr",
         "type" : "literal",
-        "value" : "Jim Carr"
+        "value" : "Joe Oliver"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Joe Oliver"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q383590"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "chambre des communes du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "House of Commons"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "338"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-05-30T00:00:00Z"
       }
     }, {
       "party" : {
@@ -32204,6 +33459,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6211786"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joe Peschisolido"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32231,11 +33491,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Joe Peschisolido"
       }
     }, {
       "party" : {
@@ -32302,6 +33557,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6369875"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Karen McCrimmon"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32329,11 +33589,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Karen McCrimmon"
       }
     }, {
       "party" : {
@@ -32400,6 +33655,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6385949"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kelly Block"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32427,11 +33687,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kelly Block"
       }
     }, {
       "party" : {
@@ -32498,6 +33753,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6391762"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kent Hehr"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32525,11 +33785,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Kent Hehr"
       }
     }, {
       "party" : {
@@ -32596,6 +33851,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6490735"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Larry Maguire"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32623,11 +33883,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Larry Maguire"
       }
     }, {
       "party" : {
@@ -32694,6 +33949,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6522015"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Len Webber"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32721,11 +33981,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Len Webber"
       }
     }, {
       "party" : {
@@ -32792,6 +34047,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6558350"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lisa Raitt"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32819,11 +34079,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Lisa Raitt"
       }
     }, {
       "party" : {
@@ -32890,6 +34145,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6778737"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "MaryAnn Mihychuk"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -32917,11 +34177,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "MaryAnn Mihychuk"
       }
     }, {
       "party" : {
@@ -32988,6 +34243,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6788847"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Matt Jeneroux"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33015,11 +34275,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Matt Jeneroux"
       }
     }, {
       "party" : {
@@ -33086,6 +34341,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6832752"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Michael McLeod"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33113,11 +34373,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Michael McLeod"
       }
     }, {
       "party" : {
@@ -33184,6 +34439,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6939423"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Murray Rankin"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33211,11 +34471,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Murray Rankin"
       }
     }, {
       "party" : {
@@ -33282,6 +34537,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q703321"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marc Garneau"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33309,11 +34569,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Marc Garneau"
       }
     }, {
       "party" : {
@@ -33380,6 +34635,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7174026"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Peter Fonseca"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33407,11 +34667,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Peter Fonseca"
       }
     }, {
       "party" : {
@@ -33478,6 +34733,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7182163"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Phil McColeman"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33505,11 +34765,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Phil McColeman"
       }
     }, {
       "party" : {
@@ -33576,6 +34831,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7292236"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Randy Hoback"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33603,11 +34863,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Randy Hoback"
       }
     }, {
       "party" : {
@@ -33674,6 +34929,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7340436"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Rob Oliphant"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33701,11 +34961,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Rob Oliphant"
       }
     }, {
       "party" : {
@@ -33772,6 +35027,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7349921"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert Sopuck"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33799,11 +35059,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Robert Sopuck"
       }
     }, {
       "party" : {
@@ -33870,6 +35125,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7364077"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ron Liepert"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33897,11 +35157,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Ron Liepert"
       }
     }, {
       "party" : {
@@ -33968,6 +35223,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7440780"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Seamus O'Regan"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -33995,11 +35255,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Seamus O'Regan"
       }
     }, {
       "party" : {
@@ -34066,6 +35321,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7704329"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Terry Duguid"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -34093,11 +35353,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Terry Duguid"
       }
     }, {
       "party" : {
@@ -34164,6 +35419,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q771878"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mark Strahl"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -34191,11 +35451,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Mark Strahl"
       }
     }, {
       "party" : {
@@ -34262,6 +35517,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q774134"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Jacques Gourde"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -34289,11 +35549,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Jacques Gourde"
       }
     }, {
       "party" : {
@@ -34360,6 +35615,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q8062466"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Yvonne Jones"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -34387,11 +35647,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Yvonne Jones"
       }
     }, {
       "party" : {
@@ -34458,6 +35713,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q952017"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Harold Albrecht"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -34485,11 +35745,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Harold Albrecht"
       }
     }, {
       "party" : {
@@ -34556,6 +35811,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q955143"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Francis Scarpaleggia"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -34583,11 +35843,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Francis Scarpaleggia"
       }
     }, {
       "party" : {
@@ -34654,6 +35909,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q981186"
       },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Judy Foote"
+      },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -34681,11 +35941,6 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "338"
-      },
-      "name_fr" : {
-        "xml:lang" : "fr",
-        "type" : "literal",
-        "value" : "Judy Foote"
       },
       "end" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",

--- a/legislative/Q383590/Q21157957/query-used.rq
+++ b/legislative/Q383590/Q21157957/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q21157957 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q21157957 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q21157957 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q21157957 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q4145705/Q55093545/popolo-m17n.json
+++ b/legislative/Q4145705/Q55093545/popolo-m17n.json
@@ -32,6 +32,24 @@
     },
     {
       "name": {
+        "lang:en": "Joe Magliocca"
+      },
+      "id": "Q21066770",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q21066770"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/joe.magliocca.calgary"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Ray Jones"
       },
       "id": "Q21067141",
@@ -636,6 +654,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q21066770-66283de7-4fee-0af1-8ada-e4c141eff26b",
+      "person_id": "Q21066770",
+      "organization_id": "Q4145705",
+      "area_id": "Q47455793",
+      "start_date": "2013-10-21",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414913",
+      "role": {
+        "lang:en": "member of Calgary City Council"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q21067141-FD4FD1C8-E750-470A-AD36-AA71C1DCA7BA",
       "person_id": "Q21067141",
       "organization_id": "Q4145705",
@@ -670,6 +704,22 @@
       "person_id": "Q22277744",
       "organization_id": "Q4145705",
       "area_id": "Q47455799",
+      "role_superclass_code": "Q708492",
+      "role_superclass": {
+        "lang:en": "councillor",
+        "lang:fr": "conseiller municipal"
+      },
+      "role_code": "Q45414913",
+      "role": {
+        "lang:en": "member of Calgary City Council"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q22277744-9731a8ac-4c3c-4418-d334-8bb2aaa2808a",
+      "person_id": "Q22277744",
+      "organization_id": "Q4145705",
+      "area_id": "Q47455799",
+      "start_date": "2001-10-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
         "lang:en": "councillor",

--- a/legislative/Q4145705/Q55093545/query-results.json
+++ b/legislative/Q4145705/Q55093545/query-results.json
@@ -144,6 +144,84 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455793"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ward 2 (Calgary)"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q21066770-66283de7-4fee-0af1-8ada-e4c141eff26b"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414913"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Calgary City Council"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21066770"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Joe Magliocca"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4145705"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "consesi de calgary"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q36312"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "15"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-10-21T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "joe.magliocca.calgary"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q47455802"
       },
       "district_name_en" : {
@@ -352,6 +430,84 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
         "type" : "literal",
         "value" : "15"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "DruhFarrellCalgary"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q47455799"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ward 7 (Calgary)"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q22277744-9731a8ac-4c3c-4418-d334-8bb2aaa2808a"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "conseiller municipal"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q45414913"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of Calgary City Council"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22277744"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Druh Farrell"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4145705"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "consesi de calgary"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Calgary City Council"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q36312"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "15"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2001-10-01T00:00:00Z"
       },
       "facebook" : {
         "type" : "literal",

--- a/legislative/Q4145705/Q55093545/query-used.rq
+++ b/legislative/Q4145705/Q55093545/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55093545 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55093545 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55093545 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55093545 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q47489643/Q55086916/query-used.rq
+++ b/legislative/Q47489643/Q55086916/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55086916 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55086916 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55086916 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55086916 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q47489645/Q55127597/query-used.rq
+++ b/legislative/Q47489645/Q55127597/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55127597 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55127597 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55127597 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55127597 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q5339025/Q55086858/query-used.rq
+++ b/legislative/Q5339025/Q55086858/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55086858 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55086858 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55086858 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55086858 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q5644769/2018-01-01-to-2018-12-31/query-used.rq
+++ b/legislative/Q5644769/2018-01-01-to-2018-12-31/query-used.rq
@@ -28,6 +28,10 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +42,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +66,6 @@ OPTIONAL {
 }
 
   }
-  
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q6670238/2018-01-01-to-2018-12-31/query-used.rq
+++ b/legislative/Q6670238/2018-01-01-to-2018-12-31/query-used.rq
@@ -28,6 +28,10 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +42,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +66,6 @@ OPTIONAL {
 }
 
   }
-  
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q6770993/2018-01-01-to-2018-12-31/query-used.rq
+++ b/legislative/Q6770993/2018-01-01-to-2018-12-31/query-used.rq
@@ -28,6 +28,10 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +42,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +66,6 @@ OPTIONAL {
 }
 
   }
-  
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q7646781/2018-01-01-to-2018-12-31/query-used.rq
+++ b/legislative/Q7646781/2018-01-01-to-2018-12-31/query-used.rq
@@ -28,6 +28,10 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +42,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +66,6 @@ OPTIONAL {
 }
 
   }
-  
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q825815/Q20683815/popolo-m17n.json
+++ b/legislative/Q825815/Q20683815/popolo-m17n.json
@@ -97,6 +97,22 @@
     },
     {
       "name": {
+        "lang:en": "Buck Watts",
+        "lang:fr": "Buck Watts"
+      },
+      "id": "Q2927460",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2927460"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Bush Dumville",
         "lang:fr": "Bush Dumville"
       },
@@ -177,6 +193,22 @@
     },
     {
       "name": {
+        "lang:en": "Robert Mitchell",
+        "lang:fr": "Robert Mitchell"
+      },
+      "id": "Q3435932",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3435932"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
         "lang:en": "Steven Myers",
         "lang:fr": "Steven Myers"
       },
@@ -201,6 +233,22 @@
         {
           "scheme": "wikidata",
           "identifier": "Q43921032"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Janice Sherry",
+        "lang:fr": "Janice Sherry"
+      },
+      "id": "Q656467",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q656467"
         }
       ],
       "links": [
@@ -1000,6 +1048,22 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q2927460-7C5760A8-16F1-4634-B66A-1A5B689D7F5E",
+      "person_id": "Q2927460",
+      "organization_id": "Q825815",
+      "area_id": "Q3536140",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q21010685",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Prince Edward Island",
+        "lang:fr": "député de l'Assemblée législative de l'Île-du-Prince-Édouard"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q2928710-114C9BD9-2625-4CC3-8CCA-C29C8636488A",
       "person_id": "Q2928710",
       "organization_id": "Q825815",
@@ -1081,6 +1145,23 @@
       }
     },
     {
+      "id": "http://www.wikidata.org/entity/statement/Q3435932-996c05b0-4dec-8afd-1e50-932d3e15fe69",
+      "person_id": "Q3435932",
+      "organization_id": "Q825815",
+      "area_id": "Q2961051",
+      "start_date": "2007-06-12",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q21010685",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Prince Edward Island",
+        "lang:fr": "député de l'Assemblée législative de l'Île-du-Prince-Édouard"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q3499252-089C5E3A-B08E-4528-AFB1-4396A03E4B1E",
       "person_id": "Q3499252",
       "organization_id": "Q825815",
@@ -1101,6 +1182,23 @@
       "person_id": "Q43921032",
       "organization_id": "Q825815",
       "area_id": "Q2961048",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q21010685",
+      "role": {
+        "lang:en": "Member of the Legislative Assembly of Prince Edward Island",
+        "lang:fr": "député de l'Assemblée législative de l'Île-du-Prince-Édouard"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q656467-54d451d9-4cb9-8599-2520-8092eaa00c15",
+      "person_id": "Q656467",
+      "organization_id": "Q825815",
+      "area_id": "Q3503686",
+      "start_date": "2007-03-28",
       "role_superclass_code": "Q5230427",
       "role_superclass": {
         "lang:en": "member of a legislative assembly",

--- a/legislative/Q825815/Q20683815/query-results.json
+++ b/legislative/Q825815/Q20683815/query-results.json
@@ -505,6 +505,90 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3536140"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Tracadie-Hillsborough Park"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tracadie-Hillsborough Park"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2927460-7C5760A8-16F1-4634-B66A-1A5B689D7F5E"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21010685"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée législative de l'Île-du-Prince-Édouard"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Prince Edward Island"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2927460"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Buck Watts"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q825815"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Île-du-Prince-Édouard"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Prince Edward Island"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1979"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "27"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Buck Watts"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3567444"
       },
       "district_name_fr" : {
@@ -930,6 +1014,95 @@
     }, {
       "district" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2961051"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Charlottetown-Sherwood"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Charlottetown-Sherwood"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3435932-996c05b0-4dec-8afd-1e50-932d3e15fe69"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21010685"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée législative de l'Île-du-Prince-Édouard"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Prince Edward Island"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3435932"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Robert Mitchell"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q825815"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Île-du-Prince-Édouard"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Prince Edward Island"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1979"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "27"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Robert Mitchell"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2007-06-12T00:00:00Z"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q3103726"
       },
       "district_name_fr" : {
@@ -1094,6 +1267,95 @@
         "xml:lang" : "fr",
         "type" : "literal",
         "value" : "Hannah Bell"
+      }
+    }, {
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3503686"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Summerside-Wilmot"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Summerside-Wilmot"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q656467-54d451d9-4cb9-8599-2520-8092eaa00c15"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21010685"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "député de l'Assemblée législative de l'Île-du-Prince-Édouard"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Legislative Assembly of Prince Edward Island"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q656467"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Janice Sherry"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q825815"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative de l'Île-du-Prince-Édouard"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Legislative Assembly of Prince Edward Island"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1979"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "27"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Janice Sherry"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2007-03-28T00:00:00Z"
       }
     } ]
   }

--- a/legislative/Q825815/Q20683815/query-used.rq
+++ b/legislative/Q825815/Q20683815/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q20683815 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q20683815 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q20683815 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q20683815 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q841180/Q21157957/popolo-m17n.json
+++ b/legislative/Q841180/Q21157957/popolo-m17n.json
@@ -1,9 +1,498 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:en": "Tobias Enverga",
+        "lang:fr": "Tobias Enverga"
+      },
+      "id": "Q16186656",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16186656"
+        }
+      ],
+      "links": [
 
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Larry Campbell",
+        "lang:fr": "Larry Campbell"
+      },
+      "id": "Q1680169",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1680169"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Nancy Greene",
+        "lang:fr": "Nancy Greene"
+      },
+      "id": "Q238041",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q238041"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Lillian Dyck",
+        "lang:fr": "Lillian Dyck"
+      },
+      "id": "Q2402200",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2402200"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/100005131950086"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Marie-Françoise Mégie",
+        "lang:fr": "Marie-Françoise Mégie"
+      },
+      "id": "Q27680092",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q27680092"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Anne Cools",
+        "lang:fr": "Anne Cools"
+      },
+      "id": "Q2851043",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2851043"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Bob Runciman",
+        "lang:fr": "Bob Runciman"
+      },
+      "id": "Q2907803",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2907803"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Charlie Watt",
+        "lang:fr": "Charlie Watt"
+      },
+      "id": "Q2960890",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2960890"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Claudette Tardif",
+        "lang:fr": "Claudette Tardif"
+      },
+      "id": "Q2978387",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2978387"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Colin Kenny",
+        "lang:fr": "Colin Kenny"
+      },
+      "id": "Q2982619",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2982619"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "David Adams Richards",
+        "lang:fr": "David Adams Richards"
+      },
+      "id": "Q3017357",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3017357"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Dennis Dawson",
+        "lang:fr": "Dennis Dawson"
+      },
+      "id": "Q3023150",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3023150"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Fabian Manning",
+        "lang:fr": "Fabian Manning"
+      },
+      "id": "Q3063518",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3063518"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Joan Fraser",
+        "lang:fr": "Joan Fraser"
+      },
+      "id": "Q3179583",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3179583"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Norman Doyle",
+        "lang:fr": "Norman Doyle"
+      },
+      "id": "Q3343768",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3343768"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Pierre-Hugues Boisvenu",
+        "lang:fr": "Pierre-Hugues Boisvenu"
+      },
+      "id": "Q3383128",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3383128"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/PHBoisvenu"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "George Baker",
+        "lang:fr": "George Baker"
+      },
+      "id": "Q5536629",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5536629"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "George Furey",
+        "lang:fr": "George Furey"
+      },
+      "id": "Q5539530",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5539530"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Ghislain Maltais",
+        "lang:fr": "Ghislain Maltais"
+      },
+      "id": "Q5556749",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5556749"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Grant Mitchell",
+        "lang:fr": "Grant Mitchell"
+      },
+      "id": "Q5596353",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5596353"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/SenGrantMitchell"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Kelvin Ogilvie",
+        "lang:fr": "Kelvin Ogilvie"
+      },
+      "id": "Q6386718",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6386718"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Libbe Hubley",
+        "lang:fr": "Libbe Hubley"
+      },
+      "id": "Q6540386",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6540386"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Mobina Jaffer",
+        "lang:fr": "Mobina Jaffer"
+      },
+      "id": "Q6887337",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6887337"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/SenatorJaffer"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Art Eggleton",
+        "lang:fr": "Art Eggleton"
+      },
+      "id": "Q705518",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q705518"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Pana Merchant",
+        "lang:fr": "Pana Merchant"
+      },
+      "id": "Q7129736",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7129736"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Salma Ataullahjan",
+        "lang:fr": "Salma Ataullahjan"
+      },
+      "id": "Q7405355",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q7405355"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/SenatorSalma"
+        }
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:en": "Senate of Canada",
+        "lang:fr": "Sénat du Canada"
+      },
+      "id": "Q841180",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q841180"
+        }
+      ],
+      "area_id": "Q16",
+      "seat_counts": {
+        "Q18524027": "105"
+      }
+    },
+    {
+      "name": {
+        "lang:en": "Senate Liberal Caucus",
+        "lang:fr": "caucus des sénateurs libéraux"
+      },
+      "id": "Q21035865",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q21035865"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Independent Senators Group",
+        "lang:fr": "Groupe des sénateurs indépendants"
+      },
+      "id": "Q28946329",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q28946329"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Conservative Party of Canada",
+        "lang:fr": "Parti conservateur du Canada"
+      },
+      "id": "Q488523",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q488523"
+        }
+      ]
+    }
   ],
   "areas": [
     {
@@ -368,6 +857,448 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16186656-8F9B12E1-E9C7-40BA-B33A-501CD512B7DD",
+      "person_id": "Q16186656",
+      "organization_id": "Q841180",
+      "start_date": "2012-09-06",
+      "end_date": "2017-11-16",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1680169-AFCC5F12-0E8B-406D-B5F7-38943D051D63",
+      "person_id": "Q1680169",
+      "on_behalf_of_id": "Q28946329",
+      "organization_id": "Q841180",
+      "area_id": "Q1974",
+      "start_date": "2005-08-02",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q238041-2F2B355D-A8C5-4E9C-B227-FD50837A5B7B",
+      "person_id": "Q238041",
+      "organization_id": "Q841180",
+      "start_date": "2009-01-02",
+      "end_date": "2018-05-11",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2402200-323E00B6-D3F5-43C2-AB3B-A7313664FCB5",
+      "person_id": "Q2402200",
+      "on_behalf_of_id": "Q21035865",
+      "organization_id": "Q841180",
+      "area_id": "Q1989",
+      "start_date": "2005-03-24",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q27680092-d37a7831-4f98-7e21-1c5b-59f408cbb5b8",
+      "person_id": "Q27680092",
+      "organization_id": "Q841180",
+      "start_date": "2016-11-25",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2851043-51EF10ED-79E1-4A90-B53F-76364F53F6F2",
+      "person_id": "Q2851043",
+      "organization_id": "Q841180",
+      "start_date": "1984-01-13",
+      "end_date": "2018-08-12",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2907803-10D7A4C6-86A2-4C27-8255-AB8FBD5ACE43",
+      "person_id": "Q2907803",
+      "organization_id": "Q841180",
+      "start_date": "2010-01-29",
+      "end_date": "2017-08-10",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2960890-95445923-8F8C-4A16-B58F-941538887AE5",
+      "person_id": "Q2960890",
+      "organization_id": "Q841180",
+      "start_date": "1984-01-16",
+      "end_date": "2018-03-16",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2978387-E8F032FC-D1CA-4556-949C-F67274E9FD69",
+      "person_id": "Q2978387",
+      "organization_id": "Q841180",
+      "start_date": "2005-03-24",
+      "end_date": "2018-02-02",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2982619-739AA5D3-893E-4988-883B-B358B0E683A5",
+      "person_id": "Q2982619",
+      "organization_id": "Q841180",
+      "start_date": "1984-06-29",
+      "end_date": "2018-02-02",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3017357-c6d09549-42c6-e278-2ea3-3ae1d5be5dae",
+      "person_id": "Q3017357",
+      "organization_id": "Q841180",
+      "start_date": "2017-09-01",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3023150-8F018A50-D11C-4339-A5C2-9AB7F59992D0",
+      "person_id": "Q3023150",
+      "organization_id": "Q841180",
+      "start_date": "2005-08-02",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3063518-dcb39070-4d8c-efec-0410-8cd50a425bf1",
+      "person_id": "Q3063518",
+      "on_behalf_of_id": "Q488523",
+      "organization_id": "Q841180",
+      "area_id": "Q2003",
+      "start_date": "2011-05-25",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3179583-A284FED7-673F-443C-AD08-5159C3C83362",
+      "person_id": "Q3179583",
+      "organization_id": "Q841180",
+      "start_date": "1998-09-17",
+      "end_date": "2018-02-02",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3343768-4D0127E4-5938-4957-9E67-EA9E4598BDDD",
+      "person_id": "Q3343768",
+      "organization_id": "Q841180",
+      "start_date": "2012-01-06",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3383128-F6FD617D-E542-4149-A013-8507FEC1E019",
+      "person_id": "Q3383128",
+      "on_behalf_of_id": "Q488523",
+      "organization_id": "Q841180",
+      "area_id": "Q176",
+      "start_date": "2010-01-29",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5536629-30EB3A24-7B90-40FE-84D3-EDF116920689",
+      "person_id": "Q5536629",
+      "organization_id": "Q841180",
+      "start_date": "2002-03-26",
+      "end_date": "2017-09-04",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5539530-A747F073-79F3-420A-A269-A225980A5613",
+      "person_id": "Q5539530",
+      "organization_id": "Q841180",
+      "start_date": "2015-12-03",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5556749-494B1DAC-1017-4100-914E-0D3CEED0557E",
+      "person_id": "Q5556749",
+      "organization_id": "Q841180",
+      "area_id": "Q18642499",
+      "start_date": "2012-01-06",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q5596353-80D68CF1-889F-4592-9E8F-B200E28C4DA0",
+      "person_id": "Q5596353",
+      "on_behalf_of_id": "Q21035865",
+      "organization_id": "Q841180",
+      "area_id": "Q1951",
+      "start_date": "2005-03-24",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6386718-285FD346-6001-41BE-BE93-BED88C7DB6CC",
+      "person_id": "Q6386718",
+      "organization_id": "Q841180",
+      "start_date": "2009-08-27",
+      "end_date": "2017-11-06",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6540386-67D19356-E576-465D-8924-7213AAEBC429",
+      "person_id": "Q6540386",
+      "organization_id": "Q841180",
+      "start_date": "2001-03-08",
+      "end_date": "2017-09-08",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6887337-928BDA78-B576-4672-99C2-E84C0F341E37",
+      "person_id": "Q6887337",
+      "on_behalf_of_id": "Q21035865",
+      "organization_id": "Q841180",
+      "area_id": "Q1974",
+      "start_date": "2001-06-13",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q705518-356E078E-C7A6-4DBC-AC55-A4C523AAA06E",
+      "person_id": "Q705518",
+      "organization_id": "Q841180",
+      "start_date": "2005-03-24",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7129736-26BBCCDF-5809-42EE-85C2-382AB42E7584",
+      "person_id": "Q7129736",
+      "organization_id": "Q841180",
+      "start_date": "2002-12-12",
+      "end_date": "2017-03-31",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q7405355-E0B7B958-F601-4141-9BA7-E0902BB6A4C5",
+      "person_id": "Q7405355",
+      "on_behalf_of_id": "Q488523",
+      "organization_id": "Q841180",
+      "area_id": "Q1904",
+      "start_date": "2010-07-09",
+      "role_superclass_code": "Q15686806",
+      "role_superclass": {
+        "lang:en": "senator",
+        "lang:fr": "sénateur"
+      },
+      "role_code": "Q18524027",
+      "role": {
+        "lang:en": "Member of the Senate of Canada",
+        "lang:fr": "membre du Sénat du Canada"
+      }
+    }
   ]
 }

--- a/legislative/Q841180/Q21157957/query-results.json
+++ b/legislative/Q841180/Q21157957/query-results.json
@@ -3,6 +3,2246 @@
     "vars" : [ "statement", "item", "name_en", "name_fr", "party", "party_name_en", "party_name_fr", "district", "district_name_en", "district_name_fr", "role", "role_en", "role_fr", "role_superclass", "role_superclass_en", "role_superclass_fr", "start", "end", "facebook", "org", "org_en", "org_fr", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16186656-8F9B12E1-E9C7-40BA-B33A-501CD512B7DD"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16186656"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Tobias Enverga"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tobias Enverga"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-09-06T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-11-16T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1680169-AFCC5F12-0E8B-406D-B5F7-38943D051D63"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1680169"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Larry Campbell"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Larry Campbell"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-08-02T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28946329"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Groupe des sénateurs indépendants"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Independent Senators Group"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1974"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Colombie-Britannique"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "British Columbia"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q238041-2F2B355D-A8C5-4E9C-B227-FD50837A5B7B"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q238041"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nancy Greene"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Nancy Greene"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2009-01-02T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-05-11T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2402200-323E00B6-D3F5-43C2-AB3B-A7313664FCB5"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2402200"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lillian Dyck"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lillian Dyck"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-03-24T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21035865"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "caucus des sénateurs libéraux"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate Liberal Caucus"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1989"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Saskatchewan"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Saskatchewan"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "100005131950086"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q27680092-d37a7831-4f98-7e21-1c5b-59f408cbb5b8"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q27680092"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Marie-Françoise Mégie"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Marie-Françoise Mégie"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-25T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2851043-51EF10ED-79E1-4A90-B53F-76364F53F6F2"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2851043"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Anne Cools"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Anne Cools"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1984-01-13T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-08-12T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2907803-10D7A4C6-86A2-4C27-8255-AB8FBD5ACE43"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2907803"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Bob Runciman"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bob Runciman"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-01-29T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-08-10T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2960890-95445923-8F8C-4A16-B58F-941538887AE5"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2960890"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Charlie Watt"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Charlie Watt"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1984-01-16T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-03-16T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2978387-E8F032FC-D1CA-4556-949C-F67274E9FD69"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2978387"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Claudette Tardif"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Claudette Tardif"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-03-24T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-02-02T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2982619-739AA5D3-893E-4988-883B-B358B0E683A5"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2982619"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Colin Kenny"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colin Kenny"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1984-06-29T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-02-02T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3017357-c6d09549-42c6-e278-2ea3-3ae1d5be5dae"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3017357"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "David Adams Richards"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "David Adams Richards"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-09-01T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3023150-8F018A50-D11C-4339-A5C2-9AB7F59992D0"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3023150"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Dennis Dawson"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Dennis Dawson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-08-02T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3063518-dcb39070-4d8c-efec-0410-8cd50a425bf1"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3063518"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Fabian Manning"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fabian Manning"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-05-25T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q488523"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti conservateur du Canada"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Conservative Party of Canada"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2003"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Terre-Neuve-et-Labrador"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Newfoundland and Labrador"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3179583-A284FED7-673F-443C-AD08-5159C3C83362"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3179583"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Joan Fraser"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Joan Fraser"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1998-09-17T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-02-02T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3343768-4D0127E4-5938-4957-9E67-EA9E4598BDDD"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3343768"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Norman Doyle"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Norman Doyle"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-01-06T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3383128-F6FD617D-E542-4149-A013-8507FEC1E019"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3383128"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pierre-Hugues Boisvenu"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pierre-Hugues Boisvenu"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-01-29T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q488523"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti conservateur du Canada"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Conservative Party of Canada"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q176"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Québec"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Quebec"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "PHBoisvenu"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5536629-30EB3A24-7B90-40FE-84D3-EDF116920689"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5536629"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "George Baker"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "George Baker"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2002-03-26T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-09-04T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5539530-A747F073-79F3-420A-A269-A225980A5613"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5539530"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "George Furey"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "George Furey"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-12-03T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5556749-494B1DAC-1017-4100-914E-0D3CEED0557E"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5556749"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ghislain Maltais"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ghislain Maltais"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-01-06T00:00:00Z"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18642499"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Chaouinigane"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Shawinigan"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q5596353-80D68CF1-889F-4592-9E8F-B200E28C4DA0"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5596353"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Grant Mitchell"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Grant Mitchell"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-03-24T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21035865"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "caucus des sénateurs libéraux"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate Liberal Caucus"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1951"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Alberta"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alberta"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "SenGrantMitchell"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6386718-285FD346-6001-41BE-BE93-BED88C7DB6CC"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6386718"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kelvin Ogilvie"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kelvin Ogilvie"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2009-08-27T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-11-06T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6540386-67D19356-E576-465D-8924-7213AAEBC429"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540386"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Libbe Hubley"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Libbe Hubley"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2001-03-08T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-09-08T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6887337-928BDA78-B576-4672-99C2-E84C0F341E37"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6887337"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mobina Jaffer"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mobina Jaffer"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2001-06-13T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21035865"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "caucus des sénateurs libéraux"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate Liberal Caucus"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1974"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Colombie-Britannique"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "British Columbia"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "SenatorJaffer"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q705518-356E078E-C7A6-4DBC-AC55-A4C523AAA06E"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q705518"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Art Eggleton"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Art Eggleton"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-03-24T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7129736-26BBCCDF-5809-42EE-85C2-382AB42E7584"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7129736"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Pana Merchant"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pana Merchant"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2002-12-12T00:00:00Z"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-03-31T00:00:00Z"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q7405355-E0B7B958-F601-4141-9BA7-E0902BB6A4C5"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "sénateur"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18524027"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre du Sénat du Canada"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Canada"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7405355"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Salma Ataullahjan"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Salma Ataullahjan"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841180"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sénat du Canada"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Canada"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "105"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-07-09T00:00:00Z"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q488523"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti conservateur du Canada"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Conservative Party of Canada"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1904"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Ontario"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ontario"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "SenatorSalma"
+      }
+    } ]
   }
 }

--- a/legislative/Q841180/Q21157957/query-used.rq
+++ b/legislative/Q841180/Q21157957/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q21157957 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q21157957 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q21157957 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q21157957 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {

--- a/legislative/Q908022/Q29561167/popolo-m17n.json
+++ b/legislative/Q908022/Q29561167/popolo-m17n.json
@@ -1,9 +1,272 @@
 {
   "persons": [
-
+    {
+      "name": {
+        "lang:en": "Sandy Silver",
+        "lang:fr": "Sandy Silver"
+      },
+      "id": "Q1841565",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1841565"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/sydnysilver"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Patti McLeod",
+        "lang:fr": "Patti McLeod"
+      },
+      "id": "Q1965024",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1965024"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/patti.mcleod.58"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Wade Istchenko",
+        "lang:fr": "Wade Istchenko"
+      },
+      "id": "Q1965881",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1965881"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/wade.istchenko"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Jeanie Dendys"
+      },
+      "id": "Q27788610",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q27788610"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/JeanieDendys"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Pauline Frost"
+      },
+      "id": "Q27791884",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q27791884"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/Pfrostoldcrow"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Ted Adel"
+      },
+      "id": "Q27805368",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q27805368"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/TedAdelCopperbeltNorth"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Paolo Gallina"
+      },
+      "id": "Q27805369",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q27805369"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/paologallinapolitics"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Geraldine Van Bibber",
+        "lang:fr": "Geraldine Van Bibber"
+      },
+      "id": "Q299594",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q299594"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/geraldine.vanbibber"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Elizabeth Hanson",
+        "lang:fr": "Elizabeth Hanson"
+      },
+      "id": "Q3051221",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3051221"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/lizhansonMLA"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "John Streicker",
+        "lang:fr": "John Streicker"
+      },
+      "id": "Q6259429",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q6259429"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/jstreicker"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Brad Cathers",
+        "lang:fr": "Brad Cathers"
+      },
+      "id": "Q661182",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q661182"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/BradCathers.MLAforLakeLaberge"
+        }
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:en": "Yukon Legislative Assembly",
+        "lang:fr": "Assemblée législative du Yukon"
+      },
+      "id": "Q908022",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q908022"
+        }
+      ],
+      "area_id": "Q2009",
+      "seat_counts": {
+        "Q18608478": "19"
+      }
+    },
+    {
+      "name": {
+        "lang:en": "Yukon Liberal Party",
+        "lang:fr": "Parti libéral du Yukon"
+      },
+      "id": "Q3366503",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3366503"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Yukon Party",
+        "lang:fr": "Parti du Yukon"
+      },
+      "id": "Q739885",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q739885"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:en": "Yukon New Democratic Party",
+        "lang:fr": "Nouveau Parti démocratique du Yukon"
+      },
+      "id": "Q748775",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q748775"
+        }
+      ]
+    }
   ],
   "areas": [
     {
@@ -495,6 +758,203 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1841565-86329AD1-5E0E-4276-969C-61A07A5596D6",
+      "person_id": "Q1841565",
+      "on_behalf_of_id": "Q3366503",
+      "organization_id": "Q908022",
+      "start_date": "2012-08-17",
+      "end_date": "2016-12-03",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1965024-776299CD-10CD-4B87-8948-A4D448518511",
+      "person_id": "Q1965024",
+      "on_behalf_of_id": "Q739885",
+      "organization_id": "Q908022",
+      "area_id": "Q7974835",
+      "start_date": "2011-10-11",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1965881-89491BA1-E536-4987-8DDE-A63980C65038",
+      "person_id": "Q1965881",
+      "on_behalf_of_id": "Q739885",
+      "organization_id": "Q908022",
+      "area_id": "Q3197911",
+      "start_date": "2011-10-11",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q27788610-763eb70a-428e-8b2e-fdc4-802f99cfd7be",
+      "person_id": "Q27788610",
+      "on_behalf_of_id": "Q3366503",
+      "organization_id": "Q908022",
+      "area_id": "Q1841558",
+      "start_date": "2016-12-03",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q27791884-34ebfbcd-4bfd-7392-49ec-21ce72b35f0d",
+      "person_id": "Q27791884",
+      "on_behalf_of_id": "Q3366503",
+      "organization_id": "Q908022",
+      "area_id": "Q3563849",
+      "start_date": "2016-12-03",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q27805368-81d02436-4b37-73d0-e75f-bb22efd58d4c",
+      "person_id": "Q27805368",
+      "on_behalf_of_id": "Q3366503",
+      "organization_id": "Q908022",
+      "area_id": "Q1840816",
+      "start_date": "2016-11-07",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q27805369-b2fd9504-4575-6f46-5cac-4b343337b60c",
+      "person_id": "Q27805369",
+      "on_behalf_of_id": "Q3366503",
+      "organization_id": "Q908022",
+      "area_id": "Q3399235",
+      "start_date": "2016-11-07",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q299594-c7179a49-401b-d118-c76c-66d0fcb67e66",
+      "person_id": "Q299594",
+      "on_behalf_of_id": "Q739885",
+      "organization_id": "Q908022",
+      "area_id": "Q3399237",
+      "start_date": "2016-11-07",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q3051221-27D63931-7397-4437-BB56-9E38F07D51ED",
+      "person_id": "Q3051221",
+      "on_behalf_of_id": "Q748775",
+      "organization_id": "Q908022",
+      "area_id": "Q3567803",
+      "start_date": "2010-12-13",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q6259429-e2cc48e1-4835-8cbd-6999-e4d86e0f4355",
+      "person_id": "Q6259429",
+      "on_behalf_of_id": "Q3366503",
+      "organization_id": "Q908022",
+      "area_id": "Q1842800",
+      "start_date": "2016-12-03",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q661182-0AB10A5F-6C37-4A9A-B016-7F5BC48D81A9",
+      "person_id": "Q661182",
+      "on_behalf_of_id": "Q739885",
+      "organization_id": "Q908022",
+      "area_id": "Q3215001",
+      "start_date": "2002-11-04",
+      "role_superclass_code": "Q5230427",
+      "role_superclass": {
+        "lang:en": "member of a legislative assembly",
+        "lang:fr": "membre d'une assemblée législative"
+      },
+      "role_code": "Q18608478",
+      "role": {
+        "lang:en": "Member of the Yukon Legislative Assembly",
+        "lang:fr": "membre de l'Assemblée législative du Yukon"
+      }
+    }
   ]
 }

--- a/legislative/Q908022/Q29561167/query-results.json
+++ b/legislative/Q908022/Q29561167/query-results.json
@@ -3,6 +3,1154 @@
     "vars" : [ "statement", "item", "name_en", "name_fr", "party", "party_name_en", "party_name_fr", "district", "district_name_en", "district_name_fr", "role", "role_en", "role_fr", "role_superclass", "role_superclass_en", "role_superclass_fr", "start", "end", "facebook", "org", "org_en", "org_fr", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366503"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Liberal Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1841565-86329AD1-5E0E-4276-969C-61A07A5596D6"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1841565"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sandy Silver"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2012-08-17T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Sandy Silver"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "sydnysilver"
+      },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-03T00:00:00Z"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q739885"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1965024-776299CD-10CD-4B87-8948-A4D448518511"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1965024"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Patti McLeod"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-11T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Patti McLeod"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "patti.mcleod.58"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7974835"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lac Watson"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Watson Lake"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q739885"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1965881-89491BA1-E536-4987-8DDE-A63980C65038"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1965881"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Wade Istchenko"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-10-11T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Wade Istchenko"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "wade.istchenko"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3197911"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Kluane"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kluane"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366503"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Liberal Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q27788610-763eb70a-428e-8b2e-fdc4-802f99cfd7be"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q27788610"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jeanie Dendys"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-03T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "JeanieDendys"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1841558"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mountainview"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mountainview"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366503"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Liberal Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q27791884-34ebfbcd-4bfd-7392-49ec-21ce72b35f0d"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q27791884"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pauline Frost"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-03T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "Pfrostoldcrow"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3563849"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Vuntut Gwitchin"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Vuntut Gwitchin"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366503"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Liberal Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q27805368-81d02436-4b37-73d0-e75f-bb22efd58d4c"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q27805368"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ted Adel"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-07T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "TedAdelCopperbeltNorth"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1840816"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Copperbelt-Nord"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Copperbelt North"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366503"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Liberal Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q27805369-b2fd9504-4575-6f46-5cac-4b343337b60c"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q27805369"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paolo Gallina"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-07T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "paologallinapolitics"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3399235"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Porter Creek Centre"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Porter Creek Centre"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q739885"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q299594-c7179a49-401b-d118-c76c-66d0fcb67e66"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q299594"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Geraldine Van Bibber"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-07T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Geraldine Van Bibber"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "geraldine.vanbibber"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3399237"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Porter Creek Nord"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Porter Creek North"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q748775"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Nouveau Parti démocratique du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon New Democratic Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q3051221-27D63931-7397-4437-BB56-9E38F07D51ED"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3051221"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Elizabeth Hanson"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-12-13T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Elizabeth Hanson"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "lizhansonMLA"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3567803"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Whitehorse Centre"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Whitehorse Centre"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3366503"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti libéral du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Liberal Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q6259429-e2cc48e1-4835-8cbd-6999-e4d86e0f4355"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6259429"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "John Streicker"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-03T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "John Streicker"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "jstreicker"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1842800"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Mount Lorne-Lac-Southern"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mount Lorne-Southern Lakes"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q739885"
+      },
+      "party_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Parti du Yukon"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q661182-0AB10A5F-6C37-4A9A-B016-7F5BC48D81A9"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5230427"
+      },
+      "role_superclass_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre d'une assemblée législative"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of a legislative assembly"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18608478"
+      },
+      "role_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "membre de l'Assemblée législative du Yukon"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Yukon Legislative Assembly"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q661182"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brad Cathers"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q908022"
+      },
+      "org_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Assemblée législative du Yukon"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Yukon Legislative Assembly"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2009"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "19"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2002-11-04T00:00:00Z"
+      },
+      "name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Brad Cathers"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "BradCathers.MLAforLakeLaberge"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3215001"
+      },
+      "district_name_fr" : {
+        "xml:lang" : "fr",
+        "type" : "literal",
+        "value" : "Lac Laberge"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lake Laberge"
+      }
+    } ]
   }
 }

--- a/legislative/Q908022/Q29561167/query-used.rq
+++ b/legislative/Q908022/Q29561167/query-used.rq
@@ -28,6 +28,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q29561167 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q29561167 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q29561167 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_en
   FILTER(LANG(?name_en) = "en")
@@ -38,7 +57,6 @@ OPTIONAL {
   FILTER(LANG(?name_fr) = "fr")
 }
 
-  ?statement ps:P39/wdt:P279* ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_en
   FILTER(LANG(?role_en) = "en")
@@ -63,9 +81,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q29561167 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {


### PR DESCRIPTION
This uses the date-aware term query to pull in better data, particularly for the Senate.

The Shawinigan warning is because it's a legitimate Senate division in Quebec, but isn't itself a province as our boundary data expects. Senate divisions are currently poorly modelled in Wikidata, so I've left it alone.